### PR TITLE
fix(timeline): #WB-3683, prevent race condition when sending weekly and daily emails

### DIFF
--- a/timeline/src/main/java/org/entcore/timeline/services/impl/DefaultTimelineMailerService.java
+++ b/timeline/src/main/java/org/entcore/timeline/services/impl/DefaultTimelineMailerService.java
@@ -291,6 +291,7 @@ public class DefaultTimelineMailerService extends Renders implements TimelineMai
 	}
 
 	protected void sendDailyMails(Optional<Date> forDate, int dayDelta, final Handler<Either<String, JsonObject>> handler){
+		final DefaultTimelineMailerService that = this;
 		final HttpServerRequest request = new JsonHttpServerRequest(new JsonObject());
 		final AtomicInteger userPagination = new AtomicInteger(0);
 		final AtomicInteger endPage = new AtomicInteger(0);
@@ -398,7 +399,7 @@ public class DefaultTimelineMailerService extends Renders implements TimelineMai
 													.put("notificationDates", dates)
 													.put("displayName", userDisplayName);
 
-											processTimelineTemplate(templateParams, "", "notifications/daily-mail.html",
+											new DefaultTimelineMailerService(that).processTimelineTemplate(templateParams, "", "notifications/daily-mail.html",
 													userDomain, userScheme, userLanguage, false, new Handler<String>() {
 														public void handle(final String processedTemplate) {
 															//On completion : log
@@ -504,6 +505,7 @@ public class DefaultTimelineMailerService extends Renders implements TimelineMai
 	}
 
 	protected void sendWeeklyMails(Optional<Date> forDate, int dayDelta, final Handler<Either<String, JsonObject>> handler) {
+		final DefaultTimelineMailerService that = this;
 		final HttpServerRequest request = new JsonHttpServerRequest(new JsonObject());
 		final AtomicInteger userPagination = new AtomicInteger(0);
 		final AtomicInteger endPage = new AtomicInteger(0);
@@ -628,7 +630,7 @@ public class DefaultTimelineMailerService extends Renders implements TimelineMai
 											JsonObject templateParams = new JsonObject().put("notifications", weeklyNotificationsGroupedArray);
 											templateParams.put("displayName", userDisplayName);
 
-											processTimelineTemplate(templateParams, "", "notifications/weekly-mail.html",
+											new DefaultTimelineMailerService(that).processTimelineTemplate(templateParams, "", "notifications/weekly-mail.html",
 													userDomain, userScheme, userLanguage, false, new Handler<String>() {
 														public void handle(final String processedTemplate) {
 															//On completion : log


### PR DESCRIPTION
# Description

When sending daily and weekly emails, recreate the Renderer that will process timeline templates to prevent race condition causing language and theme mix up.

## Fixes

WB-3683

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [x] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: