### PR TITLE
feat(peertube-saml): #MEX-347 Add a field to the SSO response to indicate whether the user has access to the app

### DIFF
--- a/auth/src/main/java/org/entcore/auth/services/impl/SSOPeertube.java
+++ b/auth/src/main/java/org/entcore/auth/services/impl/SSOPeertube.java
@@ -20,9 +20,9 @@ public class SSOPeertube extends AbstractSSOProvider {
                 "u.displayName AS displayName,\n" +
                 "u.email AS email,\n" +
                 "u.externalId AS externalId,\n" +
-                "REDUCE(s = false, i IN applications | s OR i.address CONTAINS({serviceProviderEntityId})) AS hasMatchingApplication";
+                "REDUCE(s = false, i IN applications | s OR i.name CONTAINS({serviceName})) AS hasMatchingApplication";
 
-        Neo4j.getInstance().execute(query, new JsonObject().put("userId", userId).put("serviceProviderEntityId",serviceProviderEntityId), Neo4jResult.validUniqueResultHandler(evt -> {
+        Neo4j.getInstance().execute(query, new JsonObject().put("userId", userId).put("serviceName","PeertubeSAMLId"), Neo4jResult.validUniqueResultHandler(evt -> {
             if (evt.isLeft()) {
                 handler.handle(new Either.Left(evt.left().getValue()));
                 return;


### PR DESCRIPTION
# Description
We want to verify if the user has access to the peertube connector before creating an account with the SAML peertube plugin. We thus added a field in the SSO Peertube answer to retrieve this information in peertube. The field will be set to 'true' if the user has access to the application, or 'false' otherwise
Please include a summary of the changes and the related issue.

## Fixes

[MEX-347](https://jira.support-ent.fr/browse/MEX-347)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [x] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests
With an account that has access to the connector, make an SSO request to the SSOPeertube response, check in the response if the 'hasConnectorAccess' field is properly filled and has the value 'true'. The same test can be performed with an account that does not have access to the connector and verify if the field is correctly set to 'false'.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: