### PR TITLE
feat(directory): #MOZO-155, change wording/illustration in class empty state view

### DIFF
--- a/directory/src/main/resources/i18n/fr.json
+++ b/directory/src/main/resources/i18n/fr.json
@@ -926,7 +926,8 @@
     "admin.duplicate.notify.subject" : "Votre demande de duplication de paramétrage",
     "class.empty.state.title": "Pas de classe rattachée",
     "class.empty.state.description": "Votre compte est rattaché à aucune classe.<br>Veuillez contacter votre administrateur si cela est une erreur.<br>Pour rechercher un utilisateur, vous pouvez utiliser l'application \"Annuaire\"",
+    "class.empty.state.directory": "Ouvrir l'annuaire",
     "class.search": "Rechercher une classe",
-    "class.search.noresults.title": "Pas de résultats",
+    "class.search.noresults.title": "C'est désert... Il y a quelqu'un ?",
     "class.search.noresults.description": "La recherche n'aboutit à aucun résultat.<br>Veuillez changer votre recherche."
 }

--- a/directory/src/main/resources/public/template/class-list.html
+++ b/directory/src/main/resources/public/template/class-list.html
@@ -13,7 +13,7 @@
 	<!-- emptyscreen -->
 	<div class="emptyscreen" ng-if="!classrooms.match(search.text).length && !display.loading">
 		<h2 class="emptyscreen-header"><i18n>class.search.noresults.title</i18n></h2>
-		<img class="emptyscreen-image" skin-src="/img/illustrations/illus-noresults.svg">
+		<img class="emptyscreen-image" skin-src="/img/illustrations/illus-emptyscreen.svg">
 		<p class="emptyscreen-footer"><i18n>class.search.noresults.description</i18n></p>
 	</div>
 

--- a/directory/src/main/resources/public/template/no-classroom.html
+++ b/directory/src/main/resources/public/template/no-classroom.html
@@ -12,11 +12,11 @@
 
 <div class="emptyscreen row reduce-block-six">
 	<h2 class="emptyscreen-header"><i18n>class.empty.state.title</i18n></h2>
-	<img class="emptyscreen-image" skin-src="/img/illustrations/illus-noresults.svg">
+	<img class="emptyscreen-image" skin-src="/img/illustrations/illus-emptyscreen.svg">
 	<p class="emptyscreen-footer"><i18n>class.empty.state.description</i18n></p>
 
 	<a class="cell-ellipsis right-magnet"
 		href="/userbook/annuaire#/search">
-		<button translate content="directory"></button>
+		<button translate content="class.empty.state.directory"></button>
 	</a>
 </div>


### PR DESCRIPTION
# Description

Change wording/illustration in class empty state view

## Fixes

https://edifice-community.atlassian.net/browse/MOZO-155

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [x] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

- Se connecter avec un compte 1D qui a plusieurs classes
- Aller dans la vue "La classe"
- Lancer une recherche par nom de classe inexistante
- Vérifier que le wording et l'illustration correspondent à la spéc

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: