### PR TITLE
feat(admin): #WB-3416, limit aafFunctions filter to ENS functions

### DIFF
--- a/admin/src/main/resources/i18n/fr.json
+++ b/admin/src/main/resources/i18n/fr.json
@@ -426,7 +426,7 @@
   "code.multi.combo.title": "Activation",
   "classes.multi.combo.title": "Classes",
   "sources.multi.combo.title": "Sources",
-  "functions.multi.combo.title": "Fonctions & matières",
+  "functions.multi.combo.title": "Matières",
   "functionalGroups.multi.combo.title": "Groupes d'enseignement",
   "adml.multi.combo.title": "Administrateurs locaux",
   "blocked.multi.combo.title": "Blocage",

--- a/admin/src/main/ts/src/app/core/services/userlist.filters.service.ts
+++ b/admin/src/main/ts/src/app/core/services/userlist.filters.service.ts
@@ -277,6 +277,7 @@ export class UserlistFiltersService {
     private functionalGroupsFilter = new FunctionalGroupsFilter(this.$updateSubject);
     private manualGroupsFilter = new ManualGroupsFilter(this.$updateSubject);
     private activationFilter = new ActivationFilter(this.$updateSubject);
+    private positionFilter = new PositionFilter(this.$updateSubject);
     private functionsFilter = new FunctionsFilter(this.$updateSubject);
     private sourcesFilter = new SourcesFilter(this.$updateSubject);
     private duplicatesFilter = new DuplicatesFilter(this.$updateSubject);
@@ -285,7 +286,6 @@ export class UserlistFiltersService {
     private dateFilter = new DateFilter(this.$updateSubject);
     private deleteFilter = new DeleteFilter(this.$updateSubject);
     private blockedFilter = new BlockedFilter(this.$updateSubject);
-    private positionFilter = new PositionFilter(this.$updateSubject);
 
     filters: UserFilterList<any> = [
         this.profileFilter,
@@ -293,6 +293,7 @@ export class UserlistFiltersService {
         this.functionalGroupsFilter,
         this.manualGroupsFilter,
         this.activationFilter,
+        this.positionFilter,
         this.functionsFilter,
         this.sourcesFilter,
         this.duplicatesFilter,
@@ -300,8 +301,7 @@ export class UserlistFiltersService {
         this.admlFilter,
         this.dateFilter,
         this.deleteFilter,
-        this.blockedFilter,
-        this.positionFilter
+        this.blockedFilter
     ];
 
     resetFilters() {

--- a/admin/src/main/ts/src/app/users/users-list/users-list.component.ts
+++ b/admin/src/main/ts/src/app/users/users-list/users-list.component.ts
@@ -67,7 +67,10 @@ export class UsersListComponent extends OdeComponent {
         const filterAafFunctions: Array<Array<string>> = [];
         structure.aafFunctions.forEach(structureAafFunctions => {
             structureAafFunctions.forEach(structureAafFunction => {
-                if (!includes(filterAafFunctions, [structureAafFunction[2], structureAafFunction[4]])) {
+                // WB-3416 Only keep "enseignement" groups (a.k.a. DisciplineGroup)
+                if ("ENS" == structureAafFunction[1] &&
+                    !includes(filterAafFunctions, [structureAafFunction[2], structureAafFunction[4]])
+                ) {
                     filterAafFunctions.push([structureAafFunction[2], structureAafFunction[4]]);
                 }
             });


### PR DESCRIPTION
# Description

Suite au chantier fonctions, le filtre utilisateur "Fonctions et matières" doit présenter les matières uniquement.
- On le renomme en conséquence
- On limite son contenu aux seules "matières" (clé ENS dans les AAFs)
- On déplace le nouveau filtre "Fonctions" à proximité de "Matières" afin que les end-users s'y retrouvent facilement. 

## Fixes

[WB-3416](https://edifice-community.atlassian.net/browse/WB-3416)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [X] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley:

[WB-3416]: https://edifice-community.atlassian.net/browse/WB-3416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ