### PR TITLE
fix(auth): #WB-3220, late feedback from PR 537

### DIFF
--- a/auth/src/main/java/org/entcore/auth/users/UserAuthAccount.java
+++ b/auth/src/main/java/org/entcore/auth/users/UserAuthAccount.java
@@ -21,7 +21,7 @@ package org.entcore.auth.users;
 
 import org.entcore.auth.pojo.SendPasswordDestination;
 import fr.wseduc.webutils.Either;
-import io.vertx.core.Future;
+
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonArray;
@@ -56,13 +56,17 @@ public interface UserAuthAccount {
 
 	void needToValidateCgu(String userId, Handler<Boolean> handler);
 	
-	Future<JsonObject> matchActivationCode(String login, String potentialActivationCode);
+	void matchActivationCode(String login, String potentialActivationCode,
+			Handler<Either<String, JsonObject>> handler);
 
-	Future<JsonObject> matchActivationCodeByLoginAlias(String loginAlias, String potentialActivationCode);
+	void matchActivationCodeByLoginAlias(String loginAlias, String potentialActivationCode,
+			 Handler<Either<String, JsonObject>> handler);
 
-	Future<JsonObject> matchResetCode(String login, String potentialResetCode);
+	void matchResetCode(String login, String potentialResetCode,
+			Handler<Either<String, JsonObject>> handler);
 
-	Future<JsonObject> matchResetCodeByLoginAlias(String loginAlias, String potentialResetCode);
+	void matchResetCodeByLoginAlias(String loginAlias, String potentialResetCode,
+			Handler<Either<String, JsonObject>> handler);
 
 	void findByMail(String email, Handler<Either<String, JsonObject>> handler);
 

--- a/auth/src/test/java/org/entcore/auth/UserAuthAccountTest.java
+++ b/auth/src/test/java/org/entcore/auth/UserAuthAccountTest.java
@@ -143,9 +143,8 @@ public class UserAuthAccountTest {
         test.directory().createInactiveUser("user6", "activationCode6", "user6@test.com")
         .onComplete(resAcUser -> {
             context.assertTrue(resAcUser.succeeded());
-            authAccount.matchActivationCode("user6", "activationCode6")
-            .onComplete(resActiv -> {
-                context.assertNotNull(resActiv);
+            authAccount.matchActivationCode("user6", "activationCode6", resActiv -> {
+                context.assertTrue(resActiv.isRight());
                 async.complete();
             });
         });
@@ -157,9 +156,8 @@ public class UserAuthAccountTest {
         test.directory().createInactiveUser("user7", "userAlias7", "activationCode7", "user7@test.com")
         .onComplete(resAcUser -> {
             context.assertTrue(resAcUser.succeeded());
-            authAccount.matchActivationCodeByLoginAlias("userAlias7", "activationCode7")
-            .onComplete(resActiv -> {
-                context.assertNotNull(resActiv);
+            authAccount.matchActivationCodeByLoginAlias("userAlias7", "activationCode7", resActiv -> {
+                context.assertTrue(resActiv.isRight());
                 async.complete();
             });
         });
@@ -171,9 +169,8 @@ public class UserAuthAccountTest {
         test.directory().createInactiveUser("user8", "activationCode8", "user8@test.com")
         .onComplete(resAcUser -> {
             context.assertTrue(resAcUser.succeeded());
-            authAccount.matchActivationCode("user8", "bad")
-            .onComplete(resActiv -> {
-                context.assertNotNull(resActiv);
+            authAccount.matchActivationCode("user8", "bad", resActiv -> {
+                context.assertFalse(resActiv.isRight());
                 async.complete();
             });
         });
@@ -186,9 +183,8 @@ public class UserAuthAccountTest {
         .compose(resAcUser -> test.directory().resetUser(resAcUser, "resetCode9"))
         .onComplete(resAcUser -> {
             context.assertTrue(resAcUser.succeeded());
-            authAccount.matchResetCode("user9", "resetCode9")
-            .onComplete(resActiv -> {
-                context.assertNotNull(resActiv);
+            authAccount.matchResetCode("user9", "resetCode9", resActiv -> {
+                context.assertTrue(resActiv.isRight());
                 async.complete();
             });
         });
@@ -201,9 +197,8 @@ public class UserAuthAccountTest {
         .compose(resAcUser -> test.directory().resetUser(resAcUser, "resetCode10"))
         .onComplete(resAcUser -> {
             context.assertTrue(resAcUser.succeeded());
-            authAccount.matchResetCodeByLoginAlias("userAlias10", "resetCode10")
-            .onComplete(resActiv -> {
-                context.assertNotNull(resActiv);
+            authAccount.matchResetCodeByLoginAlias("userAlias10", "resetCode10", resActiv -> {
+                context.assertTrue(resActiv.isRight());
                 async.complete();
             });
         });
@@ -216,9 +211,8 @@ public class UserAuthAccountTest {
         .compose(resAcUser -> test.directory().resetUser(resAcUser, "resetCode11"))
         .onComplete(resAcUser -> {
             context.assertTrue(resAcUser.succeeded());
-            authAccount.matchResetCode("user11", "bad")
-            .onComplete(resActiv -> {
-                context.assertNotNull(resActiv);
+            authAccount.matchResetCode("user11", "bad", resActiv -> {
+                context.assertFalse(resActiv.isRight());
                 async.complete();
             });
         });


### PR DESCRIPTION
# Description

Prise en compte du feedback d'Intégration :

* Rétablit l'interface UserAuthAccount avec des handlers, modifiés pour répondre à mon besoin, et supprime les Futures trop évolués pour cette interface.
* Conserve cet [algo sous forme de composition de Futures](https://github.com/edificeio/entcore/blob/d8bcf2aa9e02607a4f331375c5d512d8d65a5e68/auth/src/main/java/org/entcore/auth/controllers/AuthController.java#L753), à l'identique. Il y a des tests auto en Java sur cette partie.

## Fixes

(Enter here Jira or Redmine ticket(s) links)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [X] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley: