### PR TITLE
feat(workspace): #WB-2679, direct transfer of documents to protected or public space

### DIFF
--- a/common/src/main/java/org/entcore/common/folders/FolderManager.java
+++ b/common/src/main/java/org/entcore/common/folders/FolderManager.java
@@ -1,6 +1,7 @@
 package org.entcore.common.folders;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -12,6 +13,7 @@ import org.entcore.common.storage.Storage;
 import org.entcore.common.user.UserInfos;
 
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServerRequest;
@@ -292,6 +294,18 @@ public interface FolderManager {
 	 */
 	void copyAll(Collection<String> sourceIds, Optional<String> destinationFolderId, UserInfos user,
 			final Handler<AsyncResult<JsonArray>> handler);
+
+	/**
+	 * Copy an ordered list of `file` documents, without failing if any one cannot be copied.
+	 * The returned list of new documents wiil be in the same order as originals.
+	 * Any failed copy will be represented by a null in the returned list.
+	 * @param userOpt             the user doing the copy
+	 * @param originals           list of documents
+	 * @param keepVisibility      keep the `protect`or `public`flag ?
+	 * @param handler             emit the list of copied files
+	 */
+	void copyAllNoFail(Optional<UserInfos> userOpt, List<JsonObject> originals,
+			boolean keepVisibility, final Handler<AsyncResult<List<JsonObject>>> handler);
 
 	/**
 	 * trash only make the file or the folder not visible but it is still saved in

--- a/common/src/main/java/org/entcore/common/folders/FolderManager.java
+++ b/common/src/main/java/org/entcore/common/folders/FolderManager.java
@@ -302,10 +302,10 @@ public interface FolderManager {
 	 * @param userOpt             the user doing the copy
 	 * @param originals           list of documents
 	 * @param keepVisibility      keep the `protect`or `public`flag ?
-	 * @param handler             emit the list of copied files
+	 * @return                    the list of copied documents (or nulls)
 	 */
-	void copyAllNoFail(Optional<UserInfos> userOpt, List<JsonObject> originals,
-			boolean keepVisibility, final Handler<AsyncResult<List<JsonObject>>> handler);
+	Future<List<JsonObject>> copyAllNoFail(Optional<UserInfos> userOpt, List<JsonObject> originals,
+			boolean keepVisibility);
 
 	/**
 	 * trash only make the file or the folder not visible but it is still saved in

--- a/common/src/main/java/org/entcore/common/folders/impl/FolderManagerWithQuota.java
+++ b/common/src/main/java/org/entcore/common/folders/impl/FolderManagerWithQuota.java
@@ -4,6 +4,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import io.vertx.core.*;
+
+import org.apache.commons.lang3.NotImplementedException;
 import org.entcore.common.folders.ElementQuery;
 import org.entcore.common.folders.ElementShareOperations;
 import org.entcore.common.folders.FolderManager;
@@ -202,6 +204,15 @@ public class FolderManagerWithQuota implements FolderManager {
 			final long size = DocumentHelper.getFileSize(copies);
 			return decrementFreeSpace(user.getUserId(), size).map(copies);
 		}).setHandler(handler);
+	}
+
+	@Override
+	public void copyAllNoFail(
+			Optional<UserInfos> userOpt,
+			List<JsonObject> originals,
+			boolean keepVisibility,
+			Handler<AsyncResult<List<JsonObject>>> handler) {
+		handler.handle(io.vertx.core.Future.failedFuture("not.implemented"));
 	}
 
 	@Override

--- a/common/src/main/java/org/entcore/common/folders/impl/FolderManagerWithQuota.java
+++ b/common/src/main/java/org/entcore/common/folders/impl/FolderManagerWithQuota.java
@@ -5,7 +5,6 @@ import java.util.stream.Collectors;
 
 import io.vertx.core.*;
 
-import org.apache.commons.lang3.NotImplementedException;
 import org.entcore.common.folders.ElementQuery;
 import org.entcore.common.folders.ElementShareOperations;
 import org.entcore.common.folders.FolderManager;
@@ -207,12 +206,11 @@ public class FolderManagerWithQuota implements FolderManager {
 	}
 
 	@Override
-	public void copyAllNoFail(
+	public Future<List<JsonObject>> copyAllNoFail(
 			Optional<UserInfos> userOpt,
 			List<JsonObject> originals,
-			boolean keepVisibility,
-			Handler<AsyncResult<List<JsonObject>>> handler) {
-		handler.handle(io.vertx.core.Future.failedFuture("not.implemented"));
+			boolean keepVisibility) {
+		return io.vertx.core.Future.failedFuture("not.implemented");
 	}
 
 	@Override

--- a/common/src/main/java/org/entcore/common/folders/impl/QueryHelper.java
+++ b/common/src/main/java/org/entcore/common/folders/impl/QueryHelper.java
@@ -25,7 +25,7 @@ import io.vertx.core.Future;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
-class QueryHelper {
+public class QueryHelper {
 	final static int MAX_BATCH = 10;
 	final static long MAX_DEPTH = 10;
 	protected final MongoDb mongo = MongoDb.getInstance();
@@ -558,7 +558,7 @@ class QueryHelper {
 		}
 	}
 
-	DocumentQueryBuilder queryBuilder() {
+	public DocumentQueryBuilder queryBuilder() {
 		return new DocumentQueryBuilder();
 	}
 
@@ -822,7 +822,7 @@ class QueryHelper {
 		return future;
 	}
 
-	Future<List<JsonObject>> findAllAsList(DocumentQueryBuilder query) {
+	public Future<List<JsonObject>> findAllAsList(DocumentQueryBuilder query) {
 		return findAll(query).map(s -> s.stream().map(o -> (JsonObject) o).collect(Collectors.toList()));
 	}
 

--- a/common/src/main/java/org/entcore/common/folders/impl/StorageHelper.java
+++ b/common/src/main/java/org/entcore/common/folders/impl/StorageHelper.java
@@ -153,9 +153,9 @@ public class StorageHelper {
 	 * Copy main file and any thumbnail of a document. 
 	 * @param storage where to copy
 	 * @param fileIds a list of file ids
-	 * @return a Map of <ID of original file, ID of copied file>, 
-	 * 		   or null if any file was not copied successfully
-	*/
+	 * @return a Map of <ID of original file, ID of copied file>
+	 *		   
+	 */
 	static public Future<Map<String, String>> copyFiles(Storage storage, final List<String> fileIds) {
 		@SuppressWarnings("rawtypes")
 		final List<Future> copyFutures = new ArrayList<Future>();
@@ -167,7 +167,7 @@ public class StorageHelper {
 				if (isOk(res)) {
 					promise.complete(new AbstractMap.SimpleEntry<String, String>(fId, res.getString("_id")));
 				} else {
-					promise.fail(toErrorStr(res));
+					promise.complete(null);
 				}
 			});
 
@@ -175,12 +175,11 @@ public class StorageHelper {
 		}
 
 		return CompositeFuture
-		.join(copyFutures)
-		.recover( fail -> Future.succeededFuture(null) )
+		.all(copyFutures)
 		.map(unused -> {
 			@SuppressWarnings("unchecked")
 			Map<String, String> oldFileIdForNewFileId = copyFutures.stream()
-				.map(future -> (Entry<String, String>) future.result())
+				.map(future -> future == null ? null : (Entry<String, String>) future.result())
 				.filter( pair -> pair != null)
 				.collect(Collectors.toMap(pair -> pair.getKey(), pair -> pair.getValue()));
 			return oldFileIdForNewFileId;

--- a/common/src/main/java/org/entcore/common/folders/impl/StorageHelper.java
+++ b/common/src/main/java/org/entcore/common/folders/impl/StorageHelper.java
@@ -54,7 +54,13 @@ public class StorageHelper {
 		}
 	}
 
-	/** Remove fileIds from the document, if they match the document's file or any thumbnail. */
+	/**
+	 * Clean a document, by removing any reference to a file (id is given),
+	 * in the `file` and `thumbnails` fields.
+	 * 
+	 * @param jsonDocument document to clean.
+	 * @param fileIds IDs of file to be removed from `file` or `thumbnails` fields.
+	 */
 	static void removeAll(JsonObject jsonDocument, Collection<String> fileIds) {
 		final JsonObject thumbnails = jsonDocument.getJsonObject("thumbnails", null);
 		final Set<Map.Entry<String,Object>> thumbnailEntries = thumbnails==null ? null : thumbnails.getMap().entrySet();

--- a/common/src/main/java/org/entcore/common/folders/impl/StorageHelper.java
+++ b/common/src/main/java/org/entcore/common/folders/impl/StorageHelper.java
@@ -13,11 +13,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.checkerframework.checker.units.qual.K;
+import org.apache.commons.lang3.tuple.Pair;
 import org.entcore.common.storage.Storage;
 import org.entcore.common.utils.StringUtils;
 
@@ -64,14 +63,7 @@ public class StorageHelper {
 			if(getFileId(jsonDocument).contains(fileId)) {
 				jsonDocument.remove("file");
 			} else if(thumbnailEntries!=null) {
-				Iterator<Entry<String, Object>> iterator = thumbnailEntries.iterator();
-				while( iterator.hasNext() ) {
-					Entry<String, Object> entry = iterator.next();
-					if(entry!=null && entry.getValue()!=null && fileId.equals(entry.getValue().toString())) {
-						// Removing here also applies on the thumbnails JsonObject.
-						iterator.remove();
-					}
-				}
+				thumbnailEntries.removeIf(entry -> entry!=null && entry.getValue()!=null && fileId.equals(entry.getValue().toString()));
 			}
 		}
 	}
@@ -161,11 +153,11 @@ public class StorageHelper {
 		final List<Future> copyFutures = new ArrayList<Future>();
 
 		for (String fId : fileIds) {
-			Promise<Entry<String, String>> promise = Promise.promise();
+			Promise<Pair<String, String>> promise = Promise.promise();
 
 			storage.copyFile(fId, res -> {
 				if (isOk(res)) {
-					promise.complete(new AbstractMap.SimpleEntry<String, String>(fId, res.getString("_id")));
+					promise.complete(Pair.of(fId, res.getString("_id")));
 				} else {
 					promise.complete(null);
 				}
@@ -179,7 +171,7 @@ public class StorageHelper {
 		.map(unused -> {
 			@SuppressWarnings("unchecked")
 			Map<String, String> oldFileIdForNewFileId = copyFutures.stream()
-				.map(future -> future == null ? null : (Entry<String, String>) future.result())
+				.map(future -> future == null ? null : (Pair<String, String>) future.result())
 				.filter( pair -> pair != null)
 				.collect(Collectors.toMap(pair -> pair.getKey(), pair -> pair.getValue()));
 			return oldFileIdForNewFileId;

--- a/workspace/src/main/java/org/entcore/workspace/controllers/WorkspaceController.java
+++ b/workspace/src/main/java/org/entcore/workspace/controllers/WorkspaceController.java
@@ -1299,13 +1299,13 @@ public class WorkspaceController extends BaseController {
 					return;
 				}
 	
-				workspaceService.transferAll(ids.getList(), Optional.ofNullable(application), visibility, userInfos, event -> {
-					if (event.succeeded()) {
-						renderJson(request, event.result());
-					} else {
-						JsonObject error = new JsonObject().put("error", event.cause().getMessage());
-						renderError(request, error);
-					}
+				workspaceService.transferAll(ids.getList(), Optional.ofNullable(application), visibility, userInfos)
+				.onSuccess( results -> {
+					renderJson(request, (JsonArray) results);
+				})
+				.onFailure( message -> {
+					JsonObject error = new JsonObject().put("error", message);
+					renderError(request, error);
 				});
 			});
 		});

--- a/workspace/src/main/java/org/entcore/workspace/security/WorkspaceResourcesProvider.java
+++ b/workspace/src/main/java/org/entcore/workspace/security/WorkspaceResourcesProvider.java
@@ -120,6 +120,7 @@ public class WorkspaceResourcesProvider implements ResourcesProvider {
 			case "restoreFolder":
 			case "restoreTrash":
 			case "bulkDelete":
+			case "transferDocuments":
 				authorizeDocuments(request, user, binding.getServiceMethod(), handler);
 				break;
 			case "getParentInfos":

--- a/workspace/src/main/java/org/entcore/workspace/service/WorkspaceService.java
+++ b/workspace/src/main/java/org/entcore/workspace/service/WorkspaceService.java
@@ -42,6 +42,35 @@ public interface WorkspaceService extends FolderManager {
 
 	public static final String WORKSPACE_NAME = "WORKSPACE";
 
+	public enum Visibility { 
+		OWNER("owner"),
+    	PROTECTED("protected"),
+    	PUBLIC("public");
+    
+		private final String visibility;
+
+		Visibility(final String visibility) {
+			this.visibility = visibility;
+		}
+
+		public String get() {
+			return this.visibility;
+		}
+
+		public static Visibility fromString(final String visibility) {
+			if(OWNER.visibility.equals(visibility)) {
+				return OWNER;
+			}
+			if(PROTECTED.visibility.equals(visibility)) {
+				return PROTECTED;
+			}
+			if(PUBLIC.visibility.equals(visibility)) {
+				return PUBLIC;
+			}
+			return null;
+		}
+	}
+
 	public void addDocument(final UserInfos user, final float quality, final String name, final String application,
 							final JsonObject doc, final JsonObject uploaded, final Handler<AsyncResult<JsonObject>> handler);
 
@@ -113,6 +142,16 @@ public interface WorkspaceService extends FolderManager {
 	public Future<Set<String>> getNotifyContributorDest(Optional<String> id, UserInfos user, Set<String> docIds);
 
 	public void changeVisibility(final JsonArray documentIds, String visibility, final Handler<Message<JsonObject>> handler);
+
+	/**
+	 * Transfer documents file to protected or public space.
+	 * @param sourceIds List of documents id
+	 * @param application Optional application code
+	 * @param visibility PROTECTED or PUBLIC only
+	 * @param user
+	 */
+	public void transferAll(final List<String> sourceIds, Optional<String> application, Visibility visibility, UserInfos user,
+			Handler<AsyncResult<JsonArray>> handler);
 
 	void getParentInfos(final String childId, UserInfos user, final Handler<AsyncResult<JsonObject>> handler);
 }

--- a/workspace/src/main/java/org/entcore/workspace/service/WorkspaceService.java
+++ b/workspace/src/main/java/org/entcore/workspace/service/WorkspaceService.java
@@ -144,14 +144,14 @@ public interface WorkspaceService extends FolderManager {
 	public void changeVisibility(final JsonArray documentIds, String visibility, final Handler<Message<JsonObject>> handler);
 
 	/**
-	 * Transfer documents file to protected or public space.
+	 * Transfer file documents to protected or public space.
 	 * @param sourceIds List of documents id
 	 * @param application Optional application code
 	 * @param visibility PROTECTED or PUBLIC only
 	 * @param user
+	 * @return ordered JsonArray of transfered documents, being null when transfering was not possible.
 	 */
-	public void transferAll(final List<String> sourceIds, Optional<String> application, Visibility visibility, UserInfos user,
-			Handler<AsyncResult<JsonArray>> handler);
+	public Future<JsonArray> transferAll(final List<String> sourceIds, Optional<String> application, Visibility visibility, UserInfos user);
 
 	void getParentInfos(final String childId, UserInfos user, final Handler<AsyncResult<JsonObject>> handler);
 }

--- a/workspace/src/main/java/org/entcore/workspace/service/WorkspaceService.java
+++ b/workspace/src/main/java/org/entcore/workspace/service/WorkspaceService.java
@@ -53,7 +53,7 @@ public interface WorkspaceService extends FolderManager {
 			this.visibility = visibility;
 		}
 
-		public String get() {
+		public String getCode() {
 			return this.visibility;
 		}
 

--- a/workspace/src/main/resources/jsonschema/transferDocuments.json
+++ b/workspace/src/main/resources/jsonschema/transferDocuments.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "application": { "type": "string"},
+        "visibility": { "type": "string"},
+        "ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+    },
+    "required": ["visibility", "ids"]
+}


### PR DESCRIPTION
# Description

Ce endpoint permet de transférer, en un seul appel, plusieurs documents de l'utilisateur 
* depuis le dossier "Mes documents" ou "Partagés avec moi" 
* vers le pseudo-dossier "Partagé dans mes applis" (visibility=protected) ou "Publics" (visibility=public)

Un tableau de documents est retourné, dans le même ordre que les ids spécifiés dans le corps de la requête. 
Tout document retourné à `null` signifie que son transfert a échoué, ou que le document demandé n'existaient pas.

En interne, si un document est transféré vers l'espace `protected` ou `public`, alors une copie des fichiers est effectuée, et l'original est conservé intact.
S'il passe de `protected` à `public` ou inversement, seule l'indexation en DB change. Les fichiers sont conservés.

Ce comportement imite le fonctionnement historique de la MediaLibrary, où tout document mis `protected` ou `public` était téléchargé par le client web, avant d'être ré-uploadé au bon endroit. On économise ainsi de la bande passante.

## Fixes

[WB-2679](https://edifice-community.atlassian.net/browse/WB-2679)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [X] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [X] workspace

## Tests

Tests manuels seulement.
J'ai testé les différentes combinaisons, avec point d'arrêt dans le débogueur puis déroulé pas à pas, afin de vérifier la justesse de l'algorithme implémenté.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley:

[WB-2679]: https://edifice-community.atlassian.net/browse/WB-2679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ