### PR TITLE
[EDIFICE] Do not try to parse body when no body is present

### DIFF
--- a/directory/src/main/java/org/entcore/directory/security/DirectoryResourcesProvider.java
+++ b/directory/src/main/java/org/entcore/directory/security/DirectoryResourcesProvider.java
@@ -452,15 +452,24 @@ public class DirectoryResourcesProvider implements ResourcesProvider {
 			handler.handle(true);
 			return;
 		}
-		bodyToJson(request, body -> {
-			// If the requester is an ADML and the target user is also an ADML, allow the update to proceed iff the requester
-			// wants to update the allowed fields specified in fieldsUpdatableByADMLOnOtherADML
-      final boolean admlCanUpdateADML =
-        body != null &&
-				fieldsUpdatableByADMLOnOtherADML.containsAll(body.fieldNames());
-      adminOrTeacher(request, user, admlCanUpdateADML, handler);
-    }
-    );
+		final HttpMethod requestMethod = request.method();
+		switch (requestMethod) {
+			case POST:
+			case PUT:
+			case PATCH:
+				bodyToJson(request, body -> {
+						// If the requester is an ADML and the target user is also an ADML, allow the update to proceed iff the requester
+						// wants to update the allowed fields specified in fieldsUpdatableByADMLOnOtherADML
+						final boolean admlCanUpdateADML =
+							body != null &&
+								fieldsUpdatableByADMLOnOtherADML.containsAll(body.fieldNames());
+						adminOrTeacher(request, user, admlCanUpdateADML, handler);
+					}
+				);
+				break;
+			default:
+				adminOrTeacher(request, user, false, handler);
+		}
 	}
 
 	private void adminOrTeacher(final HttpServerRequest request, final UserInfos user, boolean admlCanUpdateADML, final Handler<Boolean> handler) {


### PR DESCRIPTION
# Description

La récupération des données userBook des utilisateurs depuis un compte ADML ne fonctionnait plus depuis [ce commit](https://github.com/edificeio/entcore/commit/1756a563317a8d4d7251cb13923a2d667000076b) car on tentait de récupérer le corps de la requête en JSON. Cependant, pour certaines requêtes il n'y a pas de corps et notamment pour celle de récupération des informations userBook. 

## Fixes

[WB-3376](https://edifice-community.atlassian.net/browse/WB-3376)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [x] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Se connecter avec un ADML (et non pas un ADMC)
2. Appeler l'url /directory/userbook/{idUser}
3. Constater que l'on récupère bien des infos

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley:

[WB-3376]: https://edifice-community.atlassian.net/browse/WB-3376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ