### PR TITLE
fix: checking metadata nullity for archive export

### DIFF
--- a/common/src/main/java/org/entcore/common/storage/impl/FileStorage.java
+++ b/common/src/main/java/org/entcore/common/storage/impl/FileStorage.java
@@ -588,7 +588,7 @@ public class FileStorage implements Storage {
 					String name = FileUtils.getNameWithExtension(downloadName, metadata);
 					resp.putHeader("Content-Disposition", "attachment; filename=\"" + name + "\"");
 				}
-				if(metadata.containsKey("ETag")) {
+				if(metadata != null && metadata.containsKey("ETag")) {
 					ETag.addHeader(resp, metadata.getString("ETag"));
 				} else {
 					ETag.addHeader(resp, id);


### PR DESCRIPTION
# Description

Fixing regression on file storage with nullity check on metadata.
It is necessary when sendFile() is called from ArchiveController, to export an archive.

## Fixes

No dedicated ticket : discovered when trying to run integration tests, it made one archive scenario fail.

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Running integration tests

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: