### PR TITLE
feat(directory): #MOZO-150, show all class users & customize results depending on communication rules

### DIFF
--- a/directory/src/main/resources/public/template/dominos-user.html
+++ b/directory/src/main/resources/public/template/dominos-user.html
@@ -1,22 +1,39 @@
-<section class="domino overflow-hd" ng-class="colorFromType(user.profile != null ? user.profile : user.type)" ng-click="selectUser(user)">
-    <div class="top" ng-style="avatarFor(user,'290x290')"></div>
+<section
+  class="domino overflow-hd"
+  ng-class="colorFromType(user.profile != null ? user.profile : user.type)"
+  ng-click="((classView && user.isVisible) || !classView) && selectUser(user)"
+  ng-disabled="classView && !user.isVisible"
+>
+  <div class="top" ng-style="avatarFor(user,'290x290')"></div>
 
-    <div class="center">
-        <p class="nomargin" translate content="directory.[[getType(user.profile != null ? user.profile : user.type).toLowerCase()]]"></p>
-        <p ng-if="hasSubject(user)" class="nomargin discipline cell-ellipsis" tooltip="[[getSubject(user)]]">Matière : [[getSubject(user)]]</p>
-    </div>
+  <div class="center">
+    <p
+      class="nomargin"
+      translate
+      content="directory.[[getType(user.profile != null ? user.profile : user.type).toLowerCase()]]"
+    ></p>
+    <p
+      ng-if="hasSubject(user)"
+      class="nomargin discipline cell-ellipsis"
+      tooltip="[[getSubject(user)]]"
+    >
+      Matière : [[getSubject(user)]]
+    </p>
+  </div>
 
-    <div class="bottom">
-        <div class="content">
-            <div class="multiline-ellipsis-three" style="line-height: inherit;">
-                <span>[[user.displayName]]</span>
-            </div>
-            <div class="bottom-locked">
-                <a ng-href="/conversation/conversation#/write-mail/[[user.id]]"
-                    ng-if="classView == true; hasWorkflowMessagerie()">
-                    <i class="send-mail"></i>
-                </a>
-            </div>
-        </div>
+  <div class="bottom">
+    <div class="content">
+      <div class="multiline-ellipsis-three" style="line-height: inherit">
+        <span>[[user.displayName]]</span>
+      </div>
+      <div class="bottom-locked">
+        <a
+          ng-href="/conversation/conversation#/write-mail/[[user.id]]"
+          ng-if="((classView && user.isVisible) || !classView) && hasWorkflowMessagerie()"
+        >
+          <i class="send-mail"></i>
+        </a>
+      </div>
     </div>
+  </div>
 </section>


### PR DESCRIPTION
# Description

A user must be able to see all students/tachers in the 'My Class' view regardless of communication rights, but he cannot communicate with them.

## Fixes

https://edifice-community.atlassian.net/browse/MOZO-150

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [x] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests
- Se connecter avec un compte 1D parent
- Aller sur la vue "La classe"
- On doit afficher tous les utilisateurs de la classe indépendamment des droits de communication
- Pour les utilisateurs dont on n’a pas le droit de communication, l'icone messagerie n'est pas affichée et la carte utilisateur n'est pas cliquable.

Vérifier la récupération des utilisateurs bloqués:
- Se connecter avec un compte admin et bloquer un utilisateur de la classe (élève ou enseignant)
- Revenir sur le compte du parent et vérifier si l'utisateur est toujours affiché dans la classe (pas d'icone messgerie et carte non cliquable)

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: