### PR TITLE
fix(app-registry): #WB2-1747, handle Content Too Large error in Library publishing

### DIFF
--- a/app-registry/src/main/java/org/entcore/registry/controllers/LibraryController.java
+++ b/app-registry/src/main/java/org/entcore/registry/controllers/LibraryController.java
@@ -79,8 +79,15 @@ public class LibraryController extends BaseController {
                     renderError(request, res.result());
                 }
             } else {
-                final JsonObject body = new JsonObject().put("success", false).put("reason", "unknown").put("message", res.cause().getMessage());
-                renderError(request, body);
+                final JsonObject resultJson = res.result();
+                final String message = resultJson.getString("message", "");
+                if (message.equals(DefaultLibraryService.MESSAGE.CONTENT_TOO_LARGE.name())) {
+                    renderError(request, resultJson, 413, message);
+                } else {
+                    final JsonObject body = new JsonObject().put("success", false).put("reason", "unknown").put("message", res.cause().getMessage());
+                    renderError(request, body);
+                    log.error("An unknown error occurred while calling the library publish service : \nResponse : " + res.result().encode(), res.cause());
+                }
             }
         });
     }

--- a/app-registry/src/main/java/org/entcore/registry/services/impl/DefaultLibraryService.java
+++ b/app-registry/src/main/java/org/entcore/registry/services/impl/DefaultLibraryService.java
@@ -27,11 +27,9 @@ import java.util.Optional;
 import java.util.UUID;
 
 
-enum REASON {BAD_CONFIGURATION, LIBRARY, OK}
-
-enum MESSAGE {API_URL_NOT_SET, DISABLED, WRONG_TOKEN, LIBRARY_KO, OK}
-
 public class DefaultLibraryService implements LibraryService {
+    public enum REASON {BAD_CONFIGURATION, LIBRARY, OK};
+    public enum MESSAGE {API_URL_NOT_SET, DISABLED, WRONG_TOKEN, LIBRARY_KO, CONTENT_TOO_LARGE, OK};
     private static final String RESSOURCE_ENDPOINT = "api/documents";
     private static final String CONFIG_LIBRARY_ENABLED = "library-enabled";
     private static final String CONFIG_LIBRARY_API_URL = "library-api-url";
@@ -155,6 +153,8 @@ public class DefaultLibraryService implements LibraryService {
                     } else {
                         if (response.statusCode() == 401) {
                             future.complete(generateJsonResponse(false, REASON.LIBRARY, MESSAGE.WRONG_TOKEN));
+                        } else if (response.statusCode() == 413) {
+                            future.complete(generateJsonResponse(false, REASON.LIBRARY, MESSAGE.CONTENT_TOO_LARGE));
                         } else {
                             future.complete(generateJsonResponse(false, REASON.LIBRARY, MESSAGE.LIBRARY_KO));
                         }

--- a/portal/src/main/resources/i18n/fr.json
+++ b/portal/src/main/resources/i18n/fr.json
@@ -83,6 +83,7 @@
   "bpr.form.publication.licence.text.4": "Les billets actuellement en brouillon et les billets ajoutés après la publication du Blog dans la Bibliothèque ne seront pas visibles.",
   "bpr.form.publication.response.error.content": "Veuillez réessayer et contacter l'équipe Support si le problème persiste.",
   "bpr.form.publication.response.error.title": "Oups, quelque chose s'est mal passé !",
+  "bpr.form.publication.response.error.content_too_large": "Le contenu est trop gros pour être publié sur la Bibliothèque (limite: 80 Mo). Essayez de réduire votre contenu avant de publier de nouveau.",
   "bpr.form.publication.response.empty.title": "Veuillez renseigner un titre sans espaces",
   "bpr.form.publication.response.empty.description": "Veuillez renseigner une description sans espaces",
   "bpr.form.publication.response.success.button": "Voir dans la Bibliothèque",


### PR DESCRIPTION
# Description

Render HTTP 413 error (Content Too Large) when Library backend returns that error to display a specific error message to the user.

Related to https://github.com/edificeio/edifice-ui/pull/194

## Fixes

https://edifice-community.atlassian.net/browse/WB2-1747

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [X] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley: