### PR TITLE
fix: WB-2579, add prepare query returning a future

### DIFF
--- a/common/src/main/java/org/entcore/common/sql/ISql.java
+++ b/common/src/main/java/org/entcore/common/sql/ISql.java
@@ -1,5 +1,6 @@
 package org.entcore.common.sql;
 
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.Message;
@@ -11,6 +12,8 @@ public interface ISql {
   void prepared(String query, JsonArray values, Handler<Message<JsonObject>> handler);
 
   void prepared(String query, JsonArray values, DeliveryOptions deliveryOptions, Handler<Message<JsonObject>> handler);
+
+  Future<Message<JsonObject>> prepared(String query, JsonArray values, DeliveryOptions deliveryOptions);
 
   void raw(String query, Handler<Message<JsonObject>> handler);
 

--- a/common/src/main/java/org/entcore/common/sql/Sql.java
+++ b/common/src/main/java/org/entcore/common/sql/Sql.java
@@ -19,6 +19,8 @@
 
 package org.entcore.common.sql;
 
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.eventbus.DeliveryOptions;
 import org.entcore.common.bus.ErrorMessage;
 import io.vertx.core.Handler;
@@ -73,6 +75,17 @@ public class Sql implements ISql {
 				.put("statement", query)
 				.put("values", values);
 		eb.send(address, j, deliveryOptions, handlerToAsyncHandler(handler));
+	}
+
+	@Override
+	public Future<Message<JsonObject>> prepared(String query, JsonArray values, DeliveryOptions deliveryOptions) {
+		Promise<Message<JsonObject>> responseMessagePromise = Promise.promise();
+		JsonObject message = new JsonObject()
+				.put("action", "prepared")
+				.put("statement", query)
+				.put("values", values);
+		eb.request(address, message, deliveryOptions, handlerToAsyncHandler(responseMessagePromise::complete));
+		return responseMessagePromise.future();
 	}
 
 	@Override


### PR DESCRIPTION
# Description

Implémentation d'une méthode "prepare" pour l'exécution du requête SQL qui renvoit un Future plutôt que de prendre un Handler en param.

## Fixes

https://edifice-community.atlassian.net/browse/WB-2579

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: