### PR TITLE
[EDIFICE] Do not backup users when transitionning

### DIFF
--- a/feeder/src/main/java/org/entcore/feeder/dictionary/structures/Structure.java
+++ b/feeder/src/main/java/org/entcore/feeder/dictionary/structures/Structure.java
@@ -371,7 +371,6 @@ public class Structure {
 							if ("ok".equals(event.body().getString("status"))) {
 								if (!onlyRemoveShare) {
 									for (Object u : res.getJsonArray("users")) {
-										User.backupRelationship(u.toString(), false, tx);
 										User.transition(u.toString(), tx);
 									}
 									transitionClassGroup();


### PR DESCRIPTION
# Description

Ne pas créer de noeud de backup pour les utilisateurs lors de la transition d'année. Seuls les mécanismes de suppression, pré-suppression et fusion par clef devraient générer des noeuds de Backup.

## Fixes

WB-3274

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [x] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: