### PR TITLE
feat(common,directory,admin): WB-3374, new parameter to restrict CRUD operations on UserPosition

### DIFF
--- a/admin/src/main/ts/src/app/_shared/user-position-modal/user-position-modal.component.ts
+++ b/admin/src/main/ts/src/app/_shared/user-position-modal/user-position-modal.component.ts
@@ -10,7 +10,7 @@ import {
 } from "@angular/core";
 import { OdeComponent } from "ngx-ode-core";
 import { UserPosition } from "src/app/core/store/models/userPosition.model";
-import { UserPositionServices } from "src/app/core/services/user-position.service";
+import { UserPositionService } from "src/app/core/services/user-position.service";
 import { NotifyService } from "src/app/core/services/notify.service";
 import { SpinnerService } from "ngx-ode-ui";
 
@@ -56,7 +56,7 @@ export class UserPositionModalComponent extends OdeComponent implements OnInit {
     injector: Injector,
     private ns: NotifyService,
     public spinner: SpinnerService,
-    private userPositionServices: UserPositionServices
+    private userPositionService: UserPositionService
   ) {
     super(injector);
   }
@@ -76,7 +76,7 @@ export class UserPositionModalComponent extends OdeComponent implements OnInit {
       this.userPosition = await this.spinner
         .perform(
           "portal-content",
-          this.userPositionServices.updateUserPosition({
+          this.userPositionService.updateUserPosition({
             ...this.userPosition,
             name: this.editableName,
           })
@@ -105,7 +105,7 @@ export class UserPositionModalComponent extends OdeComponent implements OnInit {
       this.userPosition = await this.spinner
         .perform(
           "portal-content",
-          this.userPositionServices.createUserPosition({
+          this.userPositionService.createUserPosition({
             name: this.editableName,
             structureId: this.structureId,
           })

--- a/admin/src/main/ts/src/app/core/core.module.ts
+++ b/admin/src/main/ts/src/app/core/core.module.ts
@@ -13,7 +13,7 @@ import { NotifyService } from './services/notify.service';
 import { SijilLabelsService } from './services/sijil.labels.service';
 import { UserService } from './services/user.service';
 import { WidgetService } from './services/widgets.service';
-import { UserPositionServices } from './services/user-position.service';
+import { UserPositionService } from './services/user-position.service';
 import { FavIconResolver } from './resolvers/favicon.resolver';
 
 @NgModule({
@@ -37,7 +37,7 @@ import { FavIconResolver } from './resolvers/favicon.resolver';
         WidgetService,
         ConfigResolver,
         UserService,
-        UserPositionServices,
+        UserPositionService,
         FavIconResolver
     ],
 })

--- a/admin/src/main/ts/src/app/core/store/models/structure.model.ts
+++ b/admin/src/main/ts/src/app/core/store/models/structure.model.ts
@@ -6,7 +6,7 @@ import { ApplicationCollection } from '../collections/application.collection';
 import { ConnectorCollection } from '../collections/connector.collection';
 import { WidgetCollection } from '../collections/widget.collection';
 import { UserPosition } from './userPosition.model';
-import { UserPositionServices } from '../../services/user-position.service';
+import { UserPositionService } from '../../services/user-position.service';
 
 export type ClassModel = { id: string, name: string };
 
@@ -126,7 +126,7 @@ export class StructureModel extends Model<StructureModel> {
 
     syncPositions(force?: boolean) {
         if (this.userPositions.length < 1 || force === true) {
-            const userPositionServices = new UserPositionServices();
+            const userPositionServices = new UserPositionService();
             return userPositionServices.searchUserPositions({structureId: this.id})
                 .then(res => {
                     this.userPositions = res;

--- a/admin/src/main/ts/src/app/management/management-root/management-root.component.ts
+++ b/admin/src/main/ts/src/app/management/management-root/management-root.component.ts
@@ -9,6 +9,7 @@ import {CalendarService} from '../calendar/calendar.service';
 import {ImportEDTReportsService} from '../import-edt/import-edt-reports.service';
 import { Session } from 'src/app/core/store/mappings/session';
 import { SessionModel } from 'src/app/core/store/models/session.model';
+import { UserPositionService } from 'src/app/core/services/user-position.service';
 
 @Component({
     selector: 'ode-management-root',
@@ -41,7 +42,8 @@ export class ManagementRootComponent extends OdeComponent implements OnInit, OnD
     private displayCalendar: boolean;
 
     constructor(injector: Injector, private zimbraService: ZimbraService, private subjectsService: SubjectsService,
-                private calendarService: CalendarService, private importEDTReportsService: ImportEDTReportsService) {
+                private calendarService: CalendarService, private importEDTReportsService: ImportEDTReportsService,
+                private userPositionService: UserPositionService) {
         super(injector);
     }
 
@@ -51,6 +53,7 @@ export class ManagementRootComponent extends OdeComponent implements OnInit, OnD
         this.subjectsTabEnable();
         this.edtTabEnable();
         this.calendarTabEnable();
+        this.userPositionsTabEnable();
         this.tabEnable("gar", false);
         this.changeDetector.markForCheck();
         // Watch selected structure
@@ -114,6 +117,13 @@ export class ManagementRootComponent extends OdeComponent implements OnInit, OnD
         this.calendarService.getCalendarConfKey().subscribe((conf) => {
             this.displayCalendar = conf.displayCalendar;
             this.tabEnable("calendar", this.displayCalendar);
+        });
+    }
+
+    userPositionsTabEnable(): void {
+        /* Remove UserPosition tab if the config restricts its use */
+        this.userPositionService.isTabEnabled().subscribe(enabled => {
+            this.tabEnable("positions", enabled);
         });
     }
 

--- a/admin/src/main/ts/src/app/management/structure-user-positions/structure-user-position/structure-user-position.component.ts
+++ b/admin/src/main/ts/src/app/management/structure-user-positions/structure-user-position/structure-user-position.component.ts
@@ -7,7 +7,7 @@ import {
 } from "@angular/core";
 import { OdeComponent } from "ngx-ode-core";
 import { UserPosition } from "src/app/core/store/models/userPosition.model";
-import { UserPositionServices } from "src/app/core/services/user-position.service";
+import { UserPositionService } from "src/app/core/services/user-position.service";
 import { MatDialog } from "@angular/material/dialog";
 import { BundlesService } from "ngx-ode-sijil";
 import { NotifyService } from "src/app/core/services/notify.service";
@@ -36,7 +36,7 @@ export class StructureUserPositionComponent extends OdeComponent {
 
   constructor(
     injector: Injector,
-    private userPositionServices: UserPositionServices,
+    private userPositionServices: UserPositionService,
     private ns: NotifyService,
     private bundles: BundlesService,
     public dialog: MatDialog

--- a/admin/src/main/ts/src/app/management/structure-user-positions/structure-user-positions.component.ts
+++ b/admin/src/main/ts/src/app/management/structure-user-positions/structure-user-positions.component.ts
@@ -6,7 +6,7 @@ import { SessionModel } from "src/app/core/store/models/session.model";
 import { UserPosition } from "src/app/core/store/models/userPosition.model";
 import { routing } from "src/app/core/services/routing.service";
 import { Data } from "@angular/router";
-import { UserPositionServices } from "src/app/core/services/user-position.service";
+import { UserPositionService } from "src/app/core/services/user-position.service";
 import { Location } from "@angular/common";
 import { MatDialog } from "@angular/material/dialog";
 
@@ -42,7 +42,7 @@ export class StructureUserPositionsComponent
   constructor(
     injector: Injector,
     private location: Location,
-    private userPositionServices: UserPositionServices,
+    private userPositionServices: UserPositionService,
     public dialog: MatDialog
   ) {
     super(injector);

--- a/admin/src/main/ts/src/app/users/create/user-create.component.html
+++ b/admin/src/main/ts/src/app/users/create/user-create.component.html
@@ -81,13 +81,13 @@
                   height="100"
                   src="/admin/public/img/user-position-empty-screen.svg"
                 />
-                <ng-container *ngIf="isUserPositionCrudAllowed">
-                  <s5l>user-position.input-name.not-found</s5l>
-                  <button type="button" (click)="showPositionCreation()">
-                    <s5l>user-position.add</s5l>
-                    <i class="fa fa-plus-circle is-size-5"></i>
-                  </button>
-                </ng-container>
+                <s5l>{{isUserPositionCrudAllowed ? 'user-position.input-name.not-found' : 'portal.no.result'}}</s5l>
+                <button *ngIf="isUserPositionCrudAllowed"
+                        type="button"
+                        (click)="showPositionCreation()">
+                  <s5l>user-position.add</s5l>
+                  <i class="fa fa-plus-circle is-size-5"></i>
+                </button>
               </div>
             </div>
           </ode-lightbox>

--- a/admin/src/main/ts/src/app/users/create/user-create.component.html
+++ b/admin/src/main/ts/src/app/users/create/user-create.component.html
@@ -81,11 +81,13 @@
                   height="100"
                   src="/admin/public/img/user-position-empty-screen.svg"
                 />
-                <s5l>user-position.input-name.not-found</s5l>
-                <button type="button" (click)="showPositionCreation()">
-                  <s5l>user-position.add</s5l>
-                  <i class="fa fa-plus-circle is-size-5"></i>
-                </button>
+                <ng-container *ngIf="isUserPositionCrudAllowed">
+                  <s5l>user-position.input-name.not-found</s5l>
+                  <button type="button" (click)="showPositionCreation()">
+                    <s5l>user-position.add</s5l>
+                    <i class="fa fa-plus-circle is-size-5"></i>
+                  </button>
+                </ng-container>
               </div>
             </div>
           </ode-lightbox>

--- a/admin/src/main/ts/src/app/users/details/sections/user-positions/user-positions-section.component.html
+++ b/admin/src/main/ts/src/app/users/details/sections/user-positions/user-positions-section.component.html
@@ -37,13 +37,12 @@
           height="100"
           src="/admin/public/img/user-position-empty-screen.svg"
         />
-        <ng-container *ngIf="isUserPositionCrudAllowed">
-          <s5l>user-position.input-name.not-found</s5l>
-          <button (click)="openUserPositionCreationModal()">
-            <s5l>user-position.add</s5l>
-            <i class="fa fa-plus-circle is-size-5"></i>
-          </button>
-        </ng-container>
+        <s5l>{{isUserPositionCrudAllowed ? 'user-position.input-name.not-found' : 'portal.no.result'}}</s5l>
+        <button *ngIf="isUserPositionCrudAllowed" 
+                (click)="openUserPositionCreationModal()">
+          <s5l>user-position.add</s5l>
+          <i class="fa fa-plus-circle is-size-5"></i>
+        </button>
       </div>
     </div>
   </ode-lightbox>

--- a/admin/src/main/ts/src/app/users/details/sections/user-positions/user-positions-section.component.html
+++ b/admin/src/main/ts/src/app/users/details/sections/user-positions/user-positions-section.component.html
@@ -37,11 +37,13 @@
           height="100"
           src="/admin/public/img/user-position-empty-screen.svg"
         />
-        <s5l>user-position.input-name.not-found</s5l>
-        <button (click)="openUserPositionCreationModal()">
-          <s5l>user-position.add</s5l>
-          <i class="fa fa-plus-circle is-size-5"></i>
-        </button>
+        <ng-container *ngIf="isUserPositionCrudAllowed">
+          <s5l>user-position.input-name.not-found</s5l>
+          <button (click)="openUserPositionCreationModal()">
+            <s5l>user-position.add</s5l>
+            <i class="fa fa-plus-circle is-size-5"></i>
+          </button>
+        </ng-container>
       </div>
     </div>
   </ode-lightbox>

--- a/common/src/main/java/org/entcore/common/user/position/UserPositionService.java
+++ b/common/src/main/java/org/entcore/common/user/position/UserPositionService.java
@@ -7,6 +7,9 @@ import org.entcore.common.user.UserInfos;
 import java.util.Set;
 
 public interface UserPositionService {
+	/** Check if CRUD operations are restricted to ADMC. */
+	Boolean isCrudRestrictedToADMC();
+
 	/**
 	 * Retrieve user positions linked to structures the user or admin is attached to.
 	 * @return the retrieved user positions

--- a/common/src/main/java/org/entcore/common/user/position/UserPositionService.java
+++ b/common/src/main/java/org/entcore/common/user/position/UserPositionService.java
@@ -7,9 +7,6 @@ import org.entcore.common.user.UserInfos;
 import java.util.Set;
 
 public interface UserPositionService {
-	/** Check if CRUD operations are restricted to ADMC. */
-	Boolean isCrudRestrictedToADMC();
-
 	/**
 	 * Retrieve user positions linked to structures the user or admin is attached to.
 	 * @return the retrieved user positions

--- a/directory/deployment/directory/conf.j2
+++ b/directory/deployment/directory/conf.j2
@@ -64,6 +64,9 @@
                 {% if disabledFederatedAdress is defined %}
                 "disabledFederatedAdress": {{ disabledFederatedAdress }},
                 {% endif %}
+                "userPosition": {
+                    "restrictCRUDToADMC":{{ restrictCRUDToADMC|default('false') }}
+                },
                 "xiti": {
                     "ID_SERVICE": {
                         "default": 2,

--- a/directory/src/main/java/org/entcore/directory/Directory.java
+++ b/directory/src/main/java/org/entcore/directory/Directory.java
@@ -91,7 +91,13 @@ public class Directory extends BaseServer {
 		SchoolService schoolService = new DefaultSchoolService(eb).setListUserMode(config.getString("listUserMode", "multi"));
 		GroupService groupService = new DefaultGroupService(eb);
 		SubjectService subjectService = new DefaultSubjectService(eb);
-		UserPositionService userPositionService = new DefaultUserPositionService(eb);
+		final JsonObject emptyJsonObject = new JsonObject();
+		UserPositionService userPositionService = new DefaultUserPositionService(eb)
+			.restrictCrudToADMC( config
+			.getJsonObject("publicConf", emptyJsonObject)
+			.getJsonObject("userPosition", emptyJsonObject)
+			.getBoolean("restrictCRUDToADMC", false)
+		);
 		ConversationNotification conversationNotification = new ConversationNotification(vertx, eb, config);
 
 		DirectoryController directoryController = new DirectoryController();

--- a/directory/src/main/java/org/entcore/directory/Directory.java
+++ b/directory/src/main/java/org/entcore/directory/Directory.java
@@ -94,10 +94,10 @@ public class Directory extends BaseServer {
 		final JsonObject emptyJsonObject = new JsonObject();
 		UserPositionService userPositionService = new DefaultUserPositionService(eb)
 			.restrictCrudToADMC( config
-			.getJsonObject("publicConf", emptyJsonObject)
-			.getJsonObject("userPosition", emptyJsonObject)
-			.getBoolean("restrictCRUDToADMC", false)
-		);
+				.getJsonObject("publicConf", emptyJsonObject)
+				.getJsonObject("userPosition", emptyJsonObject)
+				.getBoolean("restrictCRUDToADMC", false)
+			);
 		ConversationNotification conversationNotification = new ConversationNotification(vertx, eb, config);
 
 		DirectoryController directoryController = new DirectoryController();
@@ -106,7 +106,6 @@ public class Directory extends BaseServer {
 		directoryController.setUserService(userService);
 		directoryController.setGroupService(groupService);
 		directoryController.setSlotProfileService(new DefaultSlotProfileService(SLOTPROFILE_COLLECTION));
-		directoryController.setUserPositionService(userPositionService);
 		addController(directoryController);
 		vertx.setTimer(5000l, event -> directoryController.createSuperAdmin());
 
@@ -135,7 +134,6 @@ public class Directory extends BaseServer {
 		userController.setNotification(timeline);
 		userController.setUserBookService(userBookService);
 		userController.setUserService(userService);
-		userController.setUserPositionService(userPositionService);
 		addController(userController);
 
 		ProfileController profileController = new ProfileController();

--- a/directory/src/main/java/org/entcore/directory/Directory.java
+++ b/directory/src/main/java/org/entcore/directory/Directory.java
@@ -92,12 +92,11 @@ public class Directory extends BaseServer {
 		GroupService groupService = new DefaultGroupService(eb);
 		SubjectService subjectService = new DefaultSubjectService(eb);
 		final JsonObject emptyJsonObject = new JsonObject();
-		UserPositionService userPositionService = new DefaultUserPositionService(eb)
-			.restrictCrudToADMC( config
-				.getJsonObject("publicConf", emptyJsonObject)
-				.getJsonObject("userPosition", emptyJsonObject)
-				.getBoolean("restrictCRUDToADMC", false)
-			);
+		UserPositionService userPositionService = new DefaultUserPositionService(eb, config
+			.getJsonObject("publicConf", emptyJsonObject)
+			.getJsonObject("userPosition", emptyJsonObject)
+			.getBoolean("restrictCRUDToADMC", false)
+		);
 		ConversationNotification conversationNotification = new ConversationNotification(vertx, eb, config);
 
 		DirectoryController directoryController = new DirectoryController();

--- a/directory/src/main/java/org/entcore/directory/controllers/DirectoryController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/DirectoryController.java
@@ -72,7 +72,6 @@ public class DirectoryController extends BaseController {
 	private UserService userService;
 	private GroupService groupService;
 	private SlotProfileService slotProfileService;
-	private UserPositionService userPositionService;
 	private EventStore eventStore;
 
 	public void init(Vertx vertx, JsonObject config, RouteMatcher rm,
@@ -666,10 +665,6 @@ public class DirectoryController extends BaseController {
 
 	public void setSlotProfileService (SlotProfileService slotProfileService) {
 		this.slotProfileService = slotProfileService;
-	}
-
-	public void setUserPositionService(UserPositionService userPositionService) {
-		this.userPositionService = userPositionService;
 	}
 
 	// Methods used to create Workflow rights

--- a/directory/src/main/java/org/entcore/directory/controllers/UserController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/UserController.java
@@ -61,7 +61,6 @@ import org.entcore.directory.pojo.TransversalSearchType;
 import org.entcore.directory.pojo.Users;
 import org.entcore.directory.security.*;
 import org.entcore.directory.services.UserBookService;
-import org.entcore.common.user.position.UserPositionService;
 import org.entcore.directory.services.UserService;
 import org.vertx.java.core.http.RouteMatcher;
 
@@ -87,7 +86,6 @@ public class UserController extends BaseController {
 	static final String MOOD_RESOURCE_NAME = "mood";
 	private UserService userService;
 	private UserBookService userBookService;
-	private UserPositionService userPositionService;
 	private TimelineHelper notification;
 	private static final int MOTTO_MAX_LENGTH = 75;
 	private final EventHelper eventHelper;
@@ -1190,10 +1188,6 @@ public class UserController extends BaseController {
 
 	public void setUserBookService(UserBookService userBookService) {
 		this.userBookService = userBookService;
-	}
-
-	public void setUserPositionService(UserPositionService userPositionService) {
-		this.userPositionService = userPositionService;
 	}
 
 	public void setNotification(TimelineHelper notification) {

--- a/feeder/src/main/java/org/entcore/feeder/Feeder.java
+++ b/feeder/src/main/java/org/entcore/feeder/Feeder.java
@@ -189,7 +189,7 @@ public class Feeder extends BusModBase implements Handler<Message<JsonObject>> {
 			}
 		}
 
-		manual = new ManualFeeder(neo4j, eb, new DefaultUserPositionService(eb));
+		manual = new ManualFeeder(neo4j, eb, new DefaultUserPositionService(eb, false));
 		duplicateUsers = new DuplicateUsers(config.getBoolean("timetable", true),
 				config.getBoolean("autoMergeOnlyInSameStructure", true), vertx.eventBus());
 		postImport = new PostImport(vertx, duplicateUsers, config);

--- a/portal/src/main/resources/i18n/fr.json
+++ b/portal/src/main/resources/i18n/fr.json
@@ -161,6 +161,7 @@
   "collaborativeeditor": "Pad",
   "collaborativewall": "Mur Collaboratif",
   "comment": "Commenter",
+  "common.service.admc-only": "Ce service est réservé aux administrateurs en console.",
   "community": "Communautés",
   "competences": "Evaluations",
   "contactbook": "Cahier de liaison",


### PR DESCRIPTION
# Description

Ajout d'une conf plateforme pour empêcher les ADML de créer/modifier/supprimer des nouvelles fonctions (UserPosition)
* Vérification de la valeur du paramètre côté back avant tout CRUD
* Côté front, si la conf est activée :
  * Boutons de création masqués
  * Onglet de management masqué
  * Les ADML multi-établissement ne peuvent plus voir que les fonctions de l'établissement courant.

Les ADML peuvent toujours affecter et retirer des fonctions parmi celles qui existent dans leur établissement.

+ code cleanup

## Fixes

[WB-3374](https://edifice-community.atlassian.net/browse/WB-3374)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [X] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [X] common
- [ ] communication
- [ ] conversation
- [X] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Manual tests only

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley:

[WB-3374]: https://edifice-community.atlassian.net/browse/WB-3374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ