### PR TITLE
[EDIFICE] Send back original image if thumbnail not yet created

### DIFF
--- a/common/src/main/java/org/entcore/common/folders/impl/FolderManagerMongoImpl.java
+++ b/common/src/main/java/org/entcore/common/folders/impl/FolderManagerMongoImpl.java
@@ -1133,8 +1133,7 @@ public class FolderManagerMongoImpl implements FolderManager {
 					@Override
 					public void handle(AsyncResult<Message<JsonObject>> result)
 					{
-						if(result.succeeded() ==  true)
-						{
+						if(result.succeeded()) {
 							Message<JsonObject> event = result.result();
 							JsonObject thumbnails = event.body().getJsonObject("outputs");
 
@@ -1145,7 +1144,7 @@ public class FolderManagerMongoImpl implements FolderManager {
 							}
 						}
 
-						future.fail(new RuntimeException("Failed to send a request to the image resizer"));
+						future.fail(new RuntimeException("Failed to send a request to the image resizer", result.cause()));
 						handler.handle(future);
 					}
 				});

--- a/common/src/main/java/org/entcore/common/storage/impl/FileStorage.java
+++ b/common/src/main/java/org/entcore/common/storage/impl/FileStorage.java
@@ -588,7 +588,11 @@ public class FileStorage implements Storage {
 					String name = FileUtils.getNameWithExtension(downloadName, metadata);
 					resp.putHeader("Content-Disposition", "attachment; filename=\"" + name + "\"");
 				}
-				ETag.addHeader(resp, id);
+				if(metadata.containsKey("ETag")) {
+					ETag.addHeader(resp, metadata.getString("ETag"));
+				} else {
+					ETag.addHeader(resp, id);
+				}
 				if (metadata != null && metadata.getString("content-type") != null) {
 					resp.putHeader("Content-Type", metadata.getString("content-type"));
 				}


### PR DESCRIPTION
# Description

Afin d'éviter d'avoir une dépendance sur la création de miniatures, on renvoie désormais l'image original lorsque la miniature demandée n'existe pas encore (mais on lance bien la création de la mnitiature en parallèle).

## Fixes

WB-3046

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace


# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: