### PR TITLE
fix(admin,feeder,directory): #WB-3332, allow creating a Personnel with a list of UserPositions

### DIFF
--- a/admin/src/main/ts/src/app/_shared/user-position-modal/user-position-modal.component.html
+++ b/admin/src/main/ts/src/app/_shared/user-position-modal/user-position-modal.component.html
@@ -25,10 +25,11 @@
     </form>
 
     <div class="is-pulled-right">
-      <button (click)="cancel()" class="user-position-save">
+      <button type="button" (click)="cancel()" class="user-position-save">
         <s5l>user-position.cancel</s5l>
       </button>
       <button
+        type="button" 
         (click)="save()"
         class="user-position-save action"
         [disabled]="usePositionForm.invalid || saving"

--- a/admin/src/main/ts/src/app/core/resolvers/favicon.resolver.ts
+++ b/admin/src/main/ts/src/app/core/resolvers/favicon.resolver.ts
@@ -19,9 +19,8 @@ export class FavIconResolver implements Resolve<void> {
                 link.rel = "icon";
                 link.href = iconUrl;
                 document.head.appendChild(link);
-                console.log("favicon OK");
             } else {
-                console.log("favicon unreachable");
+                console.log("No favicon found");
             }
         } catch(e) {
             console.log("Cannot fetch favicon :" + e);

--- a/admin/src/main/ts/src/app/users/create/user-create.component.html
+++ b/admin/src/main/ts/src/app/users/create/user-create.component.html
@@ -57,7 +57,7 @@
           >
           </ode-user-position-modal>
       
-          <button (click)="showPositionSelection($event)">
+          <button type="button" (click)="showPositionSelection($event)">
             <i class="fa fa-plus-circle is-size-5"></i>
             <s5l>user-position.select</s5l>
           </button>
@@ -82,7 +82,7 @@
                   src="/admin/public/img/user-position-empty-screen.svg"
                 />
                 <s5l>user-position.input-name.not-found</s5l>
-                <button (click)="showPositionCreation()">
+                <button type="button" (click)="showPositionCreation()">
                   <s5l>user-position.add</s5l>
                   <i class="fa fa-plus-circle is-size-5"></i>
                 </button>
@@ -94,7 +94,7 @@
           <h3><s5l>create.user.selectedpositions</s5l></h3>
           <ul>
             <li *ngFor="let position of newUser.userDetails.userPositions">
-              <span>{{ position.name }} - <s5l>user-position.source.{{ position.source }}</s5l></span>
+              <span>{{ position.name }}</span>
               <i class="fa fa-times action" (click)="removePosition(position)"
                 [title]="'user-position.delete-assignment' | translate"></i>
             </li>

--- a/admin/src/main/ts/src/app/users/details/sections/user-positions/user-positions-section.component.html
+++ b/admin/src/main/ts/src/app/users/details/sections/user-positions/user-positions-section.component.html
@@ -9,10 +9,7 @@
 
   <ul class="actions-list">
     <li *ngFor="let userPosition of userPositions">
-      <span
-        >{{ userPosition.name }} -
-        <s5l>user-position.source.{{ userPosition.source }}</s5l></span
-      >
+      <span>{{ userPosition.name }}</span>
       <i
         class="fa fa-times action"
         (click)="removeUserPosition(userPosition)"

--- a/directory/src/main/java/org/entcore/directory/controllers/DirectoryController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/DirectoryController.java
@@ -53,6 +53,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static fr.wseduc.webutils.Utils.getOrElse;
 import static fr.wseduc.webutils.Utils.handlerToAsyncHandler;
@@ -396,8 +397,11 @@ public class DirectoryController extends BaseController {
 				}
 				List<String> childrenIds = request.formAttributes().getAll("childrenIds");
 				user.put("childrenIds", new fr.wseduc.webutils.collections.JsonArray(childrenIds));
-				List<String> userPositionIds = request.formAttributes().getAll("positionIds");
-				user.put("userPositionIds", userPositionIds);
+				// Get UserPosition IDs and remove duplicates.
+				List<String> userPositionIds = request.formAttributes().getAll("positionIds")
+				.stream().distinct().collect(Collectors.toList());
+				
+				user.put("userPositionIds", new fr.wseduc.webutils.collections.JsonArray(userPositionIds));
 				if (classId != null && !classId.trim().isEmpty()) {
 					userService.createInClass(classId, user, null, new Handler<Either<String, JsonObject>>() {
 						@Override

--- a/directory/src/main/java/org/entcore/directory/controllers/DirectoryController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/DirectoryController.java
@@ -427,7 +427,13 @@ public class DirectoryController extends BaseController {
 								}));
 								renderJson(request, r);
 							} else {
-								leftToResponse(request, res.left());
+								final Either.Left<String, JsonObject> left = res.left();
+								final String value = left.getValue();
+								if("user.profiles.not.allowed.for.profile.at.creation".equals(value)) {
+									renderError(request, new JsonObject().put("error", value), 403, "Forbidden");
+								} else {
+									leftToResponse(request, res.left());
+								}
 							}
 						}
 					});
@@ -449,7 +455,13 @@ public class DirectoryController extends BaseController {
 								}));
 								renderJson(request, r);
 							} else {
-								leftToResponse(request, res.left());
+								final Either.Left<String, JsonObject> left = res.left();
+								final String value = left.getValue();
+								if("user.profiles.not.allowed.for.profile.at.creation".equals(value)) {
+									renderError(request, new JsonObject().put("error", value), 403, "Forbidden");
+								} else {
+									leftToResponse(request, res.left());
+								}
 							}
 						}
 					});

--- a/feeder/src/main/java/org/entcore/feeder/ManualFeeder.java
+++ b/feeder/src/main/java/org/entcore/feeder/ManualFeeder.java
@@ -279,9 +279,11 @@ public class ManualFeeder extends BusModBase {
 		if ("Relative".equals(profile)) {
 			childrenIds = user.getJsonArray("childrenIds");
 		}
-		JsonArray userPositionIds = null;
-		if ("Personnel".equals(profile)) {
-			userPositionIds = user.getJsonArray("userPositionIds");
+		JsonArray userPositionIds = user.getJsonArray("userPositionIds");;
+		if (userPositionIds != null && !userPositionIds.isEmpty() && !"Personnel".equals(profile)) {
+			logger.warn("Cannot create a user with profile {0} and positions", profile);
+			sendError(message, "user.profiles.not.allowed.for.profile.at.creation");
+			return;
 		}
 		final String userSource = "SSO".equals(user.getString("source")) ? "SSO": SOURCE;
 		final String error = profiles.get(profile).validate(user);

--- a/feeder/src/main/java/org/entcore/feeder/ManualFeeder.java
+++ b/feeder/src/main/java/org/entcore/feeder/ManualFeeder.java
@@ -279,6 +279,10 @@ public class ManualFeeder extends BusModBase {
 		if ("Relative".equals(profile)) {
 			childrenIds = user.getJsonArray("childrenIds");
 		}
+		JsonArray userPositionIds = null;
+		if ("Personnel".equals(profile)) {
+			userPositionIds = user.getJsonArray("userPositionIds");
+		}
 		final String userSource = "SSO".equals(user.getString("source")) ? "SSO": SOURCE;
 		final String error = profiles.get(profile).validate(user);
 		if (error != null) {
@@ -292,7 +296,7 @@ public class ManualFeeder extends BusModBase {
 		final String structureId = message.body().getString("structureId");
 		if (structureId != null && !structureId.trim().isEmpty()) {
 			final JsonArray classesNames = message.body().getJsonArray("classesNames");
-			createUserInStructure(message, user, profile, structureId, childrenIds, classesNames);
+			createUserInStructure(message, user, profile, structureId, childrenIds, classesNames, userPositionIds);
 			return;
 		}
 		final String classId = message.body().getString("classId");
@@ -304,12 +308,11 @@ public class ManualFeeder extends BusModBase {
 	}
 
 	private void createUserInStructure(final Message<JsonObject> message,
-			final JsonObject user, String profile, String structureId, JsonArray childrenIds, JsonArray classesNames) {
+			final JsonObject user, String profile, String structureId, JsonArray childrenIds, 
+			JsonArray classesNames, JsonArray userPositionIds) {
 		final Integer transactionId = message.body().getInteger("transactionId");
 		final Boolean commit = message.body().getBoolean("commit", true);
 		StatementsBuilder statementsBuilder = new StatementsBuilder();
-		// Retrieve user position ids and remove them from user properties before creating user node
-		final JsonArray userPositionIds = (JsonArray) user.remove("userPositionIds");
 		String related = "";
 		JsonObject params = new JsonObject()
 				.put("structureId", structureId)

--- a/tests/src/test/js/it/scenarios/position/run.sh
+++ b/tests/src/test/js/it/scenarios/position/run.sh
@@ -2,6 +2,7 @@
 tests=(
     "docker compose run --rm k6 run file:///home/k6/src/it/scenarios/position/crud.js"
     "docker compose run --rm k6 run file:///home/k6/src/it/scenarios/position/attribute-position.js"
+    "docker compose run --rm k6 run file:///home/k6/src/it/scenarios/position/user-creation.js"
 )
 exit_code=0
 for test in "${tests[@]}"; do

--- a/tests/src/test/js/it/scenarios/position/user-creation.js
+++ b/tests/src/test/js/it/scenarios/position/user-creation.js
@@ -1,0 +1,118 @@
+import { check } from "k6";
+import chai, { describe } from "https://jslib.k6.io/k6chaijs/4.3.4.2/index.js";
+import {
+  authenticateWeb,
+  getOrCreatePosition,
+  assertOk,
+  initStructure,
+  attachStructureAsChild,
+  getAdmlsOrMakThem,
+  checkReturnCode,
+  attachUserToStructures,
+  createUser,
+  getUserProfileOrFail
+} from "https://raw.githubusercontent.com/edificeio/edifice-k6-commons/develop/dist/index.js";
+
+chai.config.logFailures = true;
+
+export const options = {
+  setupTimeout: "1h",
+  maxRedirects: 0,
+  thresholds: {
+    checks: ["rate == 1.00"],
+  },
+  scenarios: {
+    createUserWithPositions: {
+      exec: 'testCreateUserWithPositions',
+      executor: "per-vu-iterations",
+      vus: 1,
+      maxDuration: "5s",
+      gracefulStop: '5s',
+    },
+  },
+};
+
+const seed = Date.now()
+
+export function setup() {
+  let structureTree;
+  describe("[Position-UserCreation] Initialize data", () => {
+    const schoolName = `IT Positions-Creation`
+    let session = authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD)
+    //////////////////////////////////
+    // Create 1 head structure and 2
+    // depending structures
+    const chapeau = initStructure(`Chapeau-${schoolName}`, 'tiny')
+    const structure1 = initStructure(`1 - ${schoolName}`, 'tiny')
+    const structure2 = initStructure(`2 - ${schoolName}`, 'tiny')
+    attachStructureAsChild(chapeau, structure1, session)
+    attachStructureAsChild(chapeau, structure2, session)
+    ////////////////////////////////////////
+    // Create ADMLs
+    const megaAdml = getAdmlsOrMakThem(chapeau, 'Teacher', 1, [], session)[0]
+    const adml1 = getAdmlsOrMakThem(structure1, 'Teacher', 1, [megaAdml], session)[0]
+    const adml2 = getAdmlsOrMakThem(structure2, 'Teacher', 1, [megaAdml], session)[0]
+
+    attachUserToStructures(megaAdml, [structure1, structure2], session)
+    ////////////////////////////////////////
+    // Create 1 ADML for each structure
+    structureTree = { head: chapeau, structures: [structure1, structure2], admls: [adml1, adml2], headAdml: megaAdml}
+    const positions = [0, 1, 2, 3].map(i => getOrCreatePosition(`${schoolName} - Position ${i}`, structure1, session))
+    structureTree = { 
+        head: chapeau, 
+        structures: [structure1, structure2], 
+        admls: [adml1, adml2],
+        headAdml: megaAdml,
+        positions
+      }
+  });
+  return structureTree ;
+}
+/**
+ * Ensure that only Personnel users can be created with user positions
+ */
+export function testCreateUserWithPositions({structures, admls, positions, headAdml }) {
+  const [adml1, adml2] = admls
+  const [structure1, structure2] = structures
+  describe("[Position-UserCreation] Attribute positions to users on creation", () => {
+    const session = authenticateWeb(adml1.login)
+    const profilesThatCannotBeCreatedWithPositions = ['Student', 'Relative', 'Teacher']
+    for(let profile of profilesThatCannotBeCreatedWithPositions) {
+        describe(`Creation of a ${profile} should not be possible with a position`, () => {
+            const userCreationRequest = createUserCreationRequest(profile, structure1, positions)
+            let res = createUser(userCreationRequest, structure1, session);
+            checkReturnCode(res, `should not be able to create a ${profile} with positions`, 403)
+        })
+    }
+    const profilesThatCanBeCreatedWithPositions = ['Personnel']
+    for(let profile of profilesThatCanBeCreatedWithPositions) {
+        describe(`Creation of a ${profile} should be possible with a position`, () => {
+          const userCreationRequest = createUserCreationRequest(profile, structure1, positions)
+          let res = createUser(userCreationRequest, structure1, session);
+          assertOk(res, `should be able to create a ${profile} with positions`)
+          const user = JSON.parse(res.body)
+          const newUserPositions = (getUserProfileOrFail(user.id, session).userPositions || []);
+          const actualPositionIds = newUserPositions.map(p => p.id)
+          const checkOk = check(newUserPositions, {
+            "should have all positions specified at creation and only them": ps => ps.length === positions.length &&
+                                                                      positions.filter(p => actualPositionIds.indexOf(p.id)<0).length === 0
+          })
+          if(!checkOk) {
+            console.warn("Error ", newUserPositions, "instead of ", positions)
+            console.warn("Could not find", positions.filter(p => actualPositionIds.indexOf(p.id)<0))
+          }
+        })
+    }
+})
+};
+
+function createUserCreationRequest(profile, structure, positions) {
+  return {
+    firstName: `Pr ${profile.substring(0, 1)} ${seed}`,
+    lastName: `Nom ${profile.substring(0, 1)} ${seed}`,
+    type: profile,
+    structureId: structure.id,
+    birthDate: "2010-10-10",
+    positionIds: positions.map(p => p.id)
+  }
+}


### PR DESCRIPTION
# Description

* Creating a Personnel attached to a list of UserPositions must be allowed, but they were filtered out by Feeder.
* Some buttons were acting as submit buttons and validating forms prematuraly.
* Removed some unnecessary logs.

## Fixes

[WB-3332](https://edifice-community.atlassian.net/browse/WB-3332)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [X] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [X] directory
- [X] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley:

[WB-3332]: https://edifice-community.atlassian.net/browse/WB-3332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ