### PR TITLE
feat(connector): #COE-22 add cas answer for personnel Turboself connector

### DIFF
--- a/cas/src/main/java/org/entcore/cas/services/TurboselfPersonnelRegisteredService.java
+++ b/cas/src/main/java/org/entcore/cas/services/TurboselfPersonnelRegisteredService.java
@@ -1,0 +1,73 @@
+package org.entcore.cas.services;
+
+import fr.wseduc.cas.async.Handler;
+import fr.wseduc.cas.entities.AuthCas;
+import fr.wseduc.cas.entities.User;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import static fr.wseduc.webutils.Utils.handlerToAsyncHandler;
+
+public class TurboselfPersonnelRegisteredService extends DefaultRegisteredService {
+
+    private static final String USERID = "userId";
+    private static final String TYPE = "type";
+    private static final String ID = "id";
+    private static final String STRUCTURENODES = "structureNodes";
+    private static final String UAI = "UAI";
+    private static final String STRUCTURES = "structures";
+    private static final String FIRSTNAME = "firstName";
+    private static final String LASTNAME = "lastName";
+
+
+    @Override
+    public void getUser(final AuthCas authCas, final String service, final Handler<User> userHandler) {
+        final String userId = authCas.getUser();
+        JsonObject jo = new JsonObject();
+
+        jo.put("action", directoryAction).put(USERID, userId);
+        eb.send("directory", jo, handlerToAsyncHandler(event -> {
+            JsonObject res = event.body().getJsonObject("result");
+
+            if ("ok".equals(event.body().getString("status")) && res != null) {
+                if(res.getJsonArray(TYPE).contains("Personnel")){
+                    preparePersonnel(authCas, res, userId, service, userHandler);
+                } else {
+                    userHandler.handle(null);
+                }
+            } else {
+                userHandler.handle(null);
+            }
+
+        }));
+    }
+
+
+    private JsonArray extractUais(JsonObject res){
+        JsonArray uais = new JsonArray();
+        for (Object o : res.getJsonArray(STRUCTURENODES, new JsonArray())){
+            if (!(o instanceof JsonObject)) continue;
+            JsonObject structure = (JsonObject) o;
+            if (structure.containsKey(UAI)) {
+                uais.add(structure.getString(UAI));
+            }
+        }
+        return uais;
+    }
+
+    private void preparePersonnel(final AuthCas authCas, JsonObject res, final String userId, final String service,  final Handler<User> userHandler){
+        String id = res.getString(ID);
+        String lastName = res.getString(LASTNAME);
+        String firstName = res.getString(FIRSTNAME);
+        JsonArray uais = extractUais(res);
+
+        User user = new User();
+        JsonObject smallData = new JsonObject().put(principalAttributeName, res.getString(principalAttributeName));
+        smallData.put(FIRSTNAME, firstName);
+        smallData.put(LASTNAME, lastName);
+        smallData.put(STRUCTURES, uais);
+        prepareUser(user, userId, service, smallData);
+        userHandler.handle(user);
+        createStatsEvent(authCas, res, service);
+    }
+}

--- a/cas/src/main/resources/i18n/fr.json
+++ b/cas/src/main/resources/i18n/fr.json
@@ -68,5 +68,7 @@
   "IkigaiRegisteredService.name": "Ikigai",
   "IkigaiRegisteredService.description": "Service CAS spécifique pour Ikigai, le service Ikigai utilise le login comme attribut principal.",
   "WebGesrestRegisteredService.name": "Web Gerest",
-  "WebGesrestRegisteredService.description": "Service CAS 3.0 spécifique pour Web Gerest, le service Web Gerest utilise l'identifiant externe sans préfixe académique comme attribut principal."
+  "WebGesrestRegisteredService.description": "Service CAS 3.0 spécifique pour Web Gerest, le service Web Gerest utilise l'identifiant externe sans préfixe académique comme attribut principal.",
+  "TurboselfPersonnelRegisteredService.name": "Turboself Personnel",
+  "TurboselfPersonnelRegisteredService.description": "Réponse CAS pour Turboself pour les Personnels"
 }


### PR DESCRIPTION
# Description

Added 3.0 cas answer for personnel Turboself connector.

## Fixes

[COE-22](https://jira.support-ent.fr/browse/COE-22)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [x] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests
[DOC](https://confluence.support-ent.fr/pages/viewpage.action?pageId=54724067#FonctionTransverse:R%C3%A9ponseCAS-Enlocal)

Create a Connector with a simple url like https://google.com/ or https://github.com/

In "Champs spécifiques CAS" click on the green "+" and in "Type" enter the name of your CAS response

Then in Postman you can test the requests by following the documentation.
# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: