### PR TITLE
feat(admin): #WB-3325, filter out duplicate positions at selection, n…

### DIFF
--- a/admin/src/main/ts/src/app/users/create/user-create.component.ts
+++ b/admin/src/main/ts/src/app/users/create/user-create.component.ts
@@ -41,8 +41,8 @@ export class UserCreateComponent extends OdeComponent implements OnInit, OnDestr
     get filteredPositionList() {
         // Extract and trim names
         const filteredList = this.positionList?.map(position => position.name)
-            // Remove empty and already selected names
-            .filter(name => !this.newUser.userDetails.userPositions.some(value=> name.length===0 || (value.name && value.name?.trim()===name))) ?? [];
+            // Remove empty names
+            .filter(name => name.length>0) ?? [];
         // Remove remaining duplicates
         return filteredList.filter((name, index) => (index+1>=filteredList.length || filteredList.indexOf(name, index+1)<0))
             // return result as an array of UserPosition
@@ -160,11 +160,13 @@ export class UserCreateComponent extends OdeComponent implements OnInit, OnDestr
             )
         )
         .then(addedPosition => {
-            if(addedPosition) {
+            // Do not duplicate positions
+            const addedName = addedPosition.name?.trim();
+            if( addedName && this.newUser.userDetails.userPositions.findIndex(pos => pos.name?.trim() == addedName) < 0 ) {
                 this.newUser.userDetails.userPositions.push(addedPosition);
-                this.showUserPositionSelectionLightbox = false;
-                this.searchContent = "";
             }
+            this.searchContent = "";
+            this.showUserPositionSelectionLightbox = false;
         });
     }
 

--- a/admin/src/main/ts/src/app/users/details/sections/user-positions/user-positions-section.component.ts
+++ b/admin/src/main/ts/src/app/users/details/sections/user-positions/user-positions-section.component.ts
@@ -45,13 +45,11 @@ export class UserPositionsSectionComponent
         this.details.userPositions.map((p) => p.id) !== this.userPositions.map((p) => p.id));
   }
 
-  /** List of selectable positions = all positions except duplicates and those already assigned. */
+  /** List of selectable positions = all positions except duplicates. */
   get filteredPositionList() {
     // Extract and trim names
-    const filteredList = this.positionList?.map(position => position.name.trim())
-      // Remove empty and already selected names
-      .filter(name => !this.userPositions.some(value=> name.length===0 || (value.name && value.name.trim()===name))) ?? [];
-    // Remove remaining duplicates
+    const filteredList = this.positionList?.map(position => position.name.trim()) ?? [];
+    // Remove duplicates
     return filteredList.filter((name, index) => (index+1>=filteredList.length || filteredList.indexOf(name, index+1)<0))
       // return result as an array of UserPosition
       .map(name => ({name}));
@@ -92,7 +90,7 @@ export class UserPositionsSectionComponent
   }
 
   selectUserPosition(position: UserPosition) {
-    const name = position.name.trim();
+    const name = position.name?.trim();
     const structureId = this.structure.id;
     // Search the structure for a UserPosition with this name.
     Promise.resolve(this.positionList.find(pos => pos.name==name && pos.structureId==structureId))
@@ -121,13 +119,16 @@ export class UserPositionsSectionComponent
             })
         )
     )
-      .then(addedPosition => {
-      console.log(addedPosition);
-        if(addedPosition) {
+    .then(addedPosition => {
+      if(addedPosition) {
+        // Do not duplicate positions
+        const addedName = addedPosition.name?.trim();
+        if( addedName && this.userPositions.findIndex(pos => pos.name?.trim() == addedName) < 0 ) {
           this.userPositions.push(addedPosition);
-          this.showUserPositionSelectionLightbox = false;
           this.saveUpdate();
         }
+        this.showUserPositionSelectionLightbox = false;
+      }
     });
   }
 


### PR DESCRIPTION
…ot at display

# Description

Pour attribuer une fonction (UserPosition) à un utilisateur, les fonctions existantes sont listées à l'écran.
Cette liste masquait les fonctions déjà attribuées à l'utilisateur, afin de ne pas pouvoir les lui ré-affecter par un clic.
Mais en saisissant la fonction à la main, on pouvait encore créer un doublon, rejeté par le backend avec un message d'erreur mal adapté.
Désormais, la liste affiche les  fonctions existantes, y compris celles déjà  affectées à l'utilisateur.
La vérification d'un doublon potentiel est faite au moment de l'ajout à l'utilisateur. 

## Fixes

[WB-3325](https://edifice-community.atlassian.net/browse/WB-3325)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [X] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Sur la page de détails et celle de création d'un utilisateur : 
1. Affectation d'une fonction en doublon
2. Affectation d'une nouvelle fonction
Le fonctions ne sont pas affectées en double, et le serveur ne renvoie pas d'erreur lors des appels API.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley:

[WB-3325]: https://edifice-community.atlassian.net/browse/WB-3325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ