### PR TITLE
feat: #WB-2604, new transformer client to mark multimedia content after transformation

### DIFF
--- a/common/src/main/java/org/entcore/common/editor/EventRecorderContentTransformerClient.java
+++ b/common/src/main/java/org/entcore/common/editor/EventRecorderContentTransformerClient.java
@@ -1,0 +1,112 @@
+package org.entcore.common.editor;
+
+import fr.wseduc.transformer.IContentTransformerClient;
+import fr.wseduc.transformer.to.ContentTransformerRequest;
+import fr.wseduc.transformer.to.ContentTransformerResponse;
+import io.vertx.core.Future;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonObject;
+import org.entcore.common.events.EventStore;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class EventRecorderContentTransformerClient implements IContentTransformerClient {
+  private final IContentTransformerClient client;
+  private final EventStore eventStore;
+  private final String module;
+  public static final String EVENT = "EDITOR_CONTENT";
+
+  private static final Map<String, String> tagsToMultimediaCount = new HashMap<>();
+  private static final Set<String> customCounts = new HashSet<>();
+
+  static {
+    tagsToMultimediaCount.put("custom-image", "nb_images");
+    tagsToMultimediaCount.put("video", "nb_videos");
+    tagsToMultimediaCount.put("audio", "nb_sounds");
+    tagsToMultimediaCount.put("iframe", "nb_embedded");
+    customCounts.add("nb_attachments");
+    customCounts.add("nb_external_links");
+    customCounts.add("nb_internal_links");
+    customCounts.add("nb_formulae");
+  }
+
+  public EventRecorderContentTransformerClient(final IContentTransformerClient client,
+                                               final EventStore eventStore,
+                                               final String module) {
+    this.client = client;
+    this.eventStore = eventStore;
+    this.module = module;
+  }
+
+  @Override
+  public Future<ContentTransformerResponse> transform(final ContentTransformerRequest request,
+                                                      final HttpServerRequest httpCallerRequest) {
+    return client.transform(request, httpCallerRequest)
+      .onSuccess(transformed -> {
+        JsonObject json = transformed.getCleanJson();
+        if(json == null) {
+          json = transformed.getJsonContent();
+        }
+        final Map<String, Integer> occurrences = computeMultimediaOccurrences(json);
+        if(occurrences != null) {
+          final JsonObject customAttributes = new JsonObject()
+            .put("override-module", module);
+          for (Map.Entry<String, Integer> entry : occurrences.entrySet()) {
+            customAttributes.put(entry.getKey(), entry.getValue());
+          }
+          eventStore.createAndStoreEvent(EVENT, httpCallerRequest, customAttributes);
+        }
+      });
+  }
+
+  public static Map<String, Integer> computeMultimediaOccurrences(final JsonObject json) {
+    final Map<String, Integer> occurrences = new HashMap<>();
+    for (String attributeName : tagsToMultimediaCount.values()) {
+      occurrences.put(attributeName, 0);
+    }
+    for (String customCount : customCounts) {
+      occurrences.put(customCount, 0);
+    }
+    return computeMultimediaOccurrences(json, occurrences);
+  }
+
+  private static Map<String, Integer> computeMultimediaOccurrences(final JsonObject json, final Map<String, Integer> occurrences) {
+    if(json != null) {
+      final String type = json.getString("type");
+      if("attachments".equalsIgnoreCase(type)) {
+        final int nbAttachments = computeNbAttachements(json);
+        occurrences.compute("nb_attachments", (k, v) -> v + nbAttachments);
+      } else if("text".equalsIgnoreCase(type)) {
+        final String text = json.getString("text", "").trim();
+        if(text.length() >= 2 && text.charAt(0) == '$' && text.charAt(text.length() - 1) == '$') {
+          occurrences.compute("nb_formulae", (k, v) -> v == null ? 1 : v + 1);
+        }
+        if(json.containsKey("marks")) {
+          final List<String> hrefs = json.getJsonArray("marks").stream()
+            .map(mark -> ((JsonObject) mark))
+            .filter(mark -> "hyperlink".equalsIgnoreCase(mark.getString("type", "")))
+            .map(mark -> mark.getJsonObject("attrs").getString("href"))
+            .collect(Collectors.toList());
+          final int nbInt = (int) hrefs.stream().filter(href -> href.charAt(0) == '/').count();
+          final int nbExt = hrefs.size() - nbInt;
+          occurrences.compute("nb_internal_links", (k, v) -> v + nbInt);
+          occurrences.compute("nb_external_links", (k, v) -> v + nbExt);
+        }
+      } else if(tagsToMultimediaCount.containsKey(type)) {
+        occurrences.compute(tagsToMultimediaCount.get(type), (k, v) -> v + 1);
+      }
+      if(json.containsKey("content")) {
+        for (Object content : json.getJsonArray("content")) {
+          final JsonObject child = (JsonObject) content;
+          computeMultimediaOccurrences(child, occurrences);
+        }
+      }
+    }
+    return occurrences;
+  }
+
+  private static int computeNbAttachements(JsonObject json) {
+    return json.getJsonObject("attrs").getJsonArray("links").size();
+  }
+}

--- a/common/src/main/java/org/entcore/common/editor/EventStoredContentTransformerClientFactory.java
+++ b/common/src/main/java/org/entcore/common/editor/EventStoredContentTransformerClientFactory.java
@@ -1,0 +1,27 @@
+package org.entcore.common.editor;
+
+import fr.wseduc.transformer.IContentTransformerClient;
+import fr.wseduc.transformer.IContentTransformerFactory;
+import org.entcore.common.events.EventStore;
+
+/**
+ * Stores the multimedia composition of transformed content.
+ */
+public class EventStoredContentTransformerClientFactory implements IContentTransformerFactory {
+  private final EventStore eventStore;
+
+  private final IContentTransformerFactory innerFactory;
+  private final String module;
+
+  public EventStoredContentTransformerClientFactory(final String module, EventStore eventStore, IContentTransformerFactory innerFactory) {
+    this.module = module;
+    this.eventStore = eventStore;
+    this.innerFactory = innerFactory;
+  }
+
+  @Override
+  public IContentTransformerClient create() {
+    final IContentTransformerClient innerClient = innerFactory.create();
+    return new EventRecorderContentTransformerClient(innerClient, eventStore, module);
+  }
+}

--- a/common/src/main/java/org/entcore/common/editor/EventStoredContentTransformerFactoryProvider.java
+++ b/common/src/main/java/org/entcore/common/editor/EventStoredContentTransformerFactoryProvider.java
@@ -1,0 +1,35 @@
+package org.entcore.common.editor;
+
+import fr.wseduc.transformer.ContentTransformerFactoryProvider;
+import fr.wseduc.transformer.IContentTransformerFactory;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import org.entcore.common.events.EventStore;
+import org.entcore.common.events.EventStoreFactory;
+
+public class EventStoredContentTransformerFactoryProvider {
+
+  private EventStoredContentTransformerFactoryProvider() {};
+
+  /**
+   * Initialization method, must be called before getting a factory
+   * @param vertx vertx instance
+   */
+  public static void init(final Vertx vertx) {
+    ContentTransformerFactoryProvider.init(vertx);
+  }
+
+  /**
+   * Gets a factory according to the context specified in the configuration
+   * @param contentTransformerConfig the content transformer client configuration
+   * @return the content transformer client factory
+   */
+  public static IContentTransformerFactory getFactory(final String appName, JsonObject contentTransformerConfig) {
+    IContentTransformerFactory factory = ContentTransformerFactoryProvider.getFactory(appName, contentTransformerConfig);
+    if (contentTransformerConfig != null && contentTransformerConfig.getBoolean("store-event", true)) {
+      final EventStore eventStore = EventStoreFactory.getFactory().getEventStore(appName);
+      factory = new EventStoredContentTransformerClientFactory(appName, eventStore, factory);
+    }
+    return factory;
+  }
+}

--- a/common/src/test/java/org/entcore/common/events/impl/EventRecorderContentTransformerClientTest.java
+++ b/common/src/test/java/org/entcore/common/events/impl/EventRecorderContentTransformerClientTest.java
@@ -1,0 +1,331 @@
+package org.entcore.common.events.impl;
+
+import io.vertx.core.json.JsonObject;
+import org.entcore.common.editor.EventRecorderContentTransformerClient;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class EventRecorderContentTransformerClientTest {
+
+  @Test
+  public void testComputeCounters() {
+    final JsonObject content = new JsonObject(data).getJsonObject("jsonContent");
+    final Map<String, Integer> occurrences = EventRecorderContentTransformerClient.computeMultimediaOccurrences(content);
+    assertEquals(5, (int)occurrences.get("nb_images"));
+    assertEquals(4, (int)occurrences.get("nb_videos"));
+    assertEquals(4, (int)occurrences.get("nb_sounds"));
+    assertEquals(1, (int)occurrences.get("nb_embedded"));
+    assertEquals(4, (int)occurrences.get("nb_attachments"));
+    assertEquals(1, (int)occurrences.get("nb_external_links"));
+    assertEquals(2, (int)occurrences.get("nb_internal_links"));
+    assertEquals(1, (int)occurrences.get("nb_formulae"));
+  }
+  
+  
+  public static final String data = "{" +
+    "  \"jsonContent\": {" +
+    "    \"type\": \"doc\"," +
+    "    \"content\": [" +
+    "      {" +
+    "        \"type\": \"custom-image\"," +
+    "        \"attrs\": {" +
+    "          \"src\": \"/workspace/document/982d2c2a-2b40-4f6f-bdc3-d7d9eae3aa30\"," +
+    "          \"alt\": null," +
+    "          \"title\": null," +
+    "          \"size\": \"medium\"," +
+    "          \"width\": \"80\"," +
+    "          \"height\": \"NaN\"" +
+    "        }" +
+    "      }," +
+    "      {" +
+    "        \"type\": \"video\"," +
+    "        \"attrs\": {" +
+    "          \"src\": \"/workspace/document/2af1f06a-0688-47a0-8cb8-80c137d4b691\"," +
+    "          \"controls\": \"true\"," +
+    "          \"documentId\": \"2af1f06a-0688-47a0-8cb8-80c137d4b691\"," +
+    "          \"isCaptation\": \"true\"," +
+    "          \"videoResolution\": \"350x197\"," +
+    "          \"width\": \"350\"," +
+    "          \"height\": \"197\"" +
+    "        }" +
+    "      }," +
+    "      {" +
+    "        \"type\": \"audio\"," +
+    "        \"attrs\": {" +
+    "          \"src\": \"/workspace/document/0beb7f56-9e79-4d70-b644-eb71e8e69ca7\"," +
+    "          \"documentId\": \"0beb7f56-9e79-4d70-b644-eb71e8e69ca7\"" +
+    "        }" +
+    "      }," +
+    "      {" +
+    "        \"type\": \"custom-image\"," +
+    "        \"attrs\": {" +
+    "          \"src\": \"/workspace/document/fc49393b-b18b-4e7d-b281-8e63b1f8a218\"," +
+    "          \"alt\": null," +
+    "          \"title\": null," +
+    "          \"size\": \"medium\"," +
+    "          \"width\": \"80\"," +
+    "          \"height\": \"NaN\"" +
+    "        }" +
+    "      }," +
+    "      {" +
+    "        \"type\": \"attachments\"," +
+    "        \"attrs\": {" +
+    "          \"links\": [" +
+    "            {" +
+    "              \"href\": \"/workspace/document/574381e1-e8d7-4262-bb5d-b941caba77db\"," +
+    "              \"name\": \"undraw_Interview_re_e5jn.png\"," +
+    "              \"documentId\": \"574381e1-e8d7-4262-bb5d-b941caba77db\"," +
+    "              \"dataContentType\": null" +
+    "            }," +
+    "            {" +
+    "              \"href\": \"/workspace/document/29caba75-fce3-473d-9359-de0143f78ed5\"," +
+    "              \"name\": \"undraw_Sharing_articles_re_jnkp.png\"," +
+    "              \"documentId\": \"29caba75-fce3-473d-9359-de0143f78ed5\"," +
+    "              \"dataContentType\": null" +
+    "            }" +
+    "          ]" +
+    "        }" +
+    "      }," +
+    "      {" +
+    "        \"type\": \"custom-image\"," +
+    "        \"attrs\": {" +
+    "          \"src\": \"/workspace/document/01cfefc5-af88-41c9-8144-48f63b822754\"," +
+    "          \"alt\": null," +
+    "          \"title\": null," +
+    "          \"size\": \"medium\"," +
+    "          \"width\": \"80\"," +
+    "          \"height\": \"NaN\"" +
+    "        }" +
+    "      }," +
+    "      {" +
+    "        \"type\": \"custom-image\"," +
+    "        \"attrs\": {" +
+    "          \"src\": \"/workspace/document/eb06aeff-556b-4eee-9969-defd42c86243\"," +
+    "          \"alt\": null," +
+    "          \"title\": null," +
+    "          \"size\": \"medium\"," +
+    "          \"width\": \"80\"," +
+    "          \"height\": \"NaN\"" +
+    "        }" +
+    "      }," +
+    "      {" +
+    "        \"type\": \"attachments\"," +
+    "        \"attrs\": {" +
+    "          \"links\": [" +
+    "            {" +
+    "              \"href\": \"/workspace/document/01cfefc5-af88-41c9-8144-48f63b822754\"," +
+    "              \"name\": \"Product - earphone.jpeg\"," +
+    "              \"documentId\": \"01cfefc5-af88-41c9-8144-48f63b822754\"," +
+    "              \"dataContentType\": null" +
+    "            }" +
+    "          ]" +
+    "        }" +
+    "      }," +
+    "      {" +
+    "        \"type\": \"attachments\"," +
+    "        \"attrs\": {" +
+    "          \"links\": [" +
+    "            {" +
+    "              \"href\": \"/workspace/document/b7099fcc-ad74-4f7a-9a01-7d19e3c1d21c\"," +
+    "              \"name\": \"undraw_People_search_re_5rre.png\"," +
+    "              \"documentId\": \"b7099fcc-ad74-4f7a-9a01-7d19e3c1d21c\"," +
+    "              \"dataContentType\": null" +
+    "            }" +
+    "          ]" +
+    "        }" +
+    "      }," +
+    "      {" +
+    "        \"type\": \"paragraph\"," +
+    "        \"attrs\": {" +
+    "          \"textAlign\": \"left\"" +
+    "        }" +
+    "      }," +
+    "      {" +
+    "        \"type\": \"paragraph\"," +
+    "        \"attrs\": {" +
+    "          \"textAlign\": \"left\"" +
+    "        }" +
+    "      }," +
+    "      {" +
+    "        \"type\": \"custom-image\"," +
+    "        \"attrs\": {" +
+    "          \"src\": \"/workspace/document/ea06d933-9be1-4d01-ba67-a8b5b4228212\"," +
+    "          \"alt\": null," +
+    "          \"title\": null," +
+    "          \"size\": \"medium\"," +
+    "          \"width\": \"80\"," +
+    "          \"height\": \"NaN\"" +
+    "        }" +
+    "      }," +
+    "      {" +
+    "        \"type\": \"paragraph\"," +
+    "        \"attrs\": {" +
+    "          \"textAlign\": \"left\"" +
+    "        }" +
+    "      }," +
+    "      {" +
+    "        \"type\": \"audio\"," +
+    "        \"attrs\": {" +
+    "          \"src\": \"/workspace/document/4ffccfa5-39d3-4257-a554-7598d8ea28f5\"," +
+    "          \"documentId\": \"4ffccfa5-39d3-4257-a554-7598d8ea28f5\"" +
+    "        }" +
+    "      }," +
+    "      {" +
+    "        \"type\": \"audio\"," +
+    "        \"attrs\": {" +
+    "          \"src\": \"/workspace/document/5e6ea922-fb7c-4d00-b3e7-6879221f76e6\"," +
+    "          \"documentId\": \"5e6ea922-fb7c-4d00-b3e7-6879221f76e6\"" +
+    "        }" +
+    "      }," +
+    "      {" +
+    "        \"type\": \"audio\"," +
+    "        \"attrs\": {" +
+    "          \"src\": \"/workspace/document/4c8d4ddf-730c-430b-8a3e-986b7c19c21e\"," +
+    "          \"documentId\": \"4c8d4ddf-730c-430b-8a3e-986b7c19c21e\"" +
+    "        }" +
+    "      }," +
+    "      {" +
+    "        \"type\": \"paragraph\"," +
+    "        \"attrs\": {" +
+    "          \"textAlign\": \"left\"" +
+    "        }" +
+    "      }," +
+    "      {" +
+    "        \"type\": \"paragraph\"," +
+    "        \"attrs\": {" +
+    "          \"textAlign\": \"left\"" +
+    "        }," +
+    "        \"content\": [" +
+    "          {" +
+    "            \"type\": \"text\"," +
+    "            \"marks\": [" +
+    "              {" +
+    "                \"type\": \"hyperlink\"," +
+    "                \"attrs\": {" +
+    "                  \"href\": \"/actualites#/view/thread/71/info/237\"," +
+    "                  \"target\": \"_blank\"," +
+    "                  \"class\": null" +
+    "                }" +
+    "              }" +
+    "            ]," +
+    "            \"text\": \"Présentation du CDI en 2 minutes [Vie du collège]\"" +
+    "          }" +
+    "        ]" +
+    "      }," +
+    "      {" +
+    "        \"type\": \"paragraph\"," +
+    "        \"attrs\": {" +
+    "          \"textAlign\": \"left\"" +
+    "        }," +
+    "        \"content\": [" +
+    "          {" +
+    "            \"type\": \"text\"," +
+    "            \"marks\": [" +
+    "              {" +
+    "                \"type\": \"hyperlink\"," +
+    "                \"attrs\": {" +
+    "                  \"href\": \"/actualites#/view/thread/71/info/236\"," +
+    "                  \"target\": \"_blank\"," +
+    "                  \"class\": null" +
+    "                }" +
+    "              }" +
+    "            ]," +
+    "            \"text\": \"Règlement intérieur du collège [Vie du collège]\"" +
+    "          }" +
+    "        ]" +
+    "      }," +
+    "      {" +
+    "        \"type\": \"paragraph\"," +
+    "        \"attrs\": {" +
+    "          \"textAlign\": \"left\"" +
+    "        }," +
+    "        \"content\": [" +
+    "          {" +
+    "            \"type\": \"text\"," +
+    "            \"marks\": [" +
+    "              {" +
+    "                \"type\": \"hyperlink\"," +
+    "                \"attrs\": {" +
+    "                  \"href\": \"https://edifice-community.atlassian.net/wiki/spaces/ODE/pages/3767468033/Cadrage+technique+-+Mesure+d+audience\"," +
+    "                  \"target\": \"_blank\"," +
+    "                  \"class\": null," +
+    "                  \"title\": \"\"" +
+    "                }" +
+    "              }" +
+    "            ]," +
+    "            \"text\": \"Lien externe\"" +
+    "          }" +
+    "        ]" +
+    "      }," +
+    "      {" +
+    "        \"type\": \"paragraph\"," +
+    "        \"attrs\": {" +
+    "          \"textAlign\": \"left\"" +
+    "        }," +
+    "        \"content\": [" +
+    "          {" +
+    "            \"type\": \"text\"," +
+    "            \"text\": \"$\\\\frac{-b + \\\\sqrt{b^2 - 4ac}}{2a}$\"" +
+    "          }" +
+    "        ]" +
+    "      }," +
+    "      {" +
+    "        \"type\": \"iframe\"," +
+    "        \"attrs\": {" +
+    "          \"src\": \"https://www.youtube.com/embed/P_KOOdgKTSM?rel=0\"," +
+    "          \"frameborder\": 0," +
+    "          \"allowfullscreen\": true," +
+    "          \"width\": \"560\"," +
+    "          \"height\": \"315\"," +
+    "          \"style\": null" +
+    "        }" +
+    "      }," +
+    "      {" +
+    "        \"type\": \"paragraph\"," +
+    "        \"attrs\": {" +
+    "          \"textAlign\": \"left\"" +
+    "        }" +
+    "      }," +
+    "      {" +
+    "        \"type\": \"video\"," +
+    "        \"attrs\": {" +
+    "          \"src\": \"/workspace/document/400b45dd-0b83-43e5-9ab9-80319f924ea8\"," +
+    "          \"controls\": \"true\"," +
+    "          \"documentId\": \"400b45dd-0b83-43e5-9ab9-80319f924ea8\"," +
+    "          \"isCaptation\": \"true\"," +
+    "          \"videoResolution\": \"350x197\"," +
+    "          \"width\": \"350\"," +
+    "          \"height\": \"197\"" +
+    "        }" +
+    "      }," +
+    "      {" +
+    "        \"type\": \"video\"," +
+    "        \"attrs\": {" +
+    "          \"src\": \"/workspace/document/2a022985-e357-4b78-8a68-319954404eb7\"," +
+    "          \"controls\": \"true\"," +
+    "          \"documentId\": \"2a022985-e357-4b78-8a68-319954404eb7\"," +
+    "          \"isCaptation\": \"true\"," +
+    "          \"videoResolution\": \"350x197\"," +
+    "          \"width\": \"350\"," +
+    "          \"height\": \"197\"" +
+    "        }" +
+    "      }," +
+    "      {" +
+    "        \"type\": \"video\"," +
+    "        \"attrs\": {" +
+    "          \"src\": \"/workspace/document/b4c75fac-7d7b-4b71-b919-97667a0d5f23\"," +
+    "          \"controls\": \"true\"," +
+    "          \"documentId\": \"b4c75fac-7d7b-4b71-b919-97667a0d5f23\"," +
+    "          \"isCaptation\": \"true\"," +
+    "          \"videoResolution\": \"350x197\"," +
+    "          \"width\": \"350\"," +
+    "          \"height\": \"197\"" +
+    "        }" +
+    "      }" +
+    "    ]" +
+    "  }" +
+    "}";
+}


### PR DESCRIPTION

# Description

Ajout d'un nouveau client du service de transformation de contenu afin d'envoyer au service de stats la composition multimédia du contenu transformé.

## Fixes

[WB-2604](https://edifice-community.atlassian.net/browse/WB-2604)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Créer un post avec du contenu multimédia
2. Regarder dans la base de stats que les compteurs correspondent au contenu

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: