### PR TITLE
fix : detaching aaf positions before aaf import

### DIFF
--- a/feeder/src/main/java/org/entcore/feeder/aaf/PersonnelImportProcessing.java
+++ b/feeder/src/main/java/org/entcore/feeder/aaf/PersonnelImportProcessing.java
@@ -65,7 +65,7 @@ public class PersonnelImportProcessing extends BaseImportProcessing {
 		createGroups(object.getJsonArray("groups"), c, null);
 		createClasses(new fr.wseduc.webutils.collections.JsonArray(c));
 		createFunctionGroups(object.getJsonArray("functions"), null);
-		createPositions(object.getJsonArray("functions"));
+		cleanAndCreatePositions(object.getJsonArray("structures"), object.getJsonArray("functions"), object.getString("externalId"));
 		createHeadTeacherGroups(object.getJsonArray("headTeacher"), null);
 		createDirectionGroups(object.getJsonArray("direction"), null);
 		linkMef(object.getJsonArray("modules"));
@@ -165,7 +165,18 @@ public class PersonnelImportProcessing extends BaseImportProcessing {
 		return linkStructureClasses;
 	}
 
-	protected void createPositions(JsonArray functions) {
+	protected void cleanAndCreatePositions(JsonArray structureExternalIds, JsonArray functions, String userExternalId) {
+		// clean user's positions
+		if (structureExternalIds != null) {
+			structureExternalIds.stream()
+					.filter(structureId -> structureId instanceof String)
+					.map(structureId -> (String) structureId)
+					.forEach(structureExternalId -> {
+						ImporterStructure structure = importer.getStructure(structureExternalId);
+						structure.detachUserFromItsPositions(userExternalId, UserPositionSource.AAF);
+					});
+		}
+		// create positions
 		if (functions != null) {
 			functions.stream()
 					.filter(function -> function instanceof String)

--- a/feeder/src/main/java/org/entcore/feeder/aaf/PersonnelImportProcessing2.java
+++ b/feeder/src/main/java/org/entcore/feeder/aaf/PersonnelImportProcessing2.java
@@ -70,7 +70,7 @@ public class PersonnelImportProcessing2 extends PersonnelImportProcessing {
 			structuresByFunctions = new fr.wseduc.webutils.collections.JsonArray(new ArrayList<>(s));
 		}
 		createFunctionGroups(object.getJsonArray("functions"), groups);
-		createPositions(object.getJsonArray("functions"));
+		cleanAndCreatePositions(object.getJsonArray("structures"), object.getJsonArray("functions"), object.getString("externalId"));
 		createHeadTeacherGroups(object.getJsonArray("headTeacher"), groups);
 		createDirectionGroups(object.getJsonArray("direction"), groups);
 		importer.createOrUpdatePersonnel(object, detectProfile(object), structuresByFunctions,

--- a/feeder/src/main/java/org/entcore/feeder/aaf1d/PersonnelImportProcessing1d.java
+++ b/feeder/src/main/java/org/entcore/feeder/aaf1d/PersonnelImportProcessing1d.java
@@ -105,7 +105,7 @@ public class PersonnelImportProcessing1d extends PersonnelImportProcessing {
 		JsonArray functions = object.getJsonArray("functions");
 		createDirectionGroups(object.getJsonArray("direction"), groups);
 		getDirectionOrFunctionFromFunctions(functions, groups);
-		createPositions(functions);
+		cleanAndCreatePositions(object.getJsonArray("structures"), functions, externalId);
 		JsonArray structuresByFunctions = null;
 		if (functions != null) {
 			Set<String> s = new HashSet<>();

--- a/feeder/src/main/java/org/entcore/feeder/csv/CsvFeeder.java
+++ b/feeder/src/main/java/org/entcore/feeder/csv/CsvFeeder.java
@@ -723,7 +723,7 @@ public class CsvFeeder implements Feed {
 	private void cleanAndCreateUserPositions(ImporterStructure structure, JsonObject user) {
 		String userExternalId = user.getString("externalId");
 		if (userExternalId != null) {
-			structure.detachUserFromItsPositions(userExternalId);
+			structure.detachUserFromItsPositions(userExternalId, null);
 		}
 		JsonArray functions = user.getJsonArray("functions");
 		if (functions != null) {

--- a/feeder/src/main/java/org/entcore/feeder/dictionary/structures/Structure.java
+++ b/feeder/src/main/java/org/entcore/feeder/dictionary/structures/Structure.java
@@ -256,8 +256,8 @@ public class Structure {
 		}
 	}
 
-	public void detachUserFromItsPositions(String userExternalId) {
-		DefaultUserPositionService.detachUserFromItsPositions(userExternalId, externalId, getTransaction());
+	public void detachUserFromItsPositions(String userExternalId, UserPositionSource source) {
+		DefaultUserPositionService.detachUserFromItsPositions(userExternalId, externalId, source, getTransaction());
 	}
 
 	public void createPosition(UserPosition userPosition) {
@@ -473,7 +473,7 @@ public class Structure {
 	{
 		TransactionHelper tx = TransactionManager.getInstance().getTransaction("GraphDataUpdate");
 		DefaultUserPositionService.detachSourcedUserPositionsFromStructure(
-			UserPositionSource.CSV, id, tx
+			UserPositionSource.CSV, externalId, tx
 		);
 	}
 


### PR DESCRIPTION
# Description

On détache toutes les fonctions AAF de chaque utilisateur avant de créer celles provenant du fichier en cours d'import.

À la fin de l'import, toutes les fonctions AAF  attachées à aucun utilisateur sont supprimées (déjà implémenté).

## Fixes

https://edifice-community.atlassian.net/browse/WB-3419

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [x] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Tests dev manuels & relance des tests d'intégration K6 associés

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: