### PR TITLE
feat(directory): WB-1699, restore custom sort on listIsolated method

### DIFF
--- a/directory/src/main/java/org/entcore/directory/controllers/UserController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/UserController.java
@@ -72,6 +72,8 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.text.ParseException;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static fr.wseduc.webutils.Utils.isNotEmpty;
 import static fr.wseduc.webutils.request.RequestUtils.bodyToJson;
@@ -79,6 +81,8 @@ import static org.entcore.common.http.response.DefaultResponseHandler.*;
 import static org.entcore.common.user.SessionAttributes.PERSON_ATTRIBUTE;
 
 public class UserController extends BaseController {
+	private static String SORTON_REGEXP = "^(?<order>\\+|\\-)(?<field>firstName|lastName|displayName)$";
+	private static final Pattern SORTON_PATTERN = Pattern.compile(SORTON_REGEXP);
 	static final String MOTTO_RESOURCE_NAME = "motto";
 	static final String MOOD_RESOURCE_NAME = "mood";
 	private UserService userService;
@@ -446,10 +450,23 @@ public class UserController extends BaseController {
 		final String searchType = request.params().get("searchType");
 		final String searchTerm = request.params().get("searchTerm");
 
+		String sortingField = null;
+		String sortingOrder = null;
+		if(sortOn!=null) {
+			Matcher matcher = SORTON_PATTERN.matcher(sortOn);
+			if(!matcher.find()) {
+				badRequest(request);
+				return;
+			}
+			sortingField = matcher.group("field");
+			sortingOrder = matcher.group("order").charAt(0)=='-' ? "DESC" : "ASC";
+		}
+
 		userService.listIsolated(
 				structureId,
 				expectedProfile,
-				sortOn,
+				sortingField,
+				sortingOrder,
 				fromIndexInt,
 				limitResultInt,
 				searchType,

--- a/directory/src/main/java/org/entcore/directory/services/UserService.java
+++ b/directory/src/main/java/org/entcore/directory/services/UserService.java
@@ -73,7 +73,8 @@ public interface UserService {
 	 * 
 	 * @param structureId If defined, return users attached to this structure but with no class.
 	 * @param profile If defined, return users having one of the profiles.
-	 * @param sortOn If defined, sort users by this field (defaults to "displayName")
+	 * @param sortingField If defined, sort users by this field, defaults to (profile DESC, displayName ASC).
+	 * @param sortingOrder Sort order ASC or DESC (defaults to "ASC").
 	 * @param fromIndex If defined, return users by ommitting results before the index.
 	 * @param limitResult If defined, returned resultset will contain users up to this number. 
 	 * @param searchType If defined with searchTerm, filter results on this field.
@@ -82,8 +83,9 @@ public interface UserService {
 	 */
 	void listIsolated(
 		final String structureId, 
-		final List<String> profile, 
-		final String sortOn,
+		final List<String> profile,
+		final String sortingField,
+		final String sortingOrder,
 		final Integer fromIndex,
 		final Integer limitResult,
 		final String searchType,

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserService.java
@@ -47,6 +47,8 @@ import org.entcore.directory.pojo.TransversalSearchType;
 import org.entcore.directory.services.UserBookService;
 import org.entcore.directory.services.UserService;
 
+import com.google.common.collect.Sets;
+
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -56,12 +58,15 @@ import static org.entcore.common.user.DefaultFunctions.*;
 
 public class DefaultUserService implements UserService {
 
+	private static final Set<String> VALID_SORT_FIELDS = Sets.newHashSet("displayName", "email");
+	private static final Set<String> VALID_SORT_ORDERS = Sets.newHashSet("ASC", "DESC");
 	private static final int LIMIT = 1000;
 	private final Neo4j neo = Neo4j.getInstance();
 	private final EmailSender notification;
 	private final EventBus eb;
 	private final JsonObject userBookData;
 	private Logger logger = LoggerFactory.getLogger(DefaultUserService.class);
+
 
 	public DefaultUserService(EmailSender notification, EventBus eb, JsonObject aUserBookData) {
 		this.userBookData = aUserBookData;
@@ -809,12 +814,10 @@ public class DefaultUserService implements UserService {
 	}
 
 	private boolean isValidSortField(final String sortingField) {
-		final String[] validFields = {"displayName", "email"};
-		return sortingField!=null && Arrays.stream(validFields).anyMatch(f->f.equals(sortingField));
+		return sortingField!=null && VALID_SORT_FIELDS.contains(sortingField);
 	}
 	private boolean isValidSortOrder(final String sortingOrder) {
-		final String[] validOrders = {"ASC", "DESC"};
-		return sortingOrder!=null && Arrays.stream(validOrders).anyMatch(o->o.equals(sortingOrder));
+		return sortingOrder!=null && VALID_SORT_ORDERS.contains(sortingOrder);
 	}
 
 

--- a/tests/src/test/js/it/scenarios/admin/utils.js
+++ b/tests/src/test/js/it/scenarios/admin/utils.js
@@ -1,0 +1,75 @@
+import http from "k6/http";
+import {
+  getHeaders,
+} from "https://raw.githubusercontent.com/edificeio/edifice-k6-commons/develop/dist/index.js";
+
+const rootUrl = __ENV.ROOT_URL;
+
+export function listIsolated(session, sortOn) {
+  const headers = getHeaders(session);
+  const params = new URLSearchParams({
+    sortOn: sortOn ? sortOn : "+displayName",
+    fromIndex:0,
+    limitResult:50
+  }).toString();
+
+  let res = http.get(`${rootUrl}/directory/list/isolated?${params}`, undefined, {headers});
+  if (res.status !== 200) {
+    throw `Impossible to list isolated users with query params ?${params}`;
+  }
+  return JSON.parse(res.body);
+}
+
+function getUserByName(structure, firstName, lastName, session) {
+  const structureUsers = http.get(`${rootUrl}/directory/user/admin/list?structureId=${structure.id}`, {
+    headers: getHeaders(session),
+  });
+  return JSON.parse(structureUsers.body).filter(
+    u => u.firstName === firstName && u.lastName === lastName
+  )[0];
+}
+
+export function createUser(structure, firstName, lastName, type, session) {
+  let user = getUserByName(structure, firstName, lastName, session);
+  if (user) {
+    console.log(`User "${firstName} ${lastName}" already exists.`);
+  } else {
+    const headers = getHeaders(session);
+    headers["Content-Type"] = "application/x-www-form-urlencoded;charset=UTF-8";
+    const payload = new URLSearchParams({
+      structureId: encodeURIComponent(structure.id),
+      firstName: encodeURIComponent(firstName),
+      lastName: encodeURIComponent(lastName),
+      type,
+      birthDate: "undefined"
+    }).toString();
+    const res = http.post(`${rootUrl}/directory/api/user`, payload, {headers});
+    if (res.status !== 200) {
+      throw `Impossible to create user "${firstName} ${lastName}" of ${structure.id}`;
+    }
+    user = JSON.parse(res.body);
+  }
+  return user;
+}
+
+export function detachUserFromStructures(user, structures, session) {
+    const _structures = Array.isArray(structures) ? structures : [structures];
+    for (let structure of _structures) {
+      http.del(
+        `${rootUrl}/directory/structure/${structure.id}/unlink/${user.id}`,
+        undefined,
+        {headers: getHeaders(session)},
+      );
+    }
+}
+
+export function deleteOrPresuppressUsers(users, session) {
+  const _users = Array.isArray(users) ? users : [users];
+  for (let user of _users) {
+    http.del(
+      `${rootUrl}/directory/user?userId=${user.id}`,
+      undefined,
+      {headers: getHeaders(session)},
+    );
+  }
+}

--- a/tests/src/test/js/it/scenarios/admin/utils.js
+++ b/tests/src/test/js/it/scenarios/admin/utils.js
@@ -16,7 +16,7 @@ export function listIsolated(sortOn, session) {
     limitResult:50
   }).toString();
 
-  let res = http.get(`${rootUrl}/directory/list/isolated?${params}`, null, {headers});
+  let res = http.get(`${rootUrl}/directory/list/isolated?${params}`, {headers});
   assertOk(res, `Impossible to list isolated users with query params ?${params}`);
   return JSON.parse(res.body);
 }

--- a/tests/src/test/js/it/scenarios/isolated_users/list.js
+++ b/tests/src/test/js/it/scenarios/isolated_users/list.js
@@ -1,0 +1,160 @@
+import { check } from "k6";
+import chai, { describe } from "https://jslib.k6.io/k6chaijs/4.3.4.2/index.js";
+import {
+  authenticateWeb,
+  createEmptyStructure
+} from "https://raw.githubusercontent.com/edificeio/edifice-k6-commons/develop/dist/index.js";
+import {
+  listIsolated,
+  createUser,
+  detachUserFromStructures,
+  deleteOrPresuppressUsers
+} from "../admin/utils.js";
+
+chai.config.logFailures = true;
+
+export const options = {
+  setupTimeout: "1h",
+  maxRedirects: 0,
+  thresholds: {
+    checks: ["rate == 1.00"],
+  },
+  scenarios: {
+    listIsolated: {
+      exec: 'testListIsolated',
+      executor: "per-vu-iterations",
+      vus: 1,
+      maxDuration: "5s",
+      gracefulStop: '5s',
+    },
+  },
+};
+
+
+function filterById(results, ids) {
+  return results.filter( elem => ids.filter(id=>id===elem.id).length>0 );
+}
+
+/**
+ * @returns A test dataset containing
+ *  - admc: an ADMC user
+ *  - users: a list of isolated users, without structure attachment
+ */
+export function setup() {
+  let data;
+  describe("[Isolated users] Initialize data", () => {
+    const schoolName = `IT Isolated users`;
+    const session = authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD);
+    //////////////////////////////////
+    // Create 1 structure and 4 users
+    const structure = createEmptyStructure(schoolName, false, session);
+    const user1 = createUser(structure, "User1", "Isolated", "Personnel", session);
+    detachUserFromStructures(user1, [structure], session);
+    const user2 = createUser(structure, "User2", "Isolated", "Teacher", session);
+    detachUserFromStructures(user2, [structure], session);
+    const user3 = createUser(structure, "User3", "Isolated", "Personnel", session);
+    detachUserFromStructures(user3, [structure], session);
+    const user4 = createUser(structure, "User4", "Isolated", "Relative", session);
+    detachUserFromStructures(user4, [structure], session);
+
+    data = {users: [user1, user2, user3, user4]};
+  });
+  return data;
+}
+/** Cleanup isolated users. */
+export function teardown({users}) {
+  const session = authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD);
+  if( users && session )
+    deleteOrPresuppressUsers(users, session);
+}
+
+/**
+ * Ensure that :
+ * - isolated users are found
+ * - isolated users are found in correct sort order
+ * - code-injection is rejected when listing isolated users
+ * @param {*} param0 Initialized data
+ */
+export function testListIsolated({users}) {
+  describe("[Isolated users] List basic", () => {
+    const session = authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD);
+    tryListing(users, session);
+    tryListingInDescOrder(session);
+    tryInjectCode(session);
+  });
+};
+
+function tryListing(users, session) {
+  const requesterType = "ADMC";
+  const userIds = users.map(u=>u.id);
+  const results = listIsolated(session);
+  const checks = {};
+  checks[`${requesterType} should be able to list 4 isolated users`] = () => {
+    let ok;
+    const isAnArray = Array.isArray(results);
+    const foundUsers = isAnArray ? filterById(results,userIds) : 0;
+    ok = isAnArray && foundUsers.length===4;
+    if(!ok) {
+      console.error(`------------------- ${requesterType} ----------------------`);
+      console.error(`${requesterType} should be able to list 4 isolated users`);
+      console.error('isAnArray', isAnArray);
+      console.error('foundUsers', foundUsers.length);
+      console.error(`------------------- End ----------------------`);
+    }
+    return ok;
+  };
+  return check(results, checks);
+}
+
+function tryListingInDescOrder(session) {
+  const requesterType = "ADMC";
+  const results = listIsolated(session, "-displayName");
+  const checks = {};
+  checks[`${requesterType} should be able to list isolated users in descending order`] = () => {
+    let ok;
+    const isAnArray = Array.isArray(results);
+    let isDescendingOrder = isAnArray ? true : false;
+    if(isDescendingOrder) {
+      let previous;
+      for(let result of results) {
+        if(previous && result.displayName > previous) {
+          isDescendingOrder = false;
+          break;
+        }
+        previous = result.displayName;
+      }
+    }
+    ok = isAnArray && isDescendingOrder;
+    if(!ok) {
+      console.error(`------------------- ${requesterType} ----------------------`);
+      console.error(`${requesterType} should be able to list 4 isolated users in descending order`);
+      console.error('isAnArray', isAnArray);
+      console.error('isDescendingOrder', isDescendingOrder);
+      console.error(`------------------- End ----------------------`);
+    }
+    return ok;
+  };
+  return check(results, checks);
+}
+
+function tryInjectCode(session) {
+  const requesterType = "ADMC";
+  let requestAccepted = true;
+  try {
+    listIsolated(session, 
+      "-(CASE WHEN MATCH (u:User{lastName:\"Isolated\"}) DETACH DELETE u RETURN true THEN \"displayName\" ELSE \"displayName\" END)");
+  } catch {
+    requestAccepted = false;
+  }
+  const checks = {};
+  checks[`${requesterType} should not be able to inject code while listing`] = () => {
+    const ok = !requestAccepted;
+    if(!ok) {
+      console.error(`------------------- ${requesterType} ----------------------`);
+      console.error(`${requesterType} should not be able to inject code while listing`);
+      console.error(`------------------- End ----------------------`);
+    }
+    return ok;
+  };
+  return check(requestAccepted, checks);
+}

--- a/tests/src/test/js/it/scenarios/isolated_users/list.js
+++ b/tests/src/test/js/it/scenarios/isolated_users/list.js
@@ -111,25 +111,28 @@ function tryListingInDescOrder(session) {
   const results = listIsolated("-displayName", session);
   const checks = {};
   checks[`${requesterType} should be able to list all isolated users in descending order`] = () => {
-    let ok = Array.isArray(results);
-    if(ok) {
+    let cause = true;
+    if(Array.isArray(results)) {
       let previous;
       for(let result of results) {
-        if(previous && result.displayName > previous) {
-          ok = false;
-          break;
+        if( result.displayName != null ) {
+          if(previous && result.displayName > previous) {
+            cause = "order is not descending";
+            break;
+          }
+          previous = result.displayName;
         }
-        previous = result.displayName;
       }
+    } else {
+      cause = "list is not an array";
     }
-    if(!ok) {
+    if(typeof cause === "string") {
       console.error(`------------------- ${requesterType} ----------------------`);
       console.error(`${requesterType} should be able to list all isolated users in descending order`);
-      console.error('isAnArray', isAnArray);
-      console.error('isDescendingOrder', isDescendingOrder);
+      console.error(`=> ${cause}.`);
       console.error(`------------------- End ----------------------`);
     }
-    return ok;
+    return typeof cause === "boolean";
   };
   return check(results, checks);
 }

--- a/tests/src/test/js/it/scenarios/isolated_users/run.sh
+++ b/tests/src/test/js/it/scenarios/isolated_users/run.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+tests=(
+    "docker compose run --rm k6 run file:///home/k6/src/it/scenarios/isolated_users/list.js"
+)
+exit_code=0
+for test in "${tests[@]}"; do
+    # Run the command
+    $test
+    
+    # Check the exit status of the command
+    if [ $? -ne 0 ]; then
+        exit_code=1
+    fi
+done
+if [ $exit_code == 1 ]; then
+    echo "Isolated users : some tests failed"
+fi
+exit $exit_code


### PR DESCRIPTION
# Description

Réhabiliter le tri paramétrable sur la méthode DefaultUserService.listIsolated().
Ajouter des tests d'intégration.

## Fixes

[WB-1699](https://edifice-community.atlassian.net/browse/WB-1699)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [X] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

* Via Postman `/directory/list/isolated`
Le tri custom ne semble pas utilisé dans l'ENT.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley:

[WB-1699]: https://edifice-community.atlassian.net/browse/WB-1699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ