### PR TITLE
fix(admin,common): #WB-3429, trim UserPosition names before saving

### DIFF
--- a/admin/src/main/ts/src/app/_shared/user-position-modal/user-position-modal.component.ts
+++ b/admin/src/main/ts/src/app/_shared/user-position-modal/user-position-modal.component.ts
@@ -29,8 +29,9 @@ export class UserPositionModalComponent extends OdeComponent implements OnInit {
     return this._userPosition;
   }
   @Input() set userPosition(value: UserPosition) {
+    this.editableName = value?.name?.trim();
     this._userPosition = value;
-    this.editableName = value?.name;
+    this._userPosition.name = this.editableName ?? "";
   }
   private _show: boolean = true;
   @Input() get show(): boolean {
@@ -71,7 +72,11 @@ export class UserPositionModalComponent extends OdeComponent implements OnInit {
 
   async save(): Promise<void> {
     if (this.saving) return;
+    this.editableName = this.editableName?.trim();
+    if(!this.editableName) return;
+
     this.saving = true;
+    
     if (this.isUpdateModal) {
       this.userPosition = await this.spinner
         .perform(

--- a/common/src/main/java/org/entcore/common/user/position/impl/DefaultUserPositionService.java
+++ b/common/src/main/java/org/entcore/common/user/position/impl/DefaultUserPositionService.java
@@ -157,17 +157,18 @@ public class DefaultUserPositionService implements UserPositionService {
 				logger.warn("The user tried to create a position on structure {0} but only can access structures {1}", structureId, adminStructureIds);
 				promise.fail("cannot.create.position.on.this.structure");
 			} else {
-				getPositionByNameInStructure(positionName, structureId, adminStructureIds).onSuccess(userPosition -> {
+				final String finalPositionName = positionName.trim();
+				getPositionByNameInStructure(finalPositionName, structureId, adminStructureIds).onSuccess(userPosition -> {
 					if (userPosition.isPresent()) {
 						promise.fail("position.already.exists:"+userPosition.get().getId());
 					} else {
-						final String simplifiedName = getSimplifiedString(positionName);
+						final String simplifiedName = getSimplifiedString(finalPositionName);
 						final JsonArray adminStructureArray = new JsonArray();
 						adminStructureIds.forEach(adminStructureArray::add);
 						final String positionId = UUID.randomUUID().toString();
 						final JsonObject userPositionProps = new JsonObject()
 								.put("id", positionId)
-								.put("name", positionName)
+								.put("name", finalPositionName)
 								.put("simplifiedName", simplifiedName)
 								.put("source", source.toString());
 						final JsonObject params = new JsonObject()


### PR DESCRIPTION
# Description

Il était possible de créer des doublons de UserPositions, en saisissant des espaces avant ou après leur nom.
Ce fix corrige la faille.

## Fixes

[Ticket WB-3429](https://edifice-community.atlassian.net/browse/WB-3429)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [X] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [X] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley: