### PR TITLE
feat(admin): #WB-1069, add themed favicon to admin console

### DIFF
--- a/admin/src/main/ts/proxy-development.conf.js
+++ b/admin/src/main/ts/proxy-development.conf.js
@@ -25,10 +25,19 @@ const PROXY_CONFIG = {
   changeOrigin: true,
 };
 
+const PROXY_FAVICO = {
+  context: "/assets/themes/**/*.ico",
+  target: "http://localhost:8090",
+  secure: false,
+  logLevel: "debug",
+  changeOrigin: true,
+};
+
 if (fs.existsSync("./.proxyRemoteConfig.js")) {
   const config = require("./.proxyRemoteConfig.js");
-  console.log("Using remote proxy configuration traget: ", config.target);
+  console.log("Using remote proxy configuration target: ", config.target);
   PROXY_CONFIG.target = config.target;
+  PROXY_FAVICO.target = config.target;
   if (config.oneSessionId && config.xsrfToken) {
     PROXY_CONFIG.headers = {
       cookie: `oneSessionId=${config.oneSessionId}; authenticated=true; XSRF-TOKEN=${config.xsrfToken}`,
@@ -43,4 +52,4 @@ if (fs.existsSync("./.proxyRemoteConfig.js")) {
 
 }
 
-module.exports = [PROXY_CONFIG];
+module.exports = [PROXY_CONFIG, PROXY_FAVICO];

--- a/admin/src/main/ts/src/app/app-routing.module.ts
+++ b/admin/src/main/ts/src/app/app-routing.module.ts
@@ -7,12 +7,20 @@ import {RouterModule, Routes} from '@angular/router';
 import { AppRootComponent } from './app-root.component';
 import { AdmlHomeComponent } from './adml-home.component';
 import {AppResolver} from './app.resolver';
+import { FavIconResolver } from './core/resolvers/favicon.resolver';
 
 
 const routes: Routes = [
   {
       path: 'admin',
-      resolve: {session: SessionResolver, structures: StructuresResolver, i18n: I18nResolver, config: ConfigResolver, root: AppResolver},
+      resolve: {
+        session: SessionResolver, 
+        structures: StructuresResolver, 
+        i18n: I18nResolver, 
+        config: ConfigResolver, 
+        root: AppResolver,
+        favicon: FavIconResolver
+      },
       component: AppRootComponent,
       children: [
           {path: '', component: AdmlHomeComponent},

--- a/admin/src/main/ts/src/app/core/core.module.ts
+++ b/admin/src/main/ts/src/app/core/core.module.ts
@@ -14,6 +14,7 @@ import { SijilLabelsService } from './services/sijil.labels.service';
 import { UserService } from './services/user.service';
 import { WidgetService } from './services/widgets.service';
 import { UserPositionServices } from './services/user-position.service';
+import { FavIconResolver } from './resolvers/favicon.resolver';
 
 @NgModule({
     imports: [
@@ -36,7 +37,8 @@ import { UserPositionServices } from './services/user-position.service';
         WidgetService,
         ConfigResolver,
         UserService,
-        UserPositionServices
+        UserPositionServices,
+        FavIconResolver
     ],
 })
 export class CoreModule {

--- a/admin/src/main/ts/src/app/core/resolvers/favicon.resolver.ts
+++ b/admin/src/main/ts/src/app/core/resolvers/favicon.resolver.ts
@@ -1,0 +1,30 @@
+import {Injectable} from '@angular/core';
+import {Resolve} from '@angular/router';
+import { SessionModel } from '../store/models/session.model';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable()
+export class FavIconResolver implements Resolve<void> {
+
+    constructor(private http: HttpClient) {}
+
+    async resolve(): Promise<void> {
+        const theme = await SessionModel.getTheme();
+        const iconUrl = `${theme.skin}../../img/illustrations/favicon.ico`;
+        const request = new Request(iconUrl, {method: "HEAD"});
+        try {
+            const response = await fetch(request);
+            if(response.ok) {
+                const link = document.createElement("link");
+                link.rel = "icon";
+                link.href = iconUrl;
+                document.head.appendChild(link);
+                console.log("favicon OK");
+            } else {
+                console.log("favicon unreachable");
+            }
+        } catch(e) {
+            console.log("Cannot fetch favicon :" + e);
+        }
+    }
+}

--- a/admin/src/main/ts/src/app/core/store/mappings/theme.ts
+++ b/admin/src/main/ts/src/app/core/store/mappings/theme.ts
@@ -1,0 +1,6 @@
+export class Theme {
+    skin: string;
+    skinName: string;
+    themeName: string;
+    logoutCallback: string;
+}

--- a/admin/src/main/ts/src/app/core/store/models/session.model.ts
+++ b/admin/src/main/ts/src/app/core/store/models/session.model.ts
@@ -1,12 +1,14 @@
 import http from 'axios';
 import { Context } from '../mappings/context';
 import { Session } from '../mappings/session';
+import { Theme } from '../mappings/theme';
 
 export class SessionModel {
 
     private static session: Session;
     private static context: Context;
     private static currentLanguage: string;
+    private static theme: Promise<Theme>;
 
     public static getSession(): Promise<Session> {
         if (!SessionModel.session) {
@@ -60,5 +62,26 @@ export class SessionModel {
         } else {
             return Promise.resolve( SessionModel.currentLanguage );
         }
+    }
+
+    public static getTheme(): Promise<Theme> {
+        if(!SessionModel.theme) {
+            SessionModel.theme = http.get('/theme')
+            .then(result => {
+                let theme = result.data as Theme;
+                if(typeof theme.skin === "string" && 
+                        theme.skin.length>0 &&
+                        !theme.skin.endsWith('/')) {
+                    theme.skin += '/';
+                }
+                Object.setPrototypeOf(theme, new Theme());
+                return theme;
+            })
+            .catch(e => {
+                console.error(e);
+                return new Theme();
+            });
+        }
+        return SessionModel.theme
     }
 }

--- a/admin/src/main/ts/src/app/management/message-flash/message-flash.service.ts
+++ b/admin/src/main/ts/src/app/management/message-flash/message-flash.service.ts
@@ -1,5 +1,6 @@
 import http from 'axios';
 import { FlashMessageModel } from 'src/app/core/store/models/flashmessage.model';
+import { SessionModel } from 'src/app/core/store/models/session.model';
 import { StructureModel } from 'src/app/core/store/models/structure.model';
 
 export class MessageFlashService {
@@ -147,10 +148,9 @@ export class MessageFlashService {
     }
 
     static async getTheme() {
-        let response;
         try {
-            response = await http.get(`/theme`);
-            return response.data.skin + 'theme.css';
+            const theme = await SessionModel.getTheme();
+            return theme.skin + 'theme.css';
         } catch (error) {
             return error.response.data;
         }

--- a/admin/src/main/ts/src/app/navbar/navbar.component.ts
+++ b/admin/src/main/ts/src/app/navbar/navbar.component.ts
@@ -3,6 +3,7 @@ import { Component, ElementRef, EventEmitter, Injector, Input, Output, ViewChild
 import { OdeComponent } from 'ngx-ode-core';
 import { removeAccents } from 'ngx-ode-ui';
 import { StructureModel } from '../core/store/models/structure.model';
+import { SessionModel } from '../core/store/models/session.model';
 
 @Component({
     selector: 'ode-navbar',
@@ -54,8 +55,8 @@ export class NavbarComponent extends OdeComponent {
     }
 
     public getLogoutCallback() {
-        http.get(`/theme`).then((res) => {
-            this.logoutCallback = res.data.logoutCallback;        
+        SessionModel.getTheme().then((theme) => {
+            this.logoutCallback = theme.logoutCallback;        
         })
     }
 }


### PR DESCRIPTION
# Description

Admin console v2 was showing the default Angular icon.
Now it displays the one from user's skin.

NE PAS MERGER, c'est pour une version future....

## Fixes

[WB-1069](https://edifice-community.atlassian.net/browse/WB-1069)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [X] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Connect to /admin
2. Check the displayed icon in browser tab.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley:

[WB-1069]: https://edifice-community.atlassian.net/browse/WB-1069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ