### PR TITLE
fix(common): #WB-3055, FolderManager.copyAllNoFail should not throw a…

### DIFF
--- a/common/src/main/java/org/entcore/common/folders/impl/FolderManagerMongoImpl.java
+++ b/common/src/main/java/org/entcore/common/folders/impl/FolderManagerMongoImpl.java
@@ -345,18 +345,7 @@ public class FolderManagerMongoImpl implements FolderManager {
 				// merge shared after reset shared
 				InheritShareComputer.mergeShared(Optional.empty(), copy, true);
 				// copy file from storage
-				StorageHelper.replaceAll(copy, copiedFilesMap);
-
-				// Any fileId not copied must be removed from the new doc
-				final List<String> toRemove = new ArrayList<String>();
-				for( String fileId : fileIds) {
-					if(!copiedFilesMap.containsKey(fileId)) {
-						toRemove.add(fileId);
-					}
-				}
-				if( toRemove.size() > 0 ) {
-					StorageHelper.removeAll(copy, toRemove);
-				}
+				StorageHelper.replaceAll(copy, copiedFilesMap, true);
 
 				return Optional.of(copy);
 			});


### PR DESCRIPTION
…n exception when a thumbnail file is missing

# Description

FolderManager exposes a `copyAllNoFail` method, which is throwing an exception
while copying a document with a thumbnail, but without the physical file available in the file system of the OS.

Now, it simply skips the unavailable thumbnail, without failing.

## Fixes

[Ticket WB-3055](https://edifice-community.atlassian.net/browse/WB-3055)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [X] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

None

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] NOT All done ! :smiley: but i'm in a hurry