### PR TITLE
feat(admin): #WB-3208 #WB-3207 add filter with user position

### DIFF
--- a/admin/src/main/resources/i18n/fr.json
+++ b/admin/src/main/resources/i18n/fr.json
@@ -431,6 +431,7 @@
   "adml.multi.combo.title": "Administrateurs locaux",
   "blocked.multi.combo.title": "Blocage",
   "delete.multi.combo.title": "Pré-suppression",
+  "userPositions.multi.combo.title": "Fonctions",
   "ignore.activation": "Pas de filtre sur l'activation",
   "users.activated": "Utilisateurs activés",
   "users.not.activated": "Utilisateurs non activés",

--- a/admin/src/main/ts/src/app/core/services/userlist.filters.service.ts
+++ b/admin/src/main/ts/src/app/core/services/userlist.filters.service.ts
@@ -1,5 +1,6 @@
 import {Injectable} from '@angular/core';
 import {Subject} from 'rxjs';
+import { UserPosition } from '../store/models/userPosition.model';
 
 export abstract class UserFilter<T> {
 
@@ -245,6 +246,25 @@ class BlockedFilter extends UserFilter<string> {
     }
 }
 
+class PositionFilter extends UserFilter<string> {
+    type = 'userPositions';
+    label = 'userPosition.multi.combo.title';
+    display = 'name';
+    comboModel = [];
+    order = '+';
+    filterProp = 'this';
+
+    filter = (userPositions: string[]) => {
+        const outputModel = this.outputModel;
+
+        return outputModel.length === 0 ||
+            userPositions && userPositions.length > 0 &&
+            userPositions.some(f => {
+                return outputModel.some(o => o === f);
+            });
+    }
+}
+
 @Injectable()
 export class UserlistFiltersService {
 
@@ -265,6 +285,7 @@ export class UserlistFiltersService {
     private dateFilter = new DateFilter(this.$updateSubject);
     private deleteFilter = new DeleteFilter(this.$updateSubject);
     private blockedFilter = new BlockedFilter(this.$updateSubject);
+    private positionFilter = new PositionFilter(this.$updateSubject);
 
     filters: UserFilterList<any> = [
         this.profileFilter,
@@ -279,7 +300,8 @@ export class UserlistFiltersService {
         this.admlFilter,
         this.dateFilter,
         this.deleteFilter,
-        this.blockedFilter
+        this.blockedFilter,
+        this.positionFilter
     ];
 
     resetFilters() {
@@ -330,6 +352,10 @@ export class UserlistFiltersService {
 
     setBlockedComboModel(combos: string[]) {
         this.blockedFilter.comboModel = combos;
+    }
+
+    setPositionComboModel(combos: UserPosition[]) {
+        this.positionFilter.comboModel = combos;
     }
 
     getFormattedFilters(customFilters?: UserFilter<any> | UserFilterList<any>): any {

--- a/admin/src/main/ts/src/app/core/services/userlist.filters.service.ts
+++ b/admin/src/main/ts/src/app/core/services/userlist.filters.service.ts
@@ -248,7 +248,7 @@ class BlockedFilter extends UserFilter<string> {
 
 class PositionFilter extends UserFilter<{id:string}> {
     type = 'userPositions';
-    label = 'userPosition.multi.combo.title';
+    label = 'userPositions.multi.combo.title';
     display = 'name';
     comboModel = [];
     order = '+';

--- a/admin/src/main/ts/src/app/core/services/userlist.filters.service.ts
+++ b/admin/src/main/ts/src/app/core/services/userlist.filters.service.ts
@@ -251,8 +251,8 @@ class PositionFilter extends UserFilter<{id:string}> {
     label = 'userPositions.multi.combo.title';
     display = 'name';
     comboModel = [];
-    order = '+';
-    filterProp = 'this';
+    order = '+name';
+    filterProp = 'name';
 
     filter = (userPositions: Array<UserPosition>) => {
         const outputModel = this.outputModel;

--- a/admin/src/main/ts/src/app/core/services/userlist.filters.service.ts
+++ b/admin/src/main/ts/src/app/core/services/userlist.filters.service.ts
@@ -246,7 +246,7 @@ class BlockedFilter extends UserFilter<string> {
     }
 }
 
-class PositionFilter extends UserFilter<string> {
+class PositionFilter extends UserFilter<{id:string}> {
     type = 'userPositions';
     label = 'userPosition.multi.combo.title';
     display = 'name';
@@ -254,13 +254,13 @@ class PositionFilter extends UserFilter<string> {
     order = '+';
     filterProp = 'this';
 
-    filter = (userPositions: string[]) => {
+    filter = (userPositions: Array<UserPosition>) => {
         const outputModel = this.outputModel;
 
         return outputModel.length === 0 ||
             userPositions && userPositions.length > 0 &&
             userPositions.some(f => {
-                return outputModel.some(o => o === f);
+                return outputModel.some(o => o.id === f.id);
             });
     }
 }

--- a/admin/src/main/ts/src/app/core/store/models/structure.model.ts
+++ b/admin/src/main/ts/src/app/core/store/models/structure.model.ts
@@ -5,6 +5,8 @@ import { SubjectCollection } from '../collections/subject.collection';
 import { ApplicationCollection } from '../collections/application.collection';
 import { ConnectorCollection } from '../collections/connector.collection';
 import { WidgetCollection } from '../collections/widget.collection';
+import { UserPosition } from './userPosition.model';
+import { UserPositionServices } from '../../services/user-position.service';
 
 export type ClassModel = { id: string, name: string };
 
@@ -26,6 +28,7 @@ export class StructureModel extends Model<StructureModel> {
     source?: string;
     profiles: { name: string, blocked: any }[] = [];
     aafFunctions: Array<Array<Array<string>>> = [];
+    userPositions: Array<UserPosition> = [];
     levelsOfEducation: number[] = [];
     distributions: string[];
     timetable: string;
@@ -116,6 +119,17 @@ export class StructureModel extends Model<StructureModel> {
                         && res.data[0].aafFunctions && res.data[0].aafFunctions.length > 0) {
                         this.aafFunctions = res.data[0].aafFunctions;
                     }
+                });
+        }
+        return Promise.resolve();
+    }
+
+    syncPositions(force?: boolean) {
+        if (this.userPositions.length < 1 || force === true) {
+            const userPositionServices = new UserPositionServices();
+            return userPositionServices.searchUserPositions({structureId: this.id})
+                .then(res => {
+                    this.userPositions = res;
                 });
         }
         return Promise.resolve();

--- a/admin/src/main/ts/src/app/core/store/models/user.model.ts
+++ b/admin/src/main/ts/src/app/core/store/models/user.model.ts
@@ -40,6 +40,7 @@ export class UserModel extends Model<UserModel> {
     functionalGroups: string[] = [];
     manualGroups: string[] = [];
     functions?: Array<[string, Array<string>]> = [];
+    userPositions?: Array<{id: string}> = [];
     structures: { id: string, name: string, externalId: string }[] = [];
     classes: Classe[] = [];
     duplicates: { id: string, firstName: string, lastName: string, code: string, score: number, structures: { id: string, name: string }[] }[] = [];

--- a/admin/src/main/ts/src/app/structure/structure.resolver.ts
+++ b/admin/src/main/ts/src/app/structure/structure.resolver.ts
@@ -29,7 +29,8 @@ export function sync(structure: StructureModel, force?: boolean): Promise<Struct
     const groupsPromise = structure.syncGroups(force);
     const sourcesPromise = structure.syncSources(force);
     const aafFunctionsPromise = structure.syncAafFunctions(force);
+    const positionsPromise = structure.syncPositions(force);
     const profilesPromise = ProfilesService.getProfiles().then(p => structure.profiles = p);
-    return Promise.all<any>([classesPromise, groupsPromise, sourcesPromise, aafFunctionsPromise, profilesPromise])
+    return Promise.all<any>([classesPromise, groupsPromise, sourcesPromise, aafFunctionsPromise, profilesPromise, positionsPromise])
         .then(() => Promise.resolve(structure));
 }

--- a/admin/src/main/ts/src/app/users/details/sections/user-positions/user-positions-section.component.ts
+++ b/admin/src/main/ts/src/app/users/details/sections/user-positions/user-positions-section.component.ts
@@ -177,6 +177,7 @@ export class UserPositionsSectionComponent
           removePosition ? 'notify.user-position.remove.success.content' :'notify.user-position.assign.success.content',
           'notify.user-position.success.title'
         );
+        this.user.userPositions = this.details.userPositions.map(p=>({id: p.id}));
         this.userInfoService.setState(this.details);
       })
       .catch(err => {

--- a/admin/src/main/ts/src/app/users/users-list/users-list.component.ts
+++ b/admin/src/main/ts/src/app/users/users-list/users-list.component.ts
@@ -72,6 +72,7 @@ export class UsersListComponent extends OdeComponent {
                 }
             });
         });
+        this.listFilters.setPositionComboModel(structure.userPositions);
         this.listFilters.setFunctionsComboModel(filterAafFunctions);
 
         this.listFilters.setProfilesComboModel(structure.profiles.map(p => p.name));

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultSchoolService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultSchoolService.java
@@ -402,12 +402,14 @@ public class DefaultSchoolService implements SchoolService {
 			"  WITH distinct u, classes, structuresDup, duplicates, structures, functionalGroups, CASE WHEN mgroup IS NULL THEN [] ELSE COLLECT(distinct mgroup.name) END as manualGroups " +
 			"OPTIONAL MATCH (u)-[rf:HAS_FUNCTION]->(f:Function) " +
 			"  WITH distinct u, classes, structuresDup, duplicates, structures, functionalGroups, manualGroups, CASE WHEN f IS NULL THEN [] ELSE COLLECT(distinct [f.externalId, rf.scope]) END as functions " +
+			"OPTIONAL MATCH (u)-[:HAS_POSITION]->(p:UserPosition)-[:IN]->(:Structure {id:{structureId}}) " +
+			"  WITH distinct u, classes, structuresDup, duplicates, structures, functionalGroups, manualGroups, functions, CASE WHEN p IS NULL THEN [] ELSE COLLECT(distinct {id: p.id}) END as userPositions " +
 			"RETURN DISTINCT " +
 			"u.id as id, u.profiles[0] as type, u.activationCode as code, u.login as login," +
 			"u.firstName as firstName, u.lastName as lastName, u.displayName as displayName," +
 			"u.source as source, u.deleteDate as deleteDate, u.disappearanceDate as disappearanceDate, u.blocked as blocked, u.created as creationDate, u.removedFromStructures AS removedFromStructures, " +
 			"EXTRACT(function IN u.functions | split(function, \"$\")) as aafFunctions," +
-			" classes, functionalGroups, manualGroups, functions, duplicates, structures " +
+			" classes, functionalGroups, manualGroups, functions, duplicates, structures, userPositions " +
 			"ORDER BY lastName, firstName ";
 		if("none".equals(listUserMode)){
 			//do not include presuppressed user
@@ -420,7 +422,7 @@ public class DefaultSchoolService implements SchoolService {
 					"RETURN DISTINCT u.id as id, u.profiles[0] as type, u.activationCode as code, u.login as login, u.firstName as firstName, u.lastName as lastName, u.displayName as displayName, " +
 					"u.source as source, u.deleteDate as deleteDate, u.disappearanceDate as disappearanceDate, u.blocked as blocked, u.created as creationDate, u.removedFromStructures as removedFromStructures, " +
 					"[] as aafFunctions, [] as classes, [] as functionalGroups, [] as manualGroups, [] as functions, [] as duplicates, " +
-					"COLLECT(distinct {id: s.id, name: s.name, externalId: s.externalId}) as structures " +
+					"COLLECT(distinct {id: s.id, name: s.name, externalId: s.externalId}) as structures, [] as userPositions " +
 					"ORDER BY lastName, firstName ";
 		}else{
 			//include presuppressed (multi etab)
@@ -433,7 +435,7 @@ public class DefaultSchoolService implements SchoolService {
 					"RETURN DISTINCT u.id as id, u.profiles[0] as type, u.activationCode as code, u.login as login, u.firstName as firstName, u.lastName as lastName, u.displayName as displayName, " +
 					"u.source as source, u.deleteDate as deleteDate, u.disappearanceDate as disappearanceDate, u.blocked as blocked, u.created as creationDate, u.removedFromStructures as removedFromStructures, " +
 					"[] as aafFunctions, [] as classes, [] as functionalGroups, [] as manualGroups, [] as functions, [] as duplicates, " +
-					"COLLECT(distinct {id: s.id, name: s.name, externalId: s.externalId}) as structures " +
+					"COLLECT(distinct {id: s.id, name: s.name, externalId: s.externalId}) as structures, [] as userPositions " +
 					"ORDER BY lastName, firstName ";
 		}
 		JsonObject params = new JsonObject().put("structureId", structureId);

--- a/directory/src/main/resources/public/template/favorite-form.html
+++ b/directory/src/main/resources/public/template/favorite-form.html
@@ -45,7 +45,7 @@
                         </a>
                     </div>
                 </div>
-                <div class="flex-row">
+                <div style="column-gap: 16px; display: grid; grid-template-columns: repeat(3, 1fr);">
                     <multi-comboboxes ng-if="filtersOptions.users.structures.length > 1" class="twelve min-w-zero"
                         ng-model="create.favorite.filters.structures"
                         options="create.favorite.options.structures"
@@ -53,54 +53,43 @@
                         title="[[lang.translate('directory.structures')]]"
                         check="onCheck(option)">
                     </multi-comboboxes>
-                    <multi-comboboxes class="twelve min-w-zero" ng-class="{ 'horizontal-margin-twice': filtersOptions.users.structures.length > 1 }"
+                    <multi-comboboxes class="twelve min-w-zero"
                         ng-model="create.favorite.filters.classes"
                         options="create.favorite.options.classes"
                         order="classesOrder"
                         title-all="[[lang.translate('directory.allClasses')]]"
                         title="[[lang.translate('directory.classes')]]"
-                        ng-disabled="!testClassFilterAvailable(create.favorite.filters.types) || (isMultiStructure() && noStructureSelected(search.index))"
+                        ng-disabled="!testClassFilterAvailable(create.favorite.filters.types) || (isMultiStructure() && noStructureSelected(search.index)) || create.favorite.options.classes.length === 0"
                         title-disabled="[[ getDisabledClassTitle(search.index) ]]">
                     </multi-comboboxes>
-                    <multi-comboboxes class="twelve min-w-zero" ng-class="{ 'horizontal-margin-twice': filtersOptions.users.structures.length < 2 }"
+                    <multi-comboboxes class="twelve min-w-zero"
                         ng-model="create.favorite.filters.profiles"
                         options="create.favorite.options.profiles"
                         title-all="[[lang.translate('directory.allProfiles')]]"
                         title="[[lang.translate('directory.profiles')]]"
                         ng-disabled="!testProfileFilterAvailable(create.favorite.filters.types)">
                     </multi-comboboxes>
-                    <multi-comboboxes ng-if="filtersOptions.users.structures.length < 2" class="twelve min-w-zero"
+                    <multi-comboboxes class="twelve min-w-zero"
                         ng-model="create.favorite.filters.functions"
                         options="create.favorite.options.functions"
                         title-all="[[lang.translate('directory.allFunctionGroups')]]"
                         title="[[lang.translate('directory.functionGroups')]]"
                         ng-disabled="!testFunctionFilterAvailable(create.favorite.filters.profiles, create.favorite.filters.types)">
                     </multi-comboboxes>
-                    <multi-comboboxes ng-if="filtersOptions.users.structures.length < 2" class="twelve min-w-zero"
+                    <multi-comboboxes class="twelve min-w-zero"
                         ng-model="create.favorite.filters.positions"
                         options="create.favorite.options.positions"
                         title-all="[[lang.translate('directory.allFunctions')]]"
                         title="[[lang.translate('directory.functions')]]"
                         ng-disabled="!testPositionFilterAvailable(create.favorite.filters.profiles, create.favorite.filters.types)">
                     </multi-comboboxes>
-                </div>
-                <div class="flex-row">
-                    <multi-comboboxes ng-if="filtersOptions.users.structures.length > 1" class="twelve min-w-zero"
-                        ng-model="create.favorite.filters.functions"
-                        options="create.favorite.options.functions"
-                        title-all="[[lang.translate('directory.allFunctions')]]"
-                        title="[[lang.translate('directory.functions')]]"
-                        ng-disabled="!testFunctionFilterAvailable(create.favorite.filters.profiles, create.favorite.filters.types)">
-                    </multi-comboboxes>
-                    <multi-comboboxes class="twelve min-w-zero" ng-class="{ 'horizontal-margin-twice': filtersOptions.users.structures.length > 1 }"
+                    <multi-comboboxes class="twelve min-w-zero" 
                         ng-model="create.favorite.filters.types"
                         options="create.favorite.options.types"
                         title-all="[[lang.translate('directory.allGroupsTypes')]]"
                         title="[[lang.translate('directory.groupsTypes')]]"
                         ng-disabled="!testGroupTypeFilterAvailable(create.favorite.filters.classes, create.favorite.filters.profiles, create.favorite.filters.functions)">
                     </multi-comboboxes>
-                    <div ng-if="filtersOptions.users.structures.length < 2" class="twelve horizontal-margin-twice min-w-zero"></div>
-                    <div class="twelve min-w-zero"></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
# Description

Feature to filter user list in admin console by new user position field

## Fixes

[WB-3302](https://edifice-community.atlassian.net/browse/WB-3302)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [x] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [X] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

* Open admin console as ADMC
* Choose a structure
* Open the Users menu
* Add positions to a user attached to the structure
* Open the users filters
* Filter on one of the positions
* Check that the users list is correctly filtered

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley:

[WB-3302]: https://edifice-community.atlassian.net/browse/WB-3302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ