### PR TITLE
fix: WB-2993, endpoint already protected by DirectoryResourcesProvider

### DIFF
--- a/directory/src/main/java/org/entcore/directory/controllers/StructureController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/StructureController.java
@@ -157,7 +157,6 @@ public class StructureController extends BaseController {
 
 	@Get("/structure/admin/list")
 	@SecuredAction(value = "", type = ActionType.RESOURCE)
-	@MfaProtected()
 	public void listAdmin(final HttpServerRequest request) {
 		UserUtils.getUserInfos(eb, request, new Handler<UserInfos>() {
 			@Override


### PR DESCRIPTION
# Description

Endpoint being protected by DirectoryResourcesProvider

## Fixes

https://edifice-community.atlassian.net/browse/WB-2993

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [x] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Testé directement sur recette-ode-1

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: