### PR TITLE
[EDIFICE] Use import-path configuration value to store zip file being imported

### DIFF
--- a/common/src/main/java/org/entcore/common/folders/FolderManager.java
+++ b/common/src/main/java/org/entcore/common/folders/FolderManager.java
@@ -105,7 +105,7 @@ public interface FolderManager {
 	 * @param handler  the handler that emit the file object save or an error if any
 	 */
 	default void importFileZip(String zipPath, UserInfos user, Handler<AsyncResult<JsonObject>> handler){
-		importFileZip(new FolderImporterZip.FolderImporterZipContext(zipPath, user, "invalid"), handler);
+		importFileZip(new FolderImporterZip.FolderImporterZipContext(zipPath, null, user, "invalid"), handler);
 	}
 
 	/**


### PR DESCRIPTION
# Description

Use `import-path` variable to specify the import location to unzip imported archives.

## Fixes

WB-3352

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Import zip archive in "Mes données"
2. Check that the zip is unzipped in the specified location

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: