### PR TITLE
fix : WB-3378, make motto visible among local admins

### DIFF
--- a/directory/src/main/java/org/entcore/directory/security/DirectoryResourcesProvider.java
+++ b/directory/src/main/java/org/entcore/directory/security/DirectoryResourcesProvider.java
@@ -468,7 +468,7 @@ public class DirectoryResourcesProvider implements ResourcesProvider {
 				);
 				break;
 			default:
-				adminOrTeacher(request, user, false, handler);
+				adminOrTeacher(request, user, true, handler);
 		}
 	}
 


### PR DESCRIPTION
# Description

An ADML can now access the userbook information of another ADML

## Fixes

Fixing an indirect problem discovered during the investigation on this : https://edifice-community.atlassian.net/browse/WB-3378

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [x] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: