### PR TITLE
chore(timeline): #MOZO-138, remove badge default value from push-notif payload

### DIFF
--- a/timeline/src/main/java/org/entcore/timeline/services/impl/DefaultPushNotifService.java
+++ b/timeline/src/main/java/org/entcore/timeline/services/impl/DefaultPushNotifService.java
@@ -214,7 +214,7 @@ public class DefaultPushNotifService extends Renders implements TimelinePushNoti
                 message.put("notification", notif);
                 // "content-avaiable" is required here to make the mobile app awake every time it receives a notification.
                 // When the back will be able to put the right number for the "badge" value, "content-available" could be removed to preserve user battery life.
-                apns.put("payload", new JsonObject().put("aps", new JsonObject().put("badge", 1).put("content-available", 1)));
+                apns.put("payload", new JsonObject().put("aps", new JsonObject().put("content-available", 1)));
                 message.put("apns", apns);
             }
 


### PR DESCRIPTION
# Description

Depuis la version 1.10.0, l’application mobile compte le nombre de notifications push reçues et met à jour le badge sur l’icône de l’application.
Dans certains cas, lors de la réception d’une notification push, ce badge peut brièvement passer à 1 puis réafficher le bon nombre.

## Fixes

https://edifice-community.atlassian.net/browse/MOZO-138

## Type of change

Please check options that are relevant.

- [x] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [x] timeline
- [ ] workspace

## Tests

Les tests seront faits dans l'app mobile après déploiement

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: