### PR TITLE
fix : checking functions with not fully filled pseudo AAF format

### DIFF
--- a/common/src/main/java/org/entcore/common/user/position/UserPosition.java
+++ b/common/src/main/java/org/entcore/common/user/position/UserPosition.java
@@ -21,7 +21,7 @@ public class UserPosition {
 	 * Method providing a User Position built upon the Function codification
 	 * @param dollarEncodedFunction function codification separated with dollars
 	 *  - in AAF format :       [StructureExternalId]$[FunctionCode]$[FunctionName]$[PositionCode]$[PositionName]
-	 *  - in free CSV format :  [StructureExternalId]$[PositionName]
+	 *  - in free CSV format :  [StructureExternalId]$[PositionName] or [StructureExternalId]$$$$[PositionName]
 	 * @param source the source type of data feed
 	 * @return a User Position built upon Function information if possible
 	 */
@@ -36,7 +36,11 @@ public class UserPosition {
 			if (!"ENS".equals(functionCodification[1]) 
 				&& !"-".equals(functionCodification[1])
 				&& functionCodification.length > 4 ) {
-				userPosition = Optional.of(new UserPosition(null, functionCodification[2] + " / " + functionCodification[4], source, functionCodification[0]));
+				if (functionCodification[2].isEmpty()){
+					userPosition = Optional.of(new UserPosition(null, functionCodification[4], source, functionCodification[0]));
+				} else {
+					userPosition = Optional.of(new UserPosition(null, functionCodification[2] + " / " + functionCodification[4], source, functionCodification[0]));
+				}
 			}
 		}
 		return userPosition;

--- a/feeder/src/main/java/org/entcore/feeder/csv/CsvFeeder.java
+++ b/feeder/src/main/java/org/entcore/feeder/csv/CsvFeeder.java
@@ -688,8 +688,8 @@ public class CsvFeeder implements Feed {
 				String name = null;
 
 				String [] g = ((String) o).split("\\$");
-				// Function Groups are created only for functions matching aaf format
-				if (g.length != 2) {
+				// Function Groups are created only for functions matching fully filled aaf format
+				if (g.length != 2 && !g[2].isEmpty()) {
 					if (g.length == 5) {
 						if ("ENS".equals(g[1])) {
 							groupExternalId = structure.getExternalId() + "$" + g[3];

--- a/tests/src/test/js/it/scenarios/position/csv-import.js
+++ b/tests/src/test/js/it/scenarios/position/csv-import.js
@@ -58,7 +58,8 @@ export function testUserPositionsFromCSVImport() {
                 'DIRECTION / CHEF D\'ETABLISSEMENT ADJOINT',
                 'Fonction qui ne sera plus attribuée',
                 'Fonction qui restera attribuée',
-                'Ma nouvelle fonction'
+                'Ma nouvelle fonction',
+                'Fonction au format AAF via import CSV'
             ], session)
             const users = getUsersOfSchool(structure, session);
             const expectedValues = [
@@ -66,7 +67,8 @@ export function testUserPositionsFromCSVImport() {
               ['A001', 'User with a position which stayed', ['Fonction qui restera attribuée']],
               ['A002', 'User with new position', ['Ma nouvelle fonction']],
               ['A003', 'User with no positions att all', []],
-              ['A004', 'New user with no positions att all', []]
+              ['A004', 'New user with no positions att all', []],
+              ['A005', 'User with a position with AAF format from CSV import', ['Fonction au format AAF via import CSV']]
             ]
             checkUserAndPositions(expectedValues, users, session)
         })

--- a/tests/src/test/js/it/scenarios/position/csv-import.js
+++ b/tests/src/test/js/it/scenarios/position/csv-import.js
@@ -68,7 +68,7 @@ export function testUserPositionsFromCSVImport() {
               ['A002', 'User with new position', ['Ma nouvelle fonction']],
               ['A003', 'User with no positions att all', []],
               ['A004', 'New user with no positions att all', []],
-              ['A005', 'User with a position with AAF format from CSV import', ['Fonction au format AAF via import CSV']]
+              ['A005', 'User with not fully filled AAF format from CSV import', ['Fonction au format AAF via import CSV']]
             ]
             checkUserAndPositions(expectedValues, users, session)
         })

--- a/tests/src/test/resources/data/positions/csv/after/enseignants.csv
+++ b/tests/src/test/resources/data/positions/csv/after/enseignants.csv
@@ -4,3 +4,4 @@
 "M.";;"A002";"A002";;;;;;;;"non";"MS";"Ma nouvelle fonction"
 "M.";;"A003";"A003";;;;;;;;"non";"GS";
 "M.";;"A004";"A004";;;;;;;;"non";"GS";
+"M.";;"A005";"A005";;;;;;;;"non";"GS";"$$$Fonction au format AAF via import CSV"


### PR DESCRIPTION
# Description

Lors d'un import CSV, les fonctions au "format libre" sont en fait converties dans des étapes préliminaires à l'import en un format pseudo-AAF (séparateur avec des dollars mais informations vides : $$$[FunctionName]).
On prend désormais également ce cas en compte dans l'implémentation.

Cela corrige aussi le problème lié de la création des groupes de fonction pour les seuls formats AAF complets.

## Fixes

https://edifice-community.atlassian.net/browse/WB-3409
https://edifice-community.atlassian.net/browse/WB-3417

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [x] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [x] tests
- [ ] timeline
- [ ] workspace

## Tests

Updated integration tests and manual tests performed

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: