### PR TITLE
feat: #MOZO-161, send warning email & sms to old mobile phone number when it has been modified

### DIFF
--- a/auth/src/main/java/org/entcore/auth/services/impl/DefaultMfaService.java
+++ b/auth/src/main/java/org/entcore/auth/services/impl/DefaultMfaService.java
@@ -29,6 +29,7 @@ import static fr.wseduc.webutils.Utils.getOrElse;
 import static org.entcore.common.datavalidation.utils.DataStateUtils.*;
 
 import java.security.InvalidKeyException;
+import java.util.Map;
 
 
 public class DefaultMfaService implements MfaService {
@@ -219,7 +220,7 @@ public class DefaultMfaService implements MfaService {
         }
 
         @Override
-        public Future<String> sendWarningMessage(HttpServerRequest request, String target, JsonObject templateParams) {
+        public Future<String> sendWarningMessage(HttpServerRequest request, Map<String, String> targets, JsonObject templateParams) {
             return Future.succeededFuture();
         }
     }

--- a/auth/src/main/java/org/entcore/auth/services/impl/DefaultMfaService.java
+++ b/auth/src/main/java/org/entcore/auth/services/impl/DefaultMfaService.java
@@ -3,6 +3,7 @@ package org.entcore.auth.services.impl;
 import fr.wseduc.webutils.Server;
 import fr.wseduc.webutils.http.Renders;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.http.HttpServerRequest;
@@ -215,6 +216,11 @@ public class DefaultMfaService implements MfaService {
             // }
 
             return Future.failedFuture("not.implemented.yet");
+        }
+
+        @Override
+        public Future<String> sendWarningMessage(HttpServerRequest request, String target, JsonObject templateParams) {
+            return Future.succeededFuture();
         }
     }
 

--- a/common/src/main/java/org/entcore/common/datavalidation/DataValidationService.java
+++ b/common/src/main/java/org/entcore/common/datavalidation/DataValidationService.java
@@ -23,6 +23,8 @@ import io.vertx.core.Future;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonObject;
 
+import java.util.Map;
+
 public interface DataValidationService {
 
 	/**
@@ -71,11 +73,11 @@ public interface DataValidationService {
 	Future<String> sendValidationMessage(HttpServerRequest request, String target, JsonObject templateParams, String module);
 
 	/**
-	 * Send the warning message (email or sms or both).
+	 * Send the warning message (email and/or sms).
 	 * @param request required to translate things...
-	 * @param target address where to send
+	 * @param targets targets where to send (email and/or mobile)
 	 * @param templateParams email template data
 	 * @return the message ID
 	 */
-	Future<String> sendWarningMessage(HttpServerRequest request, String target, JsonObject templateParams);
+	Future<String> sendWarningMessage(HttpServerRequest request, Map<String, String> targets, JsonObject templateParams);
 }

--- a/common/src/main/java/org/entcore/common/datavalidation/DataValidationService.java
+++ b/common/src/main/java/org/entcore/common/datavalidation/DataValidationService.java
@@ -69,4 +69,13 @@ public interface DataValidationService {
 	 * @return the message ID
 	 */
 	Future<String> sendValidationMessage(HttpServerRequest request, String target, JsonObject templateParams, String module);
+
+	/**
+	 * Send the warning message (email or sms or both).
+	 * @param request required to translate things...
+	 * @param target address where to send
+	 * @param templateParams email template data
+	 * @return the message ID
+	 */
+	Future<String> sendWarningMessage(HttpServerRequest request, String target, JsonObject templateParams);
 }

--- a/common/src/main/java/org/entcore/common/datavalidation/EmailValidation.java
+++ b/common/src/main/java/org/entcore/common/datavalidation/EmailValidation.java
@@ -64,4 +64,18 @@ public class EmailValidation {
 			pendingEmailState
 		);
 	}
+
+	/**
+	 * Send a warning email to old address mail when it has been modified.
+	 * @param userInfos User infos
+	 * @param pendingEmailState with new email address
+	 * @return email ID
+	 */
+	static public Future<String> sendWarningEmail(final HttpServerRequest request, UserInfos userInfos, JsonObject pendingEmailState) {
+		return UserValidationFactory.getInstance().sendUpdateEmailWarning(
+				request,
+				userInfos,
+				pendingEmailState
+		);
+	}
 }

--- a/common/src/main/java/org/entcore/common/datavalidation/MobileValidation.java
+++ b/common/src/main/java/org/entcore/common/datavalidation/MobileValidation.java
@@ -65,4 +65,18 @@ public class MobileValidation {
 			pendingMobileState
 		);
 	}
+
+	/**
+	 * Send a warning email & SMS to the user when the mobile phone number has been modified.
+	 * @param userInfos User infos
+	 * @param pendingMobileState with new mobile phone number
+	 * @return mobile ID
+	 */
+	static public Future<String> sendWarning(final HttpServerRequest request, UserInfos userInfos, JsonObject pendingMobileState) {
+		return UserValidationFactory.getInstance().sendUpdateMobileWarning(
+				request,
+				userInfos,
+				pendingMobileState
+		);
+	}
 }

--- a/common/src/main/java/org/entcore/common/datavalidation/UserValidationService.java
+++ b/common/src/main/java/org/entcore/common/datavalidation/UserValidationService.java
@@ -127,6 +127,15 @@ public interface UserValidationService {
 	 */
 	Future<String> sendValidationSMS(HttpServerRequest request, UserInfos infos, JsonObject mobileState);
 
+
+	/**
+	 * Send a warning email to old address mail when it has been modified.
+	 * @param request required for EmailSender to translate things...
+	 * @param userInfos contains connected user information (first name, last name, email ...)
+	 * @param mobileState with the new mobile phone number
+	 * @return the email ID
+	 */
+	Future<String> sendUpdateMobileWarning(HttpServerRequest request, UserInfos userInfos, JsonObject mobileState);
 	
 	//////////////// Email-related methods ////////////////
 

--- a/common/src/main/java/org/entcore/common/datavalidation/UserValidationService.java
+++ b/common/src/main/java/org/entcore/common/datavalidation/UserValidationService.java
@@ -174,4 +174,13 @@ public interface UserValidationService {
 	 * @return the email ID
 	 */
 	Future<String> sendValidationEmail(HttpServerRequest request, UserInfos infos, JsonObject emailState);
+
+	/**
+	 * Send a warning email to old address mail when it has been modified.
+	 * @param request required for EmailSender to translate things...
+	 * @param userInfos contains connected user information (first name, last name, email ...)
+	 * @param emailState with the new email address
+	 * @return the email ID
+	 */
+	Future<String> sendUpdateEmailWarning(HttpServerRequest request, UserInfos userInfos, JsonObject emailState);
 }

--- a/common/src/main/java/org/entcore/common/datavalidation/impl/DefaultUserValidationService.java
+++ b/common/src/main/java/org/entcore/common/datavalidation/impl/DefaultUserValidationService.java
@@ -7,7 +7,6 @@ import fr.wseduc.webutils.email.EmailSender;
 import fr.wseduc.webutils.http.Renders;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.Message;
@@ -30,8 +29,8 @@ import org.entcore.common.user.UserUtils;
 import org.entcore.common.utils.Mfa;
 import org.entcore.common.utils.StringUtils;
 
-import java.io.StringReader;
-import java.io.Writer;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Map;
 
 import static fr.wseduc.webutils.Utils.getOrElse;
@@ -59,6 +58,11 @@ public class DefaultUserValidationService implements UserValidationService {
             final SmsSender sms = SmsSenderFactory.getInstance().newInstance( this, eventStore );
             return sms.sendUnique(request, mobile, "phone/mobileVerification.txt", templateParams, module);
         }
+
+        @Override
+        public Future<String> sendWarningMessage(HttpServerRequest request, String target, JsonObject templateParams) {
+            return Future.succeededFuture();
+        }
     }
 
     /** Inner service for the "email" field validation. */
@@ -75,43 +79,70 @@ public class DefaultUserValidationService implements UserValidationService {
         @Override
         public Future<String> sendValidationMessage( final HttpServerRequest request, String email, JsonObject templateParams, final String module) {
             Promise<String> promise = Promise.promise();
-            if( emailSender == null ) {
-                promise.complete(null);
-            } else if( StringUtils.isEmpty((email)) ) {
-                promise.fail("Invalid email address.");
-            } else if( templateParams==null || StringUtils.isEmpty(templateParams.getString("code")) ) {
+            if (templateParams == null || StringUtils.isEmpty(templateParams.getString("code"))) {
                 promise.fail("Invalid parameters.");
+            }
+
+            final String subject = formatEmailSubject(request,"email.validation.subject");
+            return sendEmail(request, email, subject, "email/emailValidationCode.html", templateParams);
+        }
+
+        @Override
+        public Future<String> sendWarningMessage(HttpServerRequest request, String email, JsonObject templateParams) {
+            final String subject = formatEmailSubject(request, "email.update.warning.subject");
+            return sendEmail(request, email, subject, "email/emailUpdateWarning.html", templateParams);
+        }
+
+        private Future<String> sendEmail(HttpServerRequest request, String to, String subject, String templateName, JsonObject templateParams) {
+            Promise<String> promise = Promise.promise();
+            if (emailSender == null) {
+                promise.complete(null);
+            } else if (StringUtils.isEmpty((to))) {
+                promise.fail("Invalid email address.");
             } else {
-                String code = templateParams.getString("code");
-                processEmailTemplate(request, templateParams, "email/emailValidationCode.html", false, processedTemplate -> {
-                    // Generate email subject
-                    final JsonObject timelineI18n = (requestThemeKV==null ? getThemeDefaults():requestThemeKV).getOrDefault( I18n.acceptLanguage(request).split(",")[0].split("-")[0], new JsonObject() );
-                    final String title = timelineI18n.getString("timeline.immediate.mail.subject.header", "") 
-                        + I18n.getInstance().translate("email.validation.subject", getHost(request), I18n.acceptLanguage(request), code);
-                    
-                    emailSender.sendEmail(request, email, null, null,
-                        title,
-                        processedTemplate,
-                        null,
-                        false,
-                        ar -> {
-                            if (ar.succeeded()) {
-                                Message<JsonObject> reply = ar.result();
-                                if ("ok".equals(reply.body().getString("status"))) {
-                                    Object r = reply.body().getValue("result");
-                                    promise.complete( "" );
+                processEmailTemplate(request, templateParams, templateName, false, processedTemplate -> {
+                    emailSender.sendEmail(
+                            request,
+                            to,
+                            null,
+                            null,
+                            subject,
+                            processedTemplate,
+                            null,
+                            false,
+                            ar -> {
+                                if (ar.succeeded()) {
+                                    Message<JsonObject> reply = ar.result();
+                                    if ("ok".equals(reply.body().getString("status"))) {
+                                        promise.complete("");
+                                    } else {
+                                        promise.fail(reply.body().getString("message", ""));
+                                    }
                                 } else {
-                                    promise.fail( reply.body().getString("message", "") );
+                                    promise.fail(ar.cause().getMessage());
                                 }
-                            } else {
-                                promise.fail(ar.cause().getMessage());
                             }
-                        }
                     );
                 });
             }
             return promise.future();
         }
+
+        /**
+         * Generate email subject by loading Timeline i18n to retrieve PF/Project name and add it to custom email subject.
+         * @param request to get host, language, ...
+         * @param i18nKey key for email subject
+         * @return subject
+         */
+        private String formatEmailSubject(HttpServerRequest request, String i18nKey) {
+            final JsonObject timelineI18n = (requestThemeKV == null ? getThemeDefaults() : requestThemeKV).getOrDefault(
+                    I18n.acceptLanguage(request).split(",")[0].split("-")[0],
+                    new JsonObject()
+            );
+            return timelineI18n.getString("timeline.immediate.mail.subject.header", "") +
+                    I18n.getInstance().translate(i18nKey, getHost(request), I18n.acceptLanguage(request));
+        }
+
     }
 
     //---------------------------------------------------------------
@@ -494,4 +525,19 @@ public class DefaultUserValidationService implements UserValidationService {
             return id;
         });
     }
+
+    @Override
+    public Future<String> sendUpdateEmailWarning(HttpServerRequest request, UserInfos userInfos, JsonObject emailState) {
+        JsonObject templateParams = new JsonObject()
+                .put("scheme", Renders.getScheme(request))
+                .put("host", Renders.getHost(request))
+                .put("firstName", userInfos.getFirstName())
+                .put("lastName", userInfos.getLastName())
+                .put("date", LocalDateTime.now().toEpochSecond(ZoneOffset.UTC) * 1000)
+                .put("newEmail", DataStateUtils.getValid(emailState));
+
+        return emailSvc.sendWarningMessage(request, userInfos.getEmail(), templateParams)
+                .map( id -> id);
+    }
+
 }

--- a/common/src/main/java/org/entcore/common/user/UserInfos.java
+++ b/common/src/main/java/org/entcore/common/user/UserInfos.java
@@ -296,6 +296,7 @@ public class UserInfos {
 	private List<Widget> widgets;
 	private Map<String, Object> otherProperties = new HashMap<>();
 	private String email;
+	private String mobile;
 
 	public Map<String, Child> getChildren() { return children; }
 
@@ -544,6 +545,14 @@ public class UserInfos {
 
 	public void setEmail(String email) {
 		this.email = email;
+	}
+
+	public String getMobile() {
+		return mobile;
+	}
+
+	public void setMobile(String mobile) {
+		this.mobile = mobile;
 	}
 
 	@JsonAnySetter

--- a/common/src/main/java/org/entcore/common/user/UserInfos.java
+++ b/common/src/main/java/org/entcore/common/user/UserInfos.java
@@ -295,6 +295,7 @@ public class UserInfos {
 	private Boolean federated;
 	private List<Widget> widgets;
 	private Map<String, Object> otherProperties = new HashMap<>();
+	private String email;
 
 	public Map<String, Child> getChildren() { return children; }
 
@@ -536,6 +537,14 @@ public class UserInfos {
 	public void setWidgets(List<Widget> widgets) {
 		this.widgets = widgets;
   }
+
+	public String getEmail() {
+		return email;
+	}
+
+	public void setEmail(String email) {
+		this.email = email;
+	}
 
 	@JsonAnySetter
 	public void setOtherProperty(String key, Object value) {

--- a/directory/src/main/java/org/entcore/directory/controllers/UserController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/UserController.java
@@ -994,22 +994,20 @@ public class UserController extends BaseController {
 	@MfaProtected()
 	public void putMobileState(final HttpServerRequest request) {
 		RequestUtils.bodyToJson(request, pathPrefix + "putMobileState", payload -> {
-			UserUtils.getUserInfos(eb, request, infos -> {
-				if (infos != null) {
-					// Initialize a new mobile phone number validation flow
-					MobileValidation.setPending(eb, infos.getUserId(), payload.getString("mobile"))
+			UserUtils
+					.getAuthenticatedUserInfos(eb, request)
+					.onSuccess(userInfos -> {
+						// Initialize a new mobile phone number validation flow
+						MobileValidation.setPending(eb, userInfos.getUserId(), payload.getString("mobile"))
 							.compose( pendingMobileState -> {
 								// Send the validation email to the user
-								return MobileValidation.sendSMS(eb, request, infos, pendingMobileState);
+								return MobileValidation.sendSMS(eb, request, userInfos, pendingMobileState);
 							})
 							.onSuccess(e -> ok(request))
 							.onFailure( e -> {
 								renderError( request, new JsonObject().put("error", e.getMessage()) );
 							});
-				} else {
-					notFound(request, "user.not.found");
-				}
-			});
+					});
 		});
 	}
 
@@ -1018,27 +1016,31 @@ public class UserController extends BaseController {
 	@MfaProtected()
 	public void postMobileState(final HttpServerRequest request) {
 		RequestUtils.bodyToJson(request, pathPrefix + "postMobileState", payload -> {
-			UserUtils.getUserInfos(eb, request, infos -> {
-				if (infos != null) {
-					// Try a validation code
-					final String userId = infos.getUserId();
-					MobileValidation.tryValidate(eb, UserUtils.getSessionIdOrTokenId(request).get(), userId, payload.getString("key"))
-							.onSuccess( mobileState -> {
-								// Mobile is validated and updated => session has evolved and must be recreated.
-								UserUtils.removeSessionAttribute(eb, userId, PERSON_ATTRIBUTE, e -> {
-									recreateSession(infos, userId, request, eb).onComplete(complete ->
-											renderJson( request, mobileState )
-									);
+			UserUtils
+					.getAuthenticatedUserInfos(eb, request)
+					.onSuccess(userInfos -> {
+						// Try a validation code
+						final String userId = userInfos.getUserId();
+						MobileValidation.tryValidate(eb, UserUtils.getSessionIdOrTokenId(request).get(), userId, payload.getString("key"))
+								.onSuccess( mobileState -> {
+									// Send the warning email & sms to the user
+									if (!StringUtils.isEmpty(userInfos.getMobile())) {
+										MobileValidation.sendWarning(request, userInfos, mobileState)
+												.onFailure(e -> log.error("Failed to send mobile update alert", e));
+									}
+
+									// Mobile is validated and updated => session has evolved and must be recreated.
+									UserUtils.removeSessionAttribute(eb, userId, PERSON_ATTRIBUTE, e -> {
+										recreateSession(userInfos, userId, request, eb).onComplete(complete ->
+												renderJson( request, mobileState )
+										);
+									});
+									CookieHelper.set("userbookVersion", System.currentTimeMillis()+"", request);
+								})
+								.onFailure( e -> {
+									renderError( request, new JsonObject().put("error", e.getMessage()) );
 								});
-								CookieHelper.set("userbookVersion", System.currentTimeMillis()+"", request);
-							})
-							.onFailure( e -> {
-								renderError( request, new JsonObject().put("error", e.getMessage()) );
-							});
-				} else {
-					notFound(request, "user.not.found");
-				}
-			});
+					});
 		});
 	}
 

--- a/directory/src/main/resources/i18n/fr.json
+++ b/directory/src/main/resources/i18n/fr.json
@@ -931,5 +931,11 @@
     "class.search.noresults.title": "C'est désert... Il y a quelqu'un ?",
     "class.search.noresults.description": "La recherche n'aboutit à aucun résultat.<br>Veuillez changer votre recherche.",
     "class.no.user.attached.title": "La classe est vide !",
-    "class.no.user.attached.description": "Il n'y a pas encore d'élèves ou d'ense rattachés à la classe.<br>Veuilez contacter votre administrateur si cela est une erreur.<br>Une fois configurée, vous trouverez ici le trombinoscope de la classe."
+    "class.no.user.attached.description": "Il n'y a pas encore d'élèves ou d'ense rattachés à la classe.<br>Veuilez contacter votre administrateur si cela est une erreur.<br>Une fois configurée, vous trouverez ici le trombinoscope de la classe.",
+    "email.update.warning.subject": "Modification de votre adresse mail",
+    "email.update.warning.hi": "Bonjour {{firstName}}",
+    "email.update.warning.intro": "L’adresse mail liée à votre compte a été modifiée. Vous ne recevrez plus de mails sur cette adresse mail.",
+    "email.update.warning.date": "Date de la modification: <b>{{#datetime}}{{date}}{{/datetime}}</b>",
+    "email.update.warning.new.email": "Nouvelle adresse mail : <b>{{newEmail}}</b>",
+    "email.update.warning.outro": "Si vous n’êtes pas à l’origine de cette action, nous vous conseillons de contacter votre administrateur local ou l'équipe de direction de votre établissement."
 }

--- a/directory/src/main/resources/i18n/fr.json
+++ b/directory/src/main/resources/i18n/fr.json
@@ -933,9 +933,16 @@
     "class.no.user.attached.title": "La classe est vide !",
     "class.no.user.attached.description": "Il n'y a pas encore d'élèves ou d'ense rattachés à la classe.<br>Veuilez contacter votre administrateur si cela est une erreur.<br>Une fois configurée, vous trouverez ici le trombinoscope de la classe.",
     "email.update.warning.subject": "Modification de votre adresse mail",
-    "email.update.warning.hi": "Bonjour {{firstName}}",
+    "email.update.warning.hi": "Bonjour",
     "email.update.warning.intro": "L’adresse mail liée à votre compte a été modifiée. Vous ne recevrez plus de mails sur cette adresse mail.",
-    "email.update.warning.date": "Date de la modification: <b>{{#datetime}}{{date}}{{/datetime}}</b>",
-    "email.update.warning.new.email": "Nouvelle adresse mail : <b>{{newEmail}}</b>",
-    "email.update.warning.outro": "Si vous n’êtes pas à l’origine de cette action, nous vous conseillons de contacter votre administrateur local ou l'équipe de direction de votre établissement."
+    "email.update.warning.date": "Date de la modification :",
+    "email.update.warning.new.email": "Nouvelle adresse mail :",
+    "email.update.warning.outro": "Si vous n’êtes pas à l’origine de cette action, nous vous conseillons de contacter votre administrateur local ou l'équipe de direction de votre établissement.",
+    "mobile.update.warning.subject": "Modification du numéro de téléphone",
+    "mobile.update.warning.hi": "Bonjour",
+    "mobile.update.warning.intro": "Le numéro de téléphone lié à votre compte a été modifié.",
+    "mobile.update.warning.date": "Date de la modification :",
+    "mobile.update.warning.old.phone.number": "Ancien numéro de téléphone :",
+    "mobile.update.warning.new.phone.number": "Nouveau numéro de téléphone :",
+    "mobile.update.warning.outro": "Si vous n’êtes pas à l’origine de cette action, nous vous conseillons de modifier votre mot de passe."
 }

--- a/directory/src/main/resources/view-src/email/emailUpdateWarning.html
+++ b/directory/src/main/resources/view-src/email/emailUpdateWarning.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+
+<head>
+    <meta name="viewport" content="width=device-width" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+
+    <style type="text/css">
+        body {
+            -webkit-font-smoothing: antialiased;
+            -webkit-text-size-adjust: none;
+            width: 100% !important;
+            height: 100%;
+            line-height: 1.6em;
+			font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif;
+			font-size: 14px; 
+			-webkit-font-smoothing: antialiased;
+			-webkit-text-size-adjust: none;
+			box-sizing: border-box;
+        }
+
+		header {
+			border-radius:8px 8px 0 0;
+			background:{{#theme}}timeline.mail.header.bgcolor{{/theme}};
+			height:74px;
+		}
+
+        header img {
+            max-width: 100%;
+            margin-top: 12px;
+        }
+
+        table {
+			width: 100%;
+			margin: 0;
+		}
+        table.main {
+            background: #f9f9f9;
+        }
+
+		tr {
+			margin: 0;
+		}
+
+		td {
+			margin: 0;
+			vertical-align: top;
+		}
+
+		body {
+			max-width:737px;
+			font-family:"Roboto", "Sans serif";
+			font-size:16px;
+			font-weight:400;
+			line-height:22px;
+			color:#4A4A4A;
+		}
+		img {
+			margin-left: 15px;
+		}
+
+		.update-info {
+			margin:1em;
+		}
+		.update-info ul {
+			padding-top:1em;
+			padding-bottom:1em;
+			display: block;
+			font-size:14px;
+			background:#E4F4FF;
+			border:1px solid #2A9CC8;
+			border-radius:4px;
+		}
+
+        @media only screen and (max-width: 640px) {
+            body {
+                padding: 0 !important;
+            }
+            h1 {
+                font-weight: 800 !important;
+                margin: 20px 0 5px !important;
+            }
+            h2 {
+                font-weight: 800 !important;
+                margin: 20px 0 5px !important;
+            }
+            h3 {
+                font-weight: 800 !important;
+                margin: 20px 0 5px !important;
+            }
+            h4 {
+                font-weight: 800 !important;
+                margin: 20px 0 5px !important;
+            }
+            h1 {
+                font-size: 22px !important;
+            }
+            h2 {
+                font-size: 18px !important;
+            }
+            h3 {
+                font-size: 16px !important;
+            }
+            .container {
+                padding: 0 !important;
+                width: 100% !important;
+            }
+            .content {
+                padding: 0 !important;
+            }
+            .content-wrap {
+                padding: 10px !important;
+            }
+            .invoice {
+                width: 100% !important;
+            }
+        }
+    </style>
+</head>
+
+<body itemscope itemtype="http://schema.org/EmailMessage"
+	  style="width: 100% !important; height: 100%; line-height: 1.6em; {{#theme}}timeline.mail.body.bg{{/theme}} margin: 0;"
+      bgcolor="{{#theme}}timeline.mail.body.bgcolor{{/theme}}">
+
+    <table class="body-wrap" style="{{#theme}}timeline.mail.body.bg{{/theme}}">
+        <tr>
+            <td style="vertical-align: top; margin: 0;" valign="top"></td>
+            <td class="container" width="600" style="vertical-align: top; display: block !important; max-width: 600px !important; clear: both !important; margin: 0 auto;"
+                valign="top">
+                <div class="content" style="max-width: 600px; display: block; margin: 0 auto; padding: 20px;">
+                    <table class="main" cellpadding="0" cellspacing="0" style="border-radius: 3px; {{#theme}}timeline.mail.main{{/theme}} {{#theme}}timeline.mail.main.border{{/theme}}"
+                        bgcolor=" {{#theme}}timeline.mail.maincolor{{/theme}}">
+                        <tr>
+                            <td class="alert alert-warning" style="font-size: 16px; {{#theme}}timeline.mail.text.color{{/theme}} font-weight: 500; text-align: left; border-radius: 3px 3px 0 0; {{#theme}}timeline.mail.header.bg{{/theme}} padding: 0;"
+                                align="left" bgcolor="{{#theme}}timeline.mail.header.bgcolor{{/theme}}" valign="top">
+								<header>
+								 	<img src="{{#theme}}timeline.mail.logo.src{{/theme}}" height="50" alt="logo"/>
+								</header>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="content-wrap" style="vertical-align: top; padding: 20px;" valign="top">
+                                <table cellpadding="0" cellspacing="0">
+                                    <tr style="box-sizing: border-box; font-size: 14px;">
+                                        <td class="content-block" style="{{#theme}}timeline.mail.main.text.color{{/theme}} vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+											{{#i18n}}email.update.warning.hi{{/i18n}},
+                                        </td>
+                                    </tr>
+                                    <tr style="box-sizing: border-box; font-size: 14px;">
+                                        <td class="content-block" style="{{#theme}}timeline.mail.main.text.color{{/theme}} vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+											{{#i18n}}email.update.warning.intro{{/i18n}}
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td class="content-block" style="{{#theme}}timeline.mail.main.text.color{{/theme}} vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+											<div class="update-info">
+                                                <ul>
+                                                    <li>{{#i18n}}email.update.warning.date{{/i18n}}</li>
+                                                    <li>{{#i18n}}email.update.warning.new.email{{/i18n}}</li>
+                                                </ul>
+											</div>
+										</td>
+                                    </tr>
+                                    <tr style="box-sizing: border-box; font-size: 14px;">
+                                        <td class="content-block" style="{{#theme}}timeline.mail.main.text.color{{/theme}} vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                                            {{#i18n}}email.update.warning.outro{{/i18n}}
+                                        </td>
+                                    </tr>
+                                </table>
+                            </td>
+                        </tr>
+                    </table>
+                    <div class="footer" style="width: 100%; clear: both; {{#theme}}timeline.mail.footer.color{{/theme}} margin: 0; padding: 20px 0;">
+                        <table width="100%" style="margin: 0;">
+                            <tr>
+                                <td class="aligncenter content-block" 
+									style="font-size: 12px; vertical-align: top; {{#theme}}timeline.mail.footer.color{{/theme}} margin: 0; padding: 0 0 20px;"
+                                    valign="top"
+                                >
+                                    {{#i18n}}email.signature{{/i18n}}
+                                </td>
+                            </tr>
+                        </table>
+                    </div>
+                </div>
+            </td>
+            <td style="vertical-align: top; margin: 0;" valign="top"></td>
+        </tr>
+    </table>
+</body>

--- a/directory/src/main/resources/view-src/email/mobileUpdateWarning.html
+++ b/directory/src/main/resources/view-src/email/mobileUpdateWarning.html
@@ -143,27 +143,28 @@
                                 <table cellpadding="0" cellspacing="0">
                                     <tr style="box-sizing: border-box; font-size: 14px;">
                                         <td class="content-block" style="{{#theme}}timeline.mail.main.text.color{{/theme}} vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-											{{#i18n}}email.update.warning.hi{{/i18n}} {{firstName}},
+											{{#i18n}}mobile.update.warning.hi{{/i18n}} {{firstName}},
                                         </td>
                                     </tr>
                                     <tr style="box-sizing: border-box; font-size: 14px;">
                                         <td class="content-block" style="{{#theme}}timeline.mail.main.text.color{{/theme}} vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-											{{#i18n}}email.update.warning.intro{{/i18n}}
+											{{#i18n}}mobile.update.warning.intro{{/i18n}}
                                         </td>
                                     </tr>
                                     <tr>
                                         <td class="content-block" style="{{#theme}}timeline.mail.main.text.color{{/theme}} vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
 											<div class="update-info">
                                                 <ul>
-                                                    <li>{{#i18n}}email.update.warning.date{{/i18n}} <b>{{#datetime}}{{date}}{{/datetime}}</b></li>
-                                                    <li>{{#i18n}}email.update.warning.new.email{{/i18n}} <b>{{newEmail}}</b></li>
+                                                    <li>{{#i18n}}mobile.update.warning.date{{/i18n}} <b>{{#datetime}}{{date}}{{/datetime}}</b></li>
+                                                    <li>{{#i18n}}mobile.update.warning.old.phone.number{{/i18n}} <b>{{oldPhoneNumber}}</b></li>
+                                                    <li>{{#i18n}}mobile.update.warning.new.phone.number{{/i18n}} <b>{{newPhoneNumber}}</b></li>
                                                 </ul>
 											</div>
 										</td>
                                     </tr>
                                     <tr style="box-sizing: border-box; font-size: 14px;">
                                         <td class="content-block" style="{{#theme}}timeline.mail.main.text.color{{/theme}} vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-                                            {{#i18n}}email.update.warning.outro{{/i18n}}
+                                            {{#i18n}}mobile.update.warning.outro{{/i18n}}
                                         </td>
                                     </tr>
                                 </table>

--- a/directory/src/main/resources/view-src/phone/mobileUpdateWarning.txt
+++ b/directory/src/main/resources/view-src/phone/mobileUpdateWarning.txt
@@ -1,0 +1,5 @@
+{{#i18n}}mobile.update.warning.hi{{/i18n}},
+
+{{#i18n}}mobile.update.warning.intro{{/i18n}} {{#i18n}}mobile.update.warning.outro{{/i18n}}
+
+{{#i18n}}email.signature{{/i18n}}

--- a/session/src/main/java/org/entcore/session/AuthManager.java
+++ b/session/src/main/java/org/entcore/session/AuthManager.java
@@ -836,7 +836,7 @@ public class AuthManager extends BusModBase implements Handler<Message<JsonObjec
 				"OPTIONAL MATCH n-[rf:HAS_FUNCTION]->(f:Function) " +
 				"OPTIONAL MATCH n<-[:RELATED]-(child:User) " +
 				"RETURN distinct " +
-				"n.classes as classNames, n.level as level, n.login as login, COLLECT(distinct [c.id, c.name]) as classes, " +
+				"n.classes as classNames, n.level as level, n.email as email, n.login as login, COLLECT(distinct [c.id, c.name]) as classes, " +
 				"n.lastName as lastName, n.firstName as firstName, n.externalId as externalId, n.federated as federated, " +
 				"n.birthDate as birthDate, n.changePw as forceChangePassword, COALESCE(n.needRevalidateTerms, FALSE) as needRevalidateTerms,HAS(n.deleteDate) as deletePending, " +
 				"n.displayName as username, HEAD(n.profiles) as type, " +

--- a/session/src/main/java/org/entcore/session/AuthManager.java
+++ b/session/src/main/java/org/entcore/session/AuthManager.java
@@ -836,7 +836,7 @@ public class AuthManager extends BusModBase implements Handler<Message<JsonObjec
 				"OPTIONAL MATCH n-[rf:HAS_FUNCTION]->(f:Function) " +
 				"OPTIONAL MATCH n<-[:RELATED]-(child:User) " +
 				"RETURN distinct " +
-				"n.classes as classNames, n.level as level, n.email as email, n.login as login, COLLECT(distinct [c.id, c.name]) as classes, " +
+				"n.classes as classNames, n.level as level, n.email as email, n.mobile as mobile, n.login as login, COLLECT(distinct [c.id, c.name]) as classes, " +
 				"n.lastName as lastName, n.firstName as firstName, n.externalId as externalId, n.federated as federated, " +
 				"n.birthDate as birthDate, n.changePw as forceChangePassword, COALESCE(n.needRevalidateTerms, FALSE) as needRevalidateTerms,HAS(n.deleteDate) as deletePending, " +
 				"n.displayName as username, HEAD(n.profiles) as type, " +


### PR DESCRIPTION
# Description

If the user's mobile phone number has been modified by any means, an email must be sent and an SMS to their old mobile phone number.

## Fixes

https://edifice-community.atlassian.net/browse/MOZO-161

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [x] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [x] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [x] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Se connecter avec un compte
2. Aller sur la page "Mon compte"
3. Modifier le numéro de téléphone mobile

=> Après validation du code et confirmation, l'utilisateur doit recevoir un mail d'alerte ainsi qu'un sms sur son ancien numéro lui informant que le numéro de téléphone a été modifié.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: