### PR TITLE
[EDIFICE] send back a 409 error code if we try to create a function that already exists

### DIFF
--- a/common/src/main/java/org/entcore/common/user/position/impl/DefaultUserPositionService.java
+++ b/common/src/main/java/org/entcore/common/user/position/impl/DefaultUserPositionService.java
@@ -124,7 +124,7 @@ public class DefaultUserPositionService implements UserPositionService {
 			} else {
 				getPositionByNameInStructure(positionName, structureId, adminStructureIds).onSuccess(userPosition -> {
 					if (userPosition.isPresent()) {
-						promise.complete(userPosition.get());
+						promise.fail("position.already.exists:"+userPosition.get().getId());
 					} else {
 						final JsonArray adminStructureArray = new JsonArray();
 						adminStructureIds.forEach(adminStructureArray::add);


### PR DESCRIPTION

# Description

Lors d'une tentative de création de fonction existante, on renvoie désormais une erreur 409 avec l'id de la position existante dans le body.

## Fixes

WB-3301

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [x] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests
Ajout d'un TI dans crud.js

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: