### PR TITLE
feat: #WB2-1733, move a resource to the right folder after duplicating it

### DIFF
--- a/common/src/main/java/org/entcore/common/explorer/ExplorerMessage.java
+++ b/common/src/main/java/org/entcore/common/explorer/ExplorerMessage.java
@@ -10,12 +10,14 @@ import java.util.stream.Collectors;
 
 public class ExplorerMessage {
 
-    public enum ExplorerContentType{
+
+  public enum ExplorerContentType{
         Text, Html, Pdf
     }
     public enum ExplorerAction{
         Upsert(ExplorerPriority.High),
         Delete(ExplorerPriority.High),
+        Move(ExplorerPriority.Medium),
         Audience(ExplorerPriority.Low);
         private final ExplorerPriority priority;
         ExplorerAction(final ExplorerPriority i){
@@ -83,6 +85,19 @@ public class ExplorerMessage {
         builder.withType(application, resourceType, entityType);
         return builder;
     }
+
+  public static ExplorerMessage move(final IdAndVersion id, final Long folderId,
+                                     final String application, final String resourceType,
+                                     final String entityType,
+                                     final UserInfos user) {
+    final ExplorerMessage builder = new ExplorerMessage(id.getId(), ExplorerAction.Move, false);
+    builder.withVersion(id.getVersion());
+    builder.withType(application, resourceType, entityType);
+    builder.withParentId(Optional.ofNullable(folderId));
+    builder.message.put("updaterId", user.getUserId());
+    builder.message.put("updaterName", user.getUsername());
+    return builder;
+  }
 
     public static ExplorerMessage delete(final IdAndVersion id, final UserInfos user, final boolean forSearch) {
         final ExplorerMessage builder = new ExplorerMessage(id.getId(), ExplorerAction.Delete, forSearch);

--- a/common/src/main/java/org/entcore/common/explorer/ResourceDuplicatedMessage.java
+++ b/common/src/main/java/org/entcore/common/explorer/ResourceDuplicatedMessage.java
@@ -1,0 +1,33 @@
+package org.entcore.common.explorer;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ResourceDuplicatedMessage {
+  private final String application;
+  private final String originalResourceId;
+  private final String duplicatedResourceId;
+
+  @JsonCreator
+  public ResourceDuplicatedMessage(@JsonProperty("application") final String application,
+                                   @JsonProperty("originalResourceId") final String originalResourceId,
+                                   @JsonProperty("duplicatedResourceId") final String duplicatedResourceId) {
+    this.application = application;
+    this.originalResourceId = originalResourceId;
+    this.duplicatedResourceId = duplicatedResourceId;
+  }
+
+  public String getOriginalResourceId() {
+    return originalResourceId;
+  }
+
+  public String getDuplicatedResourceId() {
+    return duplicatedResourceId;
+  }
+
+  public String getApplication() {
+    return application;
+  }
+}

--- a/common/src/main/java/org/entcore/common/explorer/impl/ExplorerResourceDetails.java
+++ b/common/src/main/java/org/entcore/common/explorer/impl/ExplorerResourceDetails.java
@@ -1,0 +1,54 @@
+package org.entcore.common.explorer.impl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ExplorerResourceDetails {
+  private final long id;
+  private final String resourceId;
+  private final String application;
+  private final String resourceType;
+  private final String entityType;
+  private final Long parentId;
+
+  @JsonCreator
+  public ExplorerResourceDetails(@JsonProperty("id") final long id,
+                                 @JsonProperty("resourceId") final String resourceId,
+                                 @JsonProperty("application") final String application,
+                                 @JsonProperty("resourceType") final String resourceType,
+                                 @JsonProperty("entityType") final String entityType,
+                                 @JsonProperty("parentId") final Long parentId) {
+    this.id = id;
+    this.resourceId = resourceId;
+    this.application = application;
+    this.resourceType = resourceType;
+    this.entityType = entityType;
+    this.parentId = parentId;
+  }
+
+  public long getId() {
+    return id;
+  }
+
+  public String getResourceId() {
+    return resourceId;
+  }
+
+  public String getApplication() {
+    return application;
+  }
+
+  public String getResourceType() {
+    return resourceType;
+  }
+
+  public String getEntityType() {
+    return entityType;
+  }
+
+  public Long getParentId() {
+    return parentId;
+  }
+}

--- a/common/src/main/java/org/entcore/common/explorer/impl/ExplorerResourceDetailsQuery.java
+++ b/common/src/main/java/org/entcore/common/explorer/impl/ExplorerResourceDetailsQuery.java
@@ -1,0 +1,32 @@
+package org.entcore.common.explorer.impl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ExplorerResourceDetailsQuery {
+  private final String resourceId;
+  private final String application;
+  private final String userId;
+  @JsonCreator
+  public ExplorerResourceDetailsQuery(@JsonProperty("resourceId") final String resourceId,
+                                      @JsonProperty("application") final String application,
+                                      @JsonProperty("userId") final String userId) {
+    this.resourceId = resourceId;
+    this.application = application;
+    this.userId = userId;
+  }
+
+  public String getResourceId() {
+    return resourceId;
+  }
+
+  public String getApplication() {
+    return application;
+  }
+
+  public String getUserId() {
+    return userId;
+  }
+}


### PR DESCRIPTION
# Description

Après la duplication d'une ressource, nous générons désormais un message Explorer afin de déplacer la ressource nouvellement créée dans le bon dossier.

## Fixes

WB2-1733

## Type of change

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [x] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Créer une ressource dans un dossier
2. Dupliquer cette ressource
3. Raffraîchir la page
4. Constater que cette ressource n'est pas à la racine
5. Se déplacer dans le dossier cible
6. Constater que la ressource dupliquée est bien dans le dossier


# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: