### PR TITLE
feat(auth): WB-3220, prefill activation form with email and mobile

### DIFF
--- a/auth/src/main/java/org/entcore/auth/controllers/AuthController.java
+++ b/auth/src/main/java/org/entcore/auth/controllers/AuthController.java
@@ -852,7 +852,6 @@ public class AuthController extends BaseController {
 
 	/**
 	 * Try to log a user in, checking his activation code.
-	 * On success, the `request` will be responded with an HTML page.
 	 * @param login the user to log in. Can be a user alias.
 	 * @param activationCode to be checked
 	 * @return a future of user's details : login, displayName, email, mobile.
@@ -866,7 +865,6 @@ public class AuthController extends BaseController {
 
 	/**
 	 * Try to log a user in, checking his reset code.
-	 * On success, the `request` will be responded with an HTML page.
 	 * @param login the user to log in. Can be a user alias.
 	 * @param resetCode to be checked
 	 * @return a future of user's details : login, displayName, email, mobile.

--- a/auth/src/main/java/org/entcore/auth/users/UserAuthAccount.java
+++ b/auth/src/main/java/org/entcore/auth/users/UserAuthAccount.java
@@ -21,13 +21,11 @@ package org.entcore.auth.users;
 
 import org.entcore.auth.pojo.SendPasswordDestination;
 import fr.wseduc.webutils.Either;
-
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-
-import fr.wseduc.webutils.Either;
 
 public interface UserAuthAccount {
 
@@ -58,17 +56,13 @@ public interface UserAuthAccount {
 
 	void needToValidateCgu(String userId, Handler<Boolean> handler);
 	
-	void matchActivationCode(String login, String potentialActivationCode,
-			Handler<Boolean> handler);
+	Future<JsonObject> matchActivationCode(String login, String potentialActivationCode);
 
-	void matchActivationCodeByLoginAlias(String loginAlias, String potentialActivationCode,
-			 Handler<Boolean> handler);
+	Future<JsonObject> matchActivationCodeByLoginAlias(String loginAlias, String potentialActivationCode);
 
-	void matchResetCode(String login, String potentialResetCode,
-			Handler<Boolean> handler);
+	Future<JsonObject> matchResetCode(String login, String potentialResetCode);
 
-	void matchResetCodeByLoginAlias(String loginAlias, String potentialResetCode,
-			Handler<Boolean> handler);
+	Future<JsonObject> matchResetCodeByLoginAlias(String loginAlias, String potentialResetCode);
 
 	void findByMail(String email, Handler<Either<String, JsonObject>> handler);
 

--- a/auth/src/main/resources/view-src/activation.html
+++ b/auth/src/main/resources/view-src/activation.html
@@ -15,7 +15,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 	</head>
 	<body class="login" ng-controller="ActivationController"
-		  ng-init='user.login = "{{login}}"; user.activationCode = "{{activationCode}}"'>
+		  ng-init='user.login="{{login}}";user.activationCode="{{activationCode}}";user.email="{{email}}";user.phone="{{phone}}"'>
 	<default-styles>
 		<div ng-include="template.containers.main" class="absolute"></div>
 	</default-styles>


### PR DESCRIPTION
# Description

Lors de la 1ère connexion d'un utilisateur, la vérification du couple (login, code activation) retournait un booléen, pour signifier si un utilisateur concordant avait bien été identifié ou non.
Désormais, cette vérification remonte aussi des méta-données supplémentaires, comme l'adresse email ou le n° de mobile. Ces données sont ensuite transmises au frontend qui peut pré-remplir le formulaire d'activation au mieux, et laisser le choix à l'utilisateur de les modifier.

Si le flux d'activation de compte fonctionne comme avant (au détail près que le formulaire est possiblement pré-rempli), beaucoup de refacto de code a été nécessaire pour pouvoir remonter les méta-données de bout-en-bout.


## Fixes

[WB-3220](https://edifice-community.atlassian.net/browse/WB-3220)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [X] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. log in d'utilisateur admin
2. log in erroné d'utilisateur
3. log in d'utilisateur avec code d'activation
4. log in d'utilisateur avec reset code
5. log in d'utilisateur via son alias de connexion

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley:

[WB-3220]: https://edifice-community.atlassian.net/browse/WB-3220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ