### PR TITLE
[EDIFICE] Récupération des tokens Bearer et OAuth lorsque le header Authorization contient plusieurs valeurs

### DIFF
--- a/common/src/main/java/org/entcore/common/http/filter/AppOAuthResourceProvider.java
+++ b/common/src/main/java/org/entcore/common/http/filter/AppOAuthResourceProvider.java
@@ -200,7 +200,7 @@ public class AppOAuthResourceProvider extends DefaultOAuthResourceProvider {
 	}
 
 
-	private static final Pattern REGEXP_AUTHORIZATION = Pattern.compile("^\\s*(OAuth|Bearer)\\s+([^\\s\\,]*)");
+	private static final Pattern REGEXP_AUTHORIZATION = Pattern.compile("^\\s*(?:.+,\\s*)?(OAuth|Bearer)\\s+([^\\s\\,]*)");
 
 	public static Optional<String> getTokenId(HttpServerRequest request)
 	{
@@ -216,7 +216,7 @@ public class AppOAuthResourceProvider extends DefaultOAuthResourceProvider {
 	public static Optional<String> getTokenHeader(final HttpServerRequest request) {
 		//get from header
 		final String header = request.getHeader("Authorization");
-		if (header != null && Pattern.matches("^\\s*(OAuth|Bearer)(.*)$", header)) {
+		if (header != null && Pattern.matches("^\\s*(?:.+,\\s*)?(OAuth|Bearer)(.*)$", header)) {
 			final Matcher matcher = REGEXP_AUTHORIZATION.matcher(header);
 			if (!matcher.find()) {
 				return Optional.empty();

--- a/common/src/test/java/org/entcore/common/http/filter/AppOAuthResourceProviderTest.java
+++ b/common/src/test/java/org/entcore/common/http/filter/AppOAuthResourceProviderTest.java
@@ -1,0 +1,272 @@
+package org.entcore.common.http.filter;
+
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.*;
+import io.vertx.core.net.NetSocket;
+import io.vertx.core.net.SocketAddress;
+import org.junit.Test;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import javax.security.cert.X509Certificate;
+import java.util.Map;
+
+import static org.entcore.common.http.filter.AppOAuthResourceProvider.getTokenHeader;
+import static org.junit.Assert.*;
+
+public class AppOAuthResourceProviderTest {
+
+  @Test
+  public void testGetTokenHeader() {
+    assertFalse(
+      "We should not get a token header when we have no authorization header",
+      getTokenHeader(new DummyRequest()).isPresent());
+    assertFalse(
+      "We should not get a token header when we have an authorization method which is no OAuth or Bearer",
+      getTokenHeader(new DummyRequest("Basic basic-token")).isPresent());
+    assertEquals(
+      "We should get a token header when we have an authorization method Bearer alone",
+      "token",
+      getTokenHeader(new DummyRequest("Bearer token")).get());
+    assertEquals(
+      "We should get a token header when we have an authorization method Bearer with another method",
+      "token",
+      getTokenHeader(new DummyRequest("Basic basic, Bearer token")).get());
+    assertEquals(
+      "We should get a token header when we have an authorization method Bearer with another method, no matter their order",
+      "token",
+      getTokenHeader(new DummyRequest("Bearer token, Basic basic")).get());
+    assertEquals(
+      "We should get a token header when we have an authorization method OAuth with another method",
+      "token",
+      getTokenHeader(new DummyRequest("Basic basic, OAuth token")).get());
+    assertEquals(
+      "We should get a token header when we have an authorization method OAuth with another method, no matter their order",
+      "token",
+      getTokenHeader(new DummyRequest("OAuth token, Basic basic")).get());
+    assertEquals(
+      "We should get a token header when we have an authorization method OAuth alone",
+      "token",
+      getTokenHeader(new DummyRequest("OAuth token")).get());
+  }
+
+  private static class DummyRequest implements HttpServerRequest {
+    private final MultiMap headers;
+
+    private DummyRequest(String auth) {
+      this.headers = MultiMap.caseInsensitiveMultiMap();
+      this.headers.add("Authorization", auth);
+    }
+
+    private DummyRequest() {
+      this.headers = MultiMap.caseInsensitiveMultiMap();
+    }
+
+    @Override
+    public String absoluteURI() {
+      throw new UnsupportedOperationException("Unimplemented method 'absoluteURI'");
+    }
+
+    @Override
+    public long bytesRead() {
+      throw new UnsupportedOperationException("Unimplemented method 'bytesRead'");
+    }
+
+    @Override
+    public HttpConnection connection() {
+      throw new UnsupportedOperationException("Unimplemented method 'connection'");
+    }
+
+    @Override
+    public int cookieCount() {
+      throw new UnsupportedOperationException("Unimplemented method 'cookieCount'");
+    }
+
+    @Override
+    public Map<String, Cookie> cookieMap() {
+      throw new UnsupportedOperationException("Unimplemented method 'cookieMap'");
+    }
+
+    @Override
+    public HttpServerRequest customFrameHandler(Handler<HttpFrame> arg0) {
+      throw new UnsupportedOperationException("Unimplemented method 'customFrameHandler'");
+    }
+
+    @Override
+    public HttpServerRequest endHandler(Handler<Void> arg0) {
+      throw new UnsupportedOperationException("Unimplemented method 'endHandler'");
+    }
+
+    @Override
+    public HttpServerRequest exceptionHandler(Handler<Throwable> arg0) {
+      throw new UnsupportedOperationException("Unimplemented method 'exceptionHandler'");
+    }
+
+    @Override
+    public HttpServerRequest fetch(long arg0) {
+      throw new UnsupportedOperationException("Unimplemented method 'fetch'");
+    }
+
+    @Override
+    public MultiMap formAttributes() {
+      throw new UnsupportedOperationException("Unimplemented method 'formAttributes'");
+    }
+
+    @Override
+    public Cookie getCookie(String arg0) {
+      throw new UnsupportedOperationException("Unimplemented method 'getCookie'");
+    }
+
+    @Override
+    public String getFormAttribute(String arg0) {
+      throw new UnsupportedOperationException("Unimplemented method 'getFormAttribute'");
+    }
+
+    @Override
+    public String getHeader(String arg0) {
+      return this.headers.get(arg0);
+    }
+
+    @Override
+    public String getHeader(CharSequence arg0) {
+      return this.headers.get(arg0);
+    }
+
+    @Override
+    public String getParam(String arg0) {
+      throw new UnsupportedOperationException("Unimplemented method 'getParam'");
+    }
+
+    @Override
+    public HttpServerRequest handler(Handler<Buffer> arg0) {
+      throw new UnsupportedOperationException("Unimplemented method 'handler'");
+    }
+
+    @Override
+    public MultiMap headers() {
+      return this.headers;
+    }
+
+    @Override
+    public String host() {
+      throw new UnsupportedOperationException("Unimplemented method 'host'");
+    }
+
+    @Override
+    public boolean isEnded() {
+      throw new UnsupportedOperationException("Unimplemented method 'isEnded'");
+    }
+
+    @Override
+    public boolean isExpectMultipart() {
+      throw new UnsupportedOperationException("Unimplemented method 'isExpectMultipart'");
+    }
+
+    @Override
+    public boolean isSSL() {
+      throw new UnsupportedOperationException("Unimplemented method 'isSSL'");
+    }
+
+    @Override
+    public SocketAddress localAddress() {
+      throw new UnsupportedOperationException("Unimplemented method 'localAddress'");
+    }
+
+    @Override
+    public HttpMethod method() {
+      throw new UnsupportedOperationException("Unimplemented method 'method'");
+    }
+
+    @Override
+    public NetSocket netSocket() {
+      throw new UnsupportedOperationException("Unimplemented method 'netSocket'");
+    }
+
+    @Override
+    public MultiMap params() {
+      throw new UnsupportedOperationException("Unimplemented method 'params'");
+    }
+
+    @Override
+    public String path() {
+      throw new UnsupportedOperationException("Unimplemented method 'path'");
+    }
+
+    @Override
+    public HttpServerRequest pause() {
+      throw new UnsupportedOperationException("Unimplemented method 'pause'");
+    }
+
+    @Override
+    public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
+      throw new UnsupportedOperationException("Unimplemented method 'peerCertificateChain'");
+    }
+
+    @Override
+    public String query() {
+      throw new UnsupportedOperationException("Unimplemented method 'query'");
+    }
+
+    @Override
+    public String rawMethod() {
+      throw new UnsupportedOperationException("Unimplemented method 'rawMethod'");
+    }
+
+    @Override
+    public SocketAddress remoteAddress() {
+      throw new UnsupportedOperationException("Unimplemented method 'remoteAddress'");
+    }
+
+    @Override
+    public HttpServerResponse response() {
+      throw new UnsupportedOperationException("Unimplemented method 'response'");
+    }
+
+    @Override
+    public HttpServerRequest resume() {
+      throw new UnsupportedOperationException("Unimplemented method 'resume'");
+    }
+
+    @Override
+    public String scheme() {
+      throw new UnsupportedOperationException("Unimplemented method 'scheme'");
+    }
+
+    @Override
+    public HttpServerRequest setExpectMultipart(boolean arg0) {
+      throw new UnsupportedOperationException("Unimplemented method 'setExpectMultipart'");
+    }
+
+    @Override
+    public SSLSession sslSession() {
+      throw new UnsupportedOperationException("Unimplemented method 'sslSession'");
+    }
+
+    @Override
+    public HttpServerRequest streamPriorityHandler(Handler<StreamPriority> arg0) {
+      throw new UnsupportedOperationException("Unimplemented method 'streamPriorityHandler'");
+    }
+
+    @Override
+    public ServerWebSocket upgrade() {
+      throw new UnsupportedOperationException("Unimplemented method 'upgrade'");
+    }
+
+    @Override
+    public HttpServerRequest uploadHandler(Handler<HttpServerFileUpload> arg0) {
+      throw new UnsupportedOperationException("Unimplemented method 'uploadHandler'");
+    }
+
+    @Override
+    public String uri() {
+      throw new UnsupportedOperationException("Unimplemented method 'uri'");
+    }
+
+    @Override
+    public HttpVersion version() {
+      throw new UnsupportedOperationException("Unimplemented method 'version'");
+    }
+  }
+}


### PR DESCRIPTION
# Description

À l'heure actuelle, la récupération de la valeur d'un jwt ou d'un access token dans le paramètre Authorization respecte la norme du W3C et ne s'attend qu'à une seule valeur. Par conséquent, lorsque node-pdf-generator envoie dans Authorization plusieurs valeurs séparées par des virgules, il ne nous ait pas possible de récupérer la valeur du jwt.
Le but de cette PR estd e supporter plusieurs valeurs dans le champ Authorization.

## Fixes

WB-2709

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Test ajouté dans les TUs.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: