### PR TITLE
feat(admin): #WB-2131, during CAS type creation, disable Confirm butt…

### DIFF
--- a/admin/src/main/ts/src/app/services/connectors/connector/properties/connector-properties.component.ts
+++ b/admin/src/main/ts/src/app/services/connectors/connector/properties/connector-properties.component.ts
@@ -39,6 +39,9 @@ export class ConnectorPropertiesComponent extends OdeComponent implements OnInit
     @ViewChild('propertiesForm')
     propertiesFormRef: NgForm;
 
+    @ViewChild('casTypeFormRef')
+    casTypeFormRef: NgForm;
+
     LINKPARAMS_TARGET_PORTAL = '';
     LINKPARAMS_TARGET_NEWPAGE = '_blank';
     LINKPARAMS_TARGET_ADAPTOR = 'adapter';
@@ -139,6 +142,10 @@ export class ConnectorPropertiesComponent extends OdeComponent implements OnInit
         }
     }
 
+    public get isCasTypeValid(): boolean {
+        return this.casTypeFormRef?.invalid ?? false;
+    }
+
     public getCasTypeDescription(): string {
         if (this.connector.casTypeId && this.casTypes) {
             return this.casTypes.find(casType => casType.id === this.connector.casTypeId).description;
@@ -190,7 +197,7 @@ export class ConnectorPropertiesComponent extends OdeComponent implements OnInit
     public async closeCasRemove(confirm: boolean)
     {
         try {
-            if(confirm){
+            if(confirm && this.propertiesFormRef.invalid){
                 await this.casMappingCollection.removeMapping(this.casTypeToRemove);
                 this.casMappings = this.casMappingCollection.data;
                 this.changeDetector.markForCheck();

--- a/admin/src/main/ts/src/app/services/connectors/connector/properties/connector.properties.component.html
+++ b/admin/src/main/ts/src/app/services/connectors/connector/properties/connector.properties.component.html
@@ -143,9 +143,11 @@
   </ode-panel-section>
   <!--TYPE LIGHTBOX-->
   <ode-lightbox-confirm *ngIf="!!isOpenCasType" lightboxTitle="services.connector.cas.newMapping"
-                    [show]="isOpenCasType"
-                    (onCancel)="closeCasType(false)"
-                    (onConfirm)="closeCasType(true)">
+                  [show]="isOpenCasType"
+                  [disableConfirm]="isCasTypeValid"
+                  (onCancel)="closeCasType(false)"
+                  (onConfirm)="closeCasType(true)">
+      <form #casTypeFormRef="ngForm">
         <ode-form-field label="services.connector.cas.mapping">
           <input type="text"
                   [ngModel]="newCasType.type"
@@ -156,8 +158,8 @@
         <ode-form-field label="services.connector.cas.type">
           <select [(ngModel)]="newCasType.casType"
                   name="newCasType_casType"
-                  [required]="true"
-                  class="is-flex-none has-min-width">
+                  class="is-flex-none has-min-width"
+                  required>
             <option *ngFor="let casType of casTypes | orderBy:'name'" [value]="casType.id">
               {{ casType.name }}
             </option>
@@ -166,24 +168,22 @@
         <ode-form-field label="services.connector.cas.pattern">
           <input type="text"
                   [(ngModel)]="newCasType.pattern"
-                  [required]="true"
                   name="casPattern"
                   [placeholder]="'form.optional' | translate">
         </ode-form-field>
         <ode-form-field label="services.connector.cas.xiti.outil">
           <input type="text"
                   [(ngModel)]="newCasType.xitiOutil"
-                  [required]="true"
                   name="newCasType_xitiOutil"
                   [placeholder]="'form.optional' | translate">
         </ode-form-field>
         <ode-form-field label="services.connector.cas.xiti.service">
           <input type="text"
                   [(ngModel)]="newCasType.xitiService"
-                  [required]="true"
                   name="newCasType_xitiService"
                   [placeholder]="'form.optional' | translate">
         </ode-form-field>
+      </form>
   </ode-lightbox-confirm>
   <!--/END LIGHTBOX-->
   <!--REMOVE LIGHTBOX-->


### PR DESCRIPTION
…on until the form is valid

# Description

Il s'agissait de griser le bouton de confirmation d'une confirm-lightbox, 
tant que les champs qu'elle contient n'étaient pas valides.

## Fixes

[Ticket WB-2131](https://edifice-community.atlassian.net/browse/WB-2131)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [X] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Open admin console as ADMC
2. Select a structure
3. Open Services > Connector Tab
4. Click Create a connector
5. Expand the Specific CAS fields
6. Click the green **+** button
7. In the confirmation modal, the Confirm button must be disabled until the 2 first fields are completed.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley: