### PR TITLE
feat(directory): #MOZO-154, #MOZO-155, handle multiple classrooms case

### DIFF
--- a/directory/src/main/resources/i18n/fr.json
+++ b/directory/src/main/resources/i18n/fr.json
@@ -925,5 +925,8 @@
     "directory.default.teacher.title" : "Enseignants et personnels de l'établissement",
     "admin.duplicate.notify.subject" : "Votre demande de duplication de paramétrage",
     "class.empty.state.title": "Pas de classe rattachée",
-    "class.empty.state.description": "Votre compte est rattaché à aucune classe.<br>Veuillez contacter votre administrateur si cela est une erreur.<br>Pour rechercher un utilisateur, vous pouvez utiliser l'application \"Annuaire\""
+    "class.empty.state.description": "Votre compte est rattaché à aucune classe.<br>Veuillez contacter votre administrateur si cela est une erreur.<br>Pour rechercher un utilisateur, vous pouvez utiliser l'application \"Annuaire\"",
+    "class.search": "Rechercher une classe",
+    "class.search.noresults.title": "Pas de résultats",
+    "class.search.noresults.description": "La recherche n'aboutit à aucun résultat.<br>Veuillez changer votre recherche."
 }

--- a/directory/src/main/resources/i18n/fr.json
+++ b/directory/src/main/resources/i18n/fr.json
@@ -923,6 +923,7 @@
     "error.commit.timetable.transaction" : "L'enregistrement des données n'a pu aboutir, veuillez essayer ultérieurement. Si le problème persiste, veuillez contacter l'assistance.",
     "directory.default.relative.title" : "Enseignants de mes enfants",
     "directory.default.teacher.title" : "Enseignants et personnels de l'établissement",
-    "admin.duplicate.notify.subject" : "Votre demande de duplication de paramétrage"
-    
+    "admin.duplicate.notify.subject" : "Votre demande de duplication de paramétrage",
+    "class.empty.state.title": "Pas de classe rattachée",
+    "class.empty.state.description": "Votre compte est rattaché à aucune classe.<br>Veuillez contacter votre administrateur si cela est une erreur.<br>Pour rechercher un utilisateur, vous pouvez utiliser l'application \"Annuaire\""
 }

--- a/directory/src/main/resources/public/template/class-list.html
+++ b/directory/src/main/resources/public/template/class-list.html
@@ -1,0 +1,38 @@
+
+<!-- /myClass content -->
+
+<div class="vertical-spacing-twice">
+	<!-- Loading animation -->
+	<div class="dominos centered-text only-large-desktop" ng-if="display.loading">
+		<div class="row reduce-block-six">
+			<div class="spacer-large"></div>
+			<img skin-src="/img/illustrations/loading.gif" width="100px" heigh="100px"/>
+		</div>
+	</div>
+
+	<!-- emptyscreen -->
+	<div class="emptyscreen" ng-if="!classrooms.match(search.text).length && !display.loading">
+		<h2 class="emptyscreen-header"><i18n>class.search.noresults.title</i18n></h2>
+		<img class="emptyscreen-image" skin-src="/img/illustrations/illus-noresults.svg">
+		<p class="emptyscreen-footer"><i18n>class.search.noresults.description</i18n></p>
+	</div>
+
+	<div class="dominos centered-text" ng-class="dominoClass">
+		<!-- Classrooms -->
+		<div class="item user" ng-repeat="classroom in classrooms.match(search.text) | limitTo:search.maxLength">
+			<section class="domino grey" ng-click="selectClassroom(classroom)">
+				<div class="top">
+					<i class="users"></i>
+				</div>
+				<div class="center">
+					<span translate content="directory.classe"></span>
+				</div>
+				<div class="bottom">
+					<div class="content">
+						<span>[[classroom.name]]</span>
+					</div>
+				</div>
+			</section>
+		</div>
+	</div>
+</div>

--- a/directory/src/main/resources/public/template/class.html
+++ b/directory/src/main/resources/public/template/class.html
@@ -7,31 +7,22 @@
 		<h1 class="cell">
 			<a data-reload>
 				<i class="userbook"></i>
-				<span translate content="userBook.class.title"></span><span>[[myClass && myClass.length > 0 ? " - " + myClass[0].name : ""]]</span>
+				<span translate content="userBook.class.title"></span>
+				<span>[[currentClass ? " - " + currentClass.name : ""]]</span>
 			</a>
 		</h1>
 	</app-title>
-
-	<div class="right-magnet three cell twelve-mobile">
-		<div class="row top-spacing" ng-if="users.all.length > 0">
-			<i class="show-details right-magnet"
-			   ng-click="selectUser(users.first())"
-			   ng-class="{ selected: currentUser }"
-			   ng-if="users.first()"></i>
-			<i class="show-icons right-magnet"
-			   ng-click="deselectUser('dominos')"
-			   ng-class="{ selected: !template.contains('details', 'user-infos') }"></i>
-		</div>
-	</div>
 </div>
 
 <div class="row vertical-spacing-twice">
 	<input type="search"
-		   ng-model="search.text" ng-change="updateSearch()"
-		   translate attr="placeholder"
-		   placeholder="userBook.search"
-		   class="three cell twelve-mobile"
-		   style="width: 285px" />
+		ng-if="!currentUser"
+		ng-model="search.text"
+		ng-change="updateSearch()"
+		placeholder="[[search.placeholder || 'userBook.search']]"
+		class="three cell twelve-mobile"
+		style="width: 285px"
+	/>
 	<a class="small-text right-magnet reduce-block-four"
 		href="/userbook/annuaire#/search"
 		translate content="search.in.directory"></a>
@@ -39,5 +30,10 @@
 
 
 <div class="row vertical-spacing-twice">
+	<a ng-if="(currentClass && classrooms.all.length > 1) || currentUser"
+		ng-click="navigateBack()">
+		<i class="back"></i>
+		<i18n>userBook.directory.back</i18n>
+	</a>
 	<div class="twelve cell" ng-include="template.containers.main"></div>
 </div>

--- a/directory/src/main/resources/public/template/dominos.html
+++ b/directory/src/main/resources/public/template/dominos.html
@@ -133,7 +133,7 @@
 	</div>	
 
 	<!-- Classrooms -->
-    <div class="item user" ng-repeat="classroom in classrooms.match(search.text) | limitTo:search.maxLength">
+    <div ng-if="!classView" class="item user" ng-repeat="classroom in classrooms.match(search.text) | limitTo:search.maxLength">
         <section class="domino grey" ng-click="selectClassroom(classroom)">
             <div class="top">
                 <i class="users"></i>

--- a/directory/src/main/resources/public/template/no-classroom.html
+++ b/directory/src/main/resources/public/template/no-classroom.html
@@ -1,0 +1,22 @@
+<!--
+
+ -->
+<!-- /myClass -->
+<h1>
+	<a data-reload>
+		<i class="userbook"></i>
+		<span translate key="userBook.class.title"></span>
+	</a>
+</h1>
+
+
+<div class="emptyscreen row reduce-block-six">
+	<h2 class="emptyscreen-header"><i18n>class.empty.state.title</i18n></h2>
+	<img class="emptyscreen-image" skin-src="/img/illustrations/illus-noresults.svg">
+	<p class="emptyscreen-footer"><i18n>class.empty.state.description</i18n></p>
+
+	<a class="cell-ellipsis right-magnet"
+		href="/userbook/annuaire#/search">
+		<button translate content="directory"></button>
+	</a>
+</div>

--- a/directory/src/main/resources/public/ts/controllers/directory.ts
+++ b/directory/src/main/resources/public/ts/controllers/directory.ts
@@ -175,40 +175,29 @@ export const directoryController = ng.controller('DirectoryController',['$scope'
 			}
 			await $scope.createAllFavorites();
 			$scope.network = directory.network;
-			directory.network.schools.sync();
-			directory.network.schools.one('sync', function(){
-				$scope.schools = directory.network.schools;
-				$scope.currentSchool = $scope.schools.first();
-				if($scope.currentSchool === undefined){
-					template.open('page', 'noschool');
-					return;
-				}
-				$scope.currentSchool.sync();
-				$scope.showSchool($scope.currentSchool);
 
-				$scope.currentSchool.one('sync', function(){
-					$scope.users = $scope.currentSchool.users;
-					$scope.allUsers = Object.assign([], $scope.users);
+			directory.network.classrooms.sync();
+			directory.network.classrooms.one('sync', function(){
+				$scope.classrooms = directory.network.classrooms.all;
 
+				if(!$scope.classrooms || $scope.classrooms.length === 0){
+					template.open('page', 'no-classroom');
+				} else {
 					template.open('page', 'class');
-
-					$scope.classrooms = $scope.currentSchool.classrooms;
-					if($scope.schools.all.length === 1 && model.me.classes.length === 1){
-						template.open('main', 'mono-class');
-						$scope.myClass = $scope.classrooms.where({id: model.me.classes[0]});
-						if($scope.myClass.length > 0)
-							$scope.selectClassroom($scope.myClass[0]);
-					}
-					else{
+					if ($scope.classrooms.length > 1) {
 						template.open('main', 'multi-class');
+					} else {
+						$scope.currentClass = directory.network.classrooms.first();
+						$scope.selectClassroom($scope.currentClass);
+						template.open('main', 'mono-class');
 					}
+				}
 
-					template.open('list', 'dominos');
-					template.open('dominosUser', 'dominos-user');	
-					$scope.dominoClass ='my-class';
-					$scope.title = 'class';
-					$scope.$apply();
-				});
+				template.open('list', 'dominos');
+				template.open('dominosUser', 'dominos-user');	
+				$scope.dominoClass ='my-class';
+				$scope.title = 'class';
+				$scope.$apply();
 			});
 		}
 	});

--- a/directory/src/main/resources/public/ts/model.ts
+++ b/directory/src/main/resources/public/ts/model.ts
@@ -15,8 +15,8 @@
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
-import { http as oldHttp, model, idiom as lang, Collection, notify, ui, _, moment } from 'entcore';
 import http from 'axios';
+import { Collection, _, idiom as lang, model, moment, notify, http as oldHttp, ui } from 'entcore';
 
 export const directory = {
 	directory: undefined,
@@ -301,6 +301,28 @@ export const directory = {
 					}
 				});
 				return res;
+			}
+		});
+
+		this.collection(directory.Classroom, {
+			sync: function() {
+				return http.get('/auth/oauth2/userinfo?version=v2.0')
+					.then(function(res) {
+						const { classes, realClassesNames } = res.data;
+
+						let results: {id: string, name: string}[];
+						if (!classes || !realClassesNames || classes.length !== realClassesNames.length) {
+							results = [];
+						}
+						results =
+							classes.map((id: string, index: number) => ({
+								id,
+								name: realClassesNames[index],
+							})
+						);
+						this.load(results);
+						this.trigger('sync');
+					}.bind(this));
 			}
 		});
 	},

--- a/directory/src/main/resources/public/ts/model.ts
+++ b/directory/src/main/resources/public/ts/model.ts
@@ -323,7 +323,17 @@ export const directory = {
 						this.load(results);
 						this.trigger('sync');
 					}.bind(this));
-			}
+			},
+			match: function(search){
+				return _.filter(this.all, function(classroom){
+					var words = search.split(' ');
+					return _.find(words, function(word){
+						var formattedOption = lang.removeAccents(classroom.name).toLowerCase();
+						var formattedWord = lang.removeAccents(word).toLowerCase();
+						return formattedOption.indexOf(formattedWord) === -1
+					}) === undefined;
+				});
+			},
 		});
 	},
 	Classroom: function(){


### PR DESCRIPTION
# Description

- If the user has multiple classes, we display the 'class list' in 'The classroom' view.
- If the user has only one classroom, we display the users of the classroom.
- The user can search classroom by name, we display an empty state if no result found.


## Fixes

https://edifice-community.atlassian.net/browse/MOZO-154
https://edifice-community.atlassian.net/browse/MOZO-155

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [x] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Cas multi classe:
Se connecter avec un compte qui a plusieurs classes
=> La vue doit afficher la liste de toutes les classes
=> Le champ "Recherche" doit filtrer les classes affichées par "nom"
=> La recherche abouti un empty state si pas de classe

3. Cas mono classe:
Se connecter avec un compte qui a une seule classe
=> La vue doit par défaut afficher les utilisateurs de la classe

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: