### PR TITLE
[EDIFICE] Allow ADML users to update other ADMLs functions

### DIFF
--- a/tests/src/test/js/it/scenarios/position/attribute-position.js
+++ b/tests/src/test/js/it/scenarios/position/attribute-position.js
@@ -16,7 +16,6 @@ import {
   attachUserToStructures
 } from "https://raw.githubusercontent.com/edificeio/edifice-k6-commons/develop/dist/index.js";
 
-
 chai.config.logFailures = true;
 
 export const options = {
@@ -132,6 +131,7 @@ export function testAttributePositions({structures, admls, positions, headAdml, 
     console.log("relative1 is ", relative1.login)
     console.log("student1 is ", student1.login)
     console.log("multiEtabUser", multiEtabUser.login)
+
     for(let profile of profiles) {
         const [user, label] = profile
         let returnCode;
@@ -189,10 +189,10 @@ export function testAttributePositions({structures, admls, positions, headAdml, 
       tryToAssignNewPositionAndCheckUserPositionsRemainUnchanged(relative1, [position1], 'ADML', 'relative', 200, session, admcSession);
       tryToAssignNewPositionAndCheckUserPositionsRemainUnchanged(student1, [position1], 'ADML', 'student', 200, session, admcSession);
     })
-    
+
     describe("ADML attributes a function to another ADML in the same structure", () => {
       session = authenticateWeb(headAdml.login)
-      assignNewPositionAndCheckThatItSucceeded(adml2, [position1], 'ADML', 'Other ADML', session, admcSession);
+      assignNewPositionAndCheckThatItSucceeded(adml2, [position2], 'ADML', 'Other ADML', session, admcSession);
     })
 
     session = authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD)


### PR DESCRIPTION
# Description

Vérifier les champs qui vont être mis à jour quand on appelle la méthode de MàJ d'un utilisateur pour savoir si on a le droit de laisser passer l'appel.

## Fixes

WB-3330

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [x] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: