### PR TITLE
fix(tests): #SUPPORT-1264, fix integrationTests

### DIFF
--- a/tests/src/main/scala/org/entcore/test/scenarios/AuthScenario.scala
+++ b/tests/src/main/scala/org/entcore/test/scenarios/AuthScenario.scala
@@ -33,7 +33,7 @@ object AuthScenario {
     .exec(http("Get OAuth2 code with disconnected user")
       .get("/auth/oauth2/auth?response_type=code&state=blip&scope=userinfo&client_id=test" +
         AppRegistryScenario.now + "&redirect_uri=http%3A%2F%2Flocalhost%3A1500%2Fcode")
-      .check(status.is(200)))
+      .check(status.is(302)))
     .exec(http("User login for OAuth2")
       .post("""/auth/login""")
       .formParam("""email""", """${teacherLogin}""")


### PR DESCRIPTION
# Description

Le test d'inté "Auth Scenario / Get OAuth2 code with disconnected user" est en erreur lors d'une exécution sur SB local.
Le message remonté est "status.find.is(200), but actually found 302"

A priori, il s'agirait d'un effet de bord du traitement du ticket "support 1264". 
@dbreyton , tu confirmes ? Cette PR serait alors un fix possible.


## Fixes

[SUPPORT-1264](https://edifice-community.atlassian.net/browse/SUPPORT-1264)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [X] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley:

[SUPPORT-1264]: https://edifice-community.atlassian.net/browse/SUPPORT-1264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ