### PR TITLE
fix: #WB-3323, do not allow renaming of positions with an already taken name in the same structure

### DIFF
--- a/admin/src/main/resources/i18n/fr.json
+++ b/admin/src/main/resources/i18n/fr.json
@@ -1714,5 +1714,7 @@
   "statistics_presences.view": "Statistiques : accès",
   "user.merge.disclaimer.confirm": "Voulez-vous conserver les rattachements des deux comptes : établissements, classes, groupes et rattachements enfants pour les comptes parents ? Par défaut la fusion va simplement conserver le compte principal (compte déjà activé ou celui en alimentation automatique) et supprimer le compte en doublon.",
   "user.merge.oldmerge.button": "Ne pas conserver",
-  "user.merge.newmerge.button": "Conserver"
+  "user.merge.newmerge.button": "Conserver",
+  "position.name.already.used": "Une fonction du même nom existe déjà dans cette structure",
+  "position.not.accessible": "Cette fonction ne peut être modifiée"
 }

--- a/directory/src/main/java/org/entcore/directory/controllers/UserPositionController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/UserPositionController.java
@@ -101,8 +101,20 @@ public class UserPositionController extends BaseController {
 				userPositionService.renameUserPosition(name, positionId, adminInfos)
 						.onSuccess(userPosition -> Renders.render(request, userPosition))
 						.onFailure(th -> {
-							Renders.log.warn("An error occurred while renaming user position with id : " + positionId + " and name : " + name, th);
-							Renders.renderError(request);
+							log.warn("An error occurred while renaming user position with id : " + positionId + " and name : " + name, th);
+							final String message;
+							final int code;
+							if("position.not.accessible".equals(th.getMessage())) {
+								message = th.getMessage();
+								code = 403;
+							} else if("position.name.already.used".equals(th.getMessage())) {
+								message = th.getMessage();
+								code = 409;
+							} else {
+								message = "unknown.error";
+								code = 500;
+							}
+							Renders.renderError(request, new JsonObject(), code, message);
 						});
 			});
 		});


### PR DESCRIPTION
# Description

Lorsque l'on tente de renommer une fonction, on vérifie désormais qu'il n'existe pas déjà une fonction portant le même nom dans le même établissement.

## Fixes

WB-3323

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [x] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: