### PR TITLE
Fix wb 3640 single has function after merging admls

### DIFF
--- a/tests/src/test/js/it/scenarios/position/crud.ts
+++ b/tests/src/test/js/it/scenarios/position/crud.ts
@@ -74,6 +74,13 @@ export const options = {
       maxDuration: "5s",
       gracefulStop: '1s'
     },
+    testGetPositionsAfterMergingAdml: {
+      exec: 'testGetPositionsAfterMergingAdml',
+      executor: "per-vu-iterations",
+      vus: 1,
+      maxDuration: "5s",
+      gracefulStop: '1s'
+    },
   },
 };
 

--- a/tests/src/test/js/it/scenarios/position/crud.ts
+++ b/tests/src/test/js/it/scenarios/position/crud.ts
@@ -437,24 +437,21 @@ export function testDeletePosition({structureTree}) {
 // structure of the resulting adml.
 // It covers the bugfix of WB-3640
 export function testGetPositionsAfterMergingAdml({structureTree}) {
-  const {structures: [structure1], admls: [adml1], headAdml} = structureTree
-  describe("", () => {
+  describe("[Position-CRUD] Get positions after merging adml", () => {
     authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD);
 
-    ////////////////////////////////////
-    // Create 2 ADML for structure 1
-    // and merge them
-    const admlToMerge1 = getAdmlsOrMakThem(structure1, 'Teacher', 1, [headAdml, adml1])[0]
-    const admlToMerge2 = getAdmlsOrMakThem(structure1, 'Teacher', 1, [headAdml, adml1, admlToMerge1])[0]
-
-    console.log("ID structure 1 : ", structure1.id)
-    console.log("ADML ids : ", admlToMerge1.id, " and ", admlToMerge2.id)
+    const structure = initStructure(`IT - WB-3640 - ${Date.now()}`, `tiny`)
+    const positionName = "position-3640"
+    createPosition(positionName, structure);
+    // Create 2 ADML for structure and merge them
+    const admlToMerge1 = getAdmlsOrMakThem(structure, 'Teacher', 1, [])[0]
+    const admlToMerge2 = getAdmlsOrMakThem(structure, 'Teacher', 1, [admlToMerge1])[0]
     mergeUsers(admlToMerge1.id, admlToMerge2.id, true)
 
     authenticateWeb(admlToMerge1.login)
-    let res = getPositionsOfStructure(structure1)
+    let res = getPositionsOfStructure(structure)
 
-    assertOk(res, "An ADML that has got merged with another ADML account should be able to retrieve the user positions of its structure.")
+    assertCondition(() => res.length === 1 && res[0].name === positionName, "The position created for the structure can be retrieved by the adml resulting from merge")
   })
 }
 

--- a/tests/src/test/js/it/scenarios/position/crud.ts
+++ b/tests/src/test/js/it/scenarios/position/crud.ts
@@ -436,22 +436,39 @@ export function testDeletePosition({structureTree}) {
 // then we still can correctly retrieve the positions related to the
 // structure of the resulting adml.
 // It covers the bugfix of WB-3640
-export function testGetPositionsAfterMergingAdml({structureTree}) {
+export function testGetPositionsAfterMergingAdml() {
   describe("[Position-CRUD] Get positions after merging adml", () => {
-    authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD);
-
-    const structure = initStructure(`IT - WB-3640 - ${Date.now()}`, `tiny`)
-    const positionName = "position-3640"
-    createPosition(positionName, structure);
-    // Create 2 ADML for structure and merge them
-    const admlToMerge1 = getAdmlsOrMakThem(structure, 'Teacher', 1, [])[0]
-    const admlToMerge2 = getAdmlsOrMakThem(structure, 'Teacher', 1, [admlToMerge1])[0]
-    mergeUsers(admlToMerge1.id, admlToMerge2.id, true)
-
-    authenticateWeb(admlToMerge1.login)
-    let res = getPositionsOfStructure(structure)
-
-    assertCondition(() => res.length === 1 && res[0].name === positionName, "The position created for the structure can be retrieved by the adml resulting from merge")
+    describe("Merging ADML from same structure", () => {
+      authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD);
+      const commonStructure = initStructure(`IT-common-WB-3640-${Date.now()}`, `tiny`)
+      const positionName = "position-3640"
+      createPosition(positionName, commonStructure)
+      // Create 2 ADML for common structure and merge them
+      const admlToMerge1 = getAdmlsOrMakThem(commonStructure, 'Teacher', 1, [])[0]
+      const admlToMerge2 = getAdmlsOrMakThem(commonStructure, 'Teacher', 1, [admlToMerge1])[0]
+      mergeUsers(admlToMerge1.id, admlToMerge2.id, true)
+  
+      authenticateWeb(admlToMerge1.login)
+      let res = getPositionsOfStructure(commonStructure)
+      assertCondition(() => res.length === 1 && res[0].name === positionName, "The position created for the common structure can be retrieved by the adml resulting from merge")  
+    });
+    describe("Merging ADML from different structures", () => {
+      authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD);
+      const structure1 = initStructure(`IT-1-WB-3640-${Date.now()}`, `tiny`)
+      const structure2 = initStructure(`IT-2-WB-3640-${Date.now()}`, `tiny`)
+      const positionName1 = "position-1-3640"
+      const positionName2 = "position-2-3640"
+      createPosition(positionName1, structure1)
+      createPosition(positionName2, structure2)
+      // Create 2 ADML for structures 1 and 2 and merge them
+      const admlToMerge1 = getAdmlsOrMakThem(structure1, 'Teacher', 1, [])[0]
+      const admlToMerge2 = getAdmlsOrMakThem(structure2, 'Teacher', 1, [])[0]
+      mergeUsers(admlToMerge1.id, admlToMerge2.id, true)
+  
+      authenticateWeb(admlToMerge1.login)
+      let res = getPositionsOfStructure(structure1)
+      assertCondition(() => res.length === 1 && res[0].name === positionName1, "The position created for the structure 1 can be retrieved by the adml resulting from merge")  
+    });
   })
 }
 

--- a/tests/src/test/js/it/scenarios/position/crud.ts
+++ b/tests/src/test/js/it/scenarios/position/crud.ts
@@ -23,7 +23,9 @@ import {
   switchSession,
   getPositionByIdOrFail,
   Session,
-  UserPosition
+  UserPosition,
+  mergeUsers,
+  getPositionsOfStructure
 } from "../../../node_modules/edifice-k6-commons/dist/index.js";
 
 
@@ -95,7 +97,7 @@ export function setup() {
     const suffix = __ENV.RECREATE_STRUCTURES === 'true' ? ` - ${Date.now()}` : ''
     structure = initStructure(`IT - Fonctions${suffix}`, 'tiny');
     let session = <Session>authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD);
-    adml = getAdmlsOrMakThem(structure, 'Teacher', 1, [], session)[0]
+    adml = getAdmlsOrMakThem(structure, 'Teacher', 1, [])[0]
 
 
     const schoolName = `IT Positions - NEtab`
@@ -105,15 +107,15 @@ export function setup() {
     const chapeau = initStructure(`Chapeau - ${schoolName}${suffix}`, 'tiny')
     const structure1 = initStructure(`1 - ${schoolName}${suffix}`, 'tiny')
     const structure2 = initStructure(`2 - ${schoolName}${suffix}`, 'tiny')
-    attachStructureAsChild(chapeau, structure1, session)
-    attachStructureAsChild(chapeau, structure2, session)
+    attachStructureAsChild(chapeau, structure1)
+    attachStructureAsChild(chapeau, structure2)
     ////////////////////////////////////
     // Create 1 ADML for each structure
     // and 1 ADML for the head structure
-    const megaAdml = getAdmlsOrMakThem(chapeau, 'Teacher', 1, [], session)[0]
-    const adml1 = getAdmlsOrMakThem(structure1, 'Teacher', 1, [megaAdml], session)[0]
-    const adml2 = getAdmlsOrMakThem(structure2, 'Teacher', 1, [megaAdml], session)[0]
-    attachUserToStructures(megaAdml, [structure1, structure2], session)
+    const megaAdml = getAdmlsOrMakThem(chapeau, 'Teacher', 1, [])[0]
+    const adml1 = getAdmlsOrMakThem(structure1, 'Teacher', 1, [megaAdml])[0]
+    const adml2 = getAdmlsOrMakThem(structure2, 'Teacher', 1, [megaAdml])[0]
+    attachUserToStructures(megaAdml, [structure1, structure2])
 
     structureTree = { head: chapeau, structures: [structure1, structure2], admls: [adml1, adml2], headAdml: megaAdml}
   });
@@ -133,37 +135,37 @@ export function testCreatePosition({structure, adml, structureTree}) {
   describe("[Position-CRUD] Create positions", () => {
     let session = <Session>authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD)
     const positionName = "IT Position - Create - " + Date.now();
-    const users = getUsersOfSchool(structure, session)
+    const users = getUsersOfSchool(structure)
     const teacher = getRandomUserWithProfile(users, 'Teacher', [adml]);
 
-    logout(session)
+    logout()
     let res = createPosition(positionName, structure);
     assertCondition(() => res.status === 401, "An unauthenticated user should not be able to create a position");
 
     session = <Session>authenticateWeb(teacher.login)
-    res = createPosition(positionName, structure, session);
+    res = createPosition(positionName, structure);
     assertCondition(() => res.status === 401, "An authenticated user without special rights should not be able to create a position");
 
 
     session = <Session>authenticateWeb(adml.login)
     let positions: UserPosition[] = []
-    res = createPosition(positionName, structure, session);
+    res = createPosition(positionName, structure);
     assertCondition(() => res.status === 201, "An ADML user should be able to create a position");
     positions.push(<UserPosition>JSON.parse(<string>res.body));
-    res = createPosition(positionName, structure, session);
+    res = createPosition(positionName, structure);
     checkReturnCode(res, "A position cannot be created multiple times", 409);
-    res = createPosition(`${positionName} - bis`, structure, session);
+    res = createPosition(`${positionName} - bis`, structure);
     positions.push(JSON.parse(<string>res.body));
-    //assertSearchCriteriaContainSpecifiedPositionsAndNotOther(positions, p => p.structureId !==  structure.id, "ADML with a structure with these positions", session);
+    //assertSearchCriteriaContainSpecifiedPositionsAndNotOther(positions, p => p.structureId !==  structure.id, "ADML with a structure with these positions");
     session = <Session>authenticateWeb(adml1.login)
 
-    res = createPosition(`${positionName}-ADML2`, structure, session);
+    res = createPosition(`${positionName}-ADML2`, structure);
     assertCondition(() => res.status === 401, "An ADML of another structure should not be able to create a position");
-    assertSearchCriteriaContainSpecifiedPositionsAndNotOther([], p => p.structureId !==  structure.id, "ADML in a structure without these positions", session);
+    assertSearchCriteriaContainSpecifiedPositionsAndNotOther([], p => p.structureId !==  structure.id, "ADML in a structure without these positions");
 
     // An ADMC should be able to create a position
     session = <Session>authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD);
-    createPositionOrFail(`${positionName}-ADMC`, structure1, session);
+    createPositionOrFail(`${positionName}-ADMC`, structure1);
 
     ////////////////////////////////////////////////////////////////////////////////
     // An ADML of multiple structures should be able to see the positions of all
@@ -173,12 +175,12 @@ export function testCreatePosition({structure, adml, structureTree}) {
     // created positions are accessible
     positions = []
     session = <Session>authenticateWeb(adml1.login);
-    positions.push(createPositionOrFail(`${positionName}-ADML1-0`, structure1, session));
-    positions.push(createPositionOrFail(`${positionName}-ADML1-1`, structure1, session));
+    positions.push(createPositionOrFail(`${positionName}-ADML1-0`, structure1));
+    positions.push(createPositionOrFail(`${positionName}-ADML1-1`, structure1));
     session = <Session>authenticateWeb(adml2.login);
-    positions.push(createPositionOrFail(`${positionName}-ADML2-0`, structure2, session));
+    positions.push(createPositionOrFail(`${positionName}-ADML2-0`, structure2));
     session = <Session>authenticateWeb(headAdml.login);
-    assertSearchCriteriaContainSpecifiedPositionsAndNotOther(positions, p => p.structureId ===  structure1.id || p.structureId ===  structure2.id, "ADML of multiple structures", session);
+    assertSearchCriteriaContainSpecifiedPositionsAndNotOther(positions, p => p.structureId ===  structure1.id || p.structureId ===  structure2.id, "ADML of multiple structures");
 })
 };
 
@@ -187,13 +189,13 @@ export function testRenamePosition({structure, adml, structureTree}) {
   const {admls: [adml1, adml2], structures: [structure1, structure2], headAdml} = structureTree
   describe("[Position-CRUD] Rename position", () => {
     let session = <Session>authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD);
-    const users1 = getUsersOfSchool(structure1, session)
+    const users1 = getUsersOfSchool(structure1)
     const unprivilegedUserOfStructure1 = getRandomUser(users1, [adml1, headAdml])
-    const users2 = getUsersOfSchool(structure2, session)
+    const users2 = getUsersOfSchool(structure2)
     const unprivilegedUserOfStructure2 = getRandomUser(users2, [adml2, headAdml])
     const adml1Session = <Session>authenticateWeb(adml1.login)
     const positionName = "IT Position - Rename - To rename" + Date.now();
-    const positionToRename = createPositionOrFail(positionName, structure1, adml1Session)
+    const positionToRename = createPositionOrFail(positionName, structure1)
     let previousName = positionName
     const usersThatCanRename: [Session, string][] = [
       [<Session>authenticateWeb(adml1.login), "ADML of administered structure"],
@@ -206,9 +208,9 @@ export function testRenamePosition({structure, adml, structureTree}) {
         switchSession(sessionToTry)
         const successfullRename = `${positionName} - renamed by ${label}`
         positionToRename.name = successfullRename
-        assertOk(updatePosition(positionToRename, session), `should be able to rename a position`)
+        assertOk(updatePosition(positionToRename), `should be able to rename a position`)
         switchSession(adml1Session)
-        let res = searchPositions(positionName, adml1Session)
+        let res = searchPositions(positionName)
         check(JSON.parse(<string>res.body), {
           'should only find the renamed position': positions => positions.length === 1,
           'position should be renamed': positions => positions[0].name === successfullRename
@@ -230,14 +232,14 @@ export function testRenamePosition({structure, adml, structureTree}) {
         }
         const failedRename = `${positionName} - renamed by ${label}`
         positionToRename.name = failedRename
-        switchSession(sessionToTry)
+        switchSession(<Session>sessionToTry)
         checkReturnCode(
-          updatePosition(positionToRename, sessionToTry),
+          updatePosition(positionToRename),
           `should not be able to rename a position`,
-          expectedHTTPErrorCode)
+          <number>expectedHTTPErrorCode)
         switchSession(adml1Session)
-        let res = searchPositions(positionName, adml1Session)
-        check(JSON.parse(res.body), {
+        let res = searchPositions(positionName,)
+        check(JSON.parse(<string>res.body), {
           'should only find the original position': positions => positions.length === 1,
           'position should not be renamed': positions => positions[0].name === previousName
         })
@@ -247,20 +249,20 @@ export function testRenamePosition({structure, adml, structureTree}) {
       session = <Session>authenticateWeb(headAdml.login)
       const fixedName = `${positionName} - fixed`
       const fixedNameInOtherStructure = `${positionName} - fixed in structure 2`
-      createPositionOrFail(fixedName, structure1, session)
-      createPositionOrFail(fixedNameInOtherStructure, structure2, session)
+      createPositionOrFail(fixedName, structure1)
+      createPositionOrFail(fixedNameInOtherStructure, structure2)
       positionToRename.name = fixedName
       checkReturnCode(
-        updatePosition(positionToRename, session),
+        updatePosition(positionToRename),
         `should not allow to rename a position with a name that already exists in the structure`,
         409
       )
-      check(getPositionByIdOrFail(positionToRename.id, session), {
+      check(getPositionByIdOrFail(positionToRename.id), {
         'should not be able to reuse a name of a position in the same structure' : p => p.name === previousName,
       })
       positionToRename.name = fixedNameInOtherStructure
-      assertOk(updatePosition(positionToRename, session), 'should allow to reuse a name of a position in another structure')
-      check(getPositionByIdOrFail(positionToRename.id, session), {
+      assertOk(updatePosition(positionToRename), 'should allow to reuse a name of a position in another structure')
+      check(getPositionByIdOrFail(positionToRename.id), {
         'should be able to reuse a name of a position in another structure' : p => p.name === fixedNameInOtherStructure,
         'source should not have been modified' : p => p.source === 'MANUAL'
       })
@@ -277,13 +279,13 @@ export function testRenamePosition({structure, adml, structureTree}) {
 export function searchPositionsOnOneEtab({structure, adml}) {
   describe("[Position-CRUD] Search Positions - One Etab", () => {
     let session = <Session>authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD);
-    createPosition(`IT Position - Search - Coucou`, structure, session)
-    createPosition(`IT Position - Search - Hello`, structure, session)
-    createPosition(`IT Position - Search - HellÔ les amis`, structure, session)
-    createPosition(`IT Position - Search - Hello les amis coucou`, structure, session)
+    createPosition(`IT Position - Search - Coucou`, structure)
+    createPosition(`IT Position - Search - Hello`, structure)
+    createPosition(`IT Position - Search - HellÔ les amis`, structure)
+    createPosition(`IT Position - Search - Hello les amis coucou`, structure)
   
     
-    const users = getUsersOfSchool(structure, session)
+    const users = getUsersOfSchool(structure)
     const teacher = getRandomUserWithProfile(users, 'Teacher', [adml]);
 
     let res = searchPositions('Coucou');
@@ -291,15 +293,15 @@ export function searchPositionsOnOneEtab({structure, adml}) {
 
 
     session = <Session>authenticateWeb(teacher.login)
-    res = searchPositions('Coucou', session);
+    res = searchPositions('Coucou');
     assertCondition(() => res.status === 401, "An authenticated user without special rights should not be able to search positions");
 
 
     session = <Session>authenticateWeb(adml.login)
-    res = searchPositions('Coucou', session);
+    res = searchPositions('Coucou');
     assertOk(res, "An ADML should be able to search positions");
-    res = searchPositions('hello', session);
-    check(JSON.parse(res.body), {
+    res = searchPositions('hello');
+    check(JSON.parse(<string>res.body), {
       'search should return all positions containing the filter': pos => pos && pos.length === 3,
       'search should be case-insensitive': pos => pos.filter(p => p.name.includes('Hello')).length == 2,
       'search should be special-character-insensitive': pos => pos.filter(p => p.name.includes('HellÔ')).length == 1,
@@ -308,7 +310,7 @@ export function searchPositionsOnOneEtab({structure, adml}) {
 
 
     session = <Session>authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD);
-    res = searchPositions('Coucou', structure, session);
+    res = searchPositions('Coucou');
     assertOk(res, "An ADMC should be able to search positions"); 
 })
 };
@@ -328,38 +330,38 @@ export function searchPositionsOnMultipleEtabs({structureTree}) {
     // Create positions for structures
     // 1 and separately
     const positions1 = [
-      getOrCreatePosition(`IT Position - Search - MEtab1 Coucou`, structure1, session),
-      getOrCreatePosition(`IT Position - Search - MEtab1 Hello`, structure1, session),
-      getOrCreatePosition(`IT Position - Search - MEtab1 Hello les amis`, structure1, session),
-      getOrCreatePosition(`IT Position - Search - MEtab1 Hello les amis coucou`, structure1, session)
+      getOrCreatePosition(`IT Position - Search - MEtab1 Coucou`, structure1),
+      getOrCreatePosition(`IT Position - Search - MEtab1 Hello`, structure1),
+      getOrCreatePosition(`IT Position - Search - MEtab1 Hello les amis`, structure1),
+      getOrCreatePosition(`IT Position - Search - MEtab1 Hello les amis coucou`, structure1)
     ]
     const positions2 = [
-      getOrCreatePosition(`IT Position - Search - MEtab2 Coucou`, structure2, session),
-      getOrCreatePosition(`IT Position - Search - MEtab2 Hello`, structure2, session),
-      getOrCreatePosition(`IT Position - Search - MEtab2 Hello les amis`, structure2, session)
+      getOrCreatePosition(`IT Position - Search - MEtab2 Coucou`, structure2),
+      getOrCreatePosition(`IT Position - Search - MEtab2 Hello`, structure2),
+      getOrCreatePosition(`IT Position - Search - MEtab2 Hello les amis`, structure2)
     ]
     session = <Session>authenticateWeb(adml1.login)
 
-    let res = searchPositions('IT Position - Search - MEtab', session);
-    check(JSON.parse(res.body), {
+    let res = searchPositions('IT Position - Search - MEtab');
+    check(JSON.parse(<string>res.body), {
       'all positions of structure1 should be fetched': pos => allPositionsOk(positions1, pos),
       'no duplicates were returned': pos =>   noDuplicates(pos)
     })
-    res = searchPositions('IT Position - Search - MEtab2', session);
-    check(JSON.parse(res.body), {
+    res = searchPositions('IT Position - Search - MEtab2');
+    check(JSON.parse(<string>res.body), {
       'adml of structure1 should see no positions of structure 2': pos => pos && pos.length === 0
     })
 
     session = <Session>authenticateWeb(adml2.login)
-    res = searchPositions('IT Position - Search - MEtab', session);
-    check(JSON.parse(res.body), {
+    res = searchPositions('IT Position - Search - MEtab');
+    check(JSON.parse(<string>res.body), {
       'all positions of structure2 should be fetched': pos => allPositionsOk(positions2, pos),
       'no duplicates were returned': pos => noDuplicates(pos)
     })
 
     session = <Session>authenticateWeb(headAdml.login)
-    res = searchPositions('IT Position - Search - MEtab', session);
-    check(JSON.parse(res.body), {
+    res = searchPositions('IT Position - Search - MEtab');
+    check(JSON.parse(<string>res.body), {
       'adml of structure1 and structure2 should see the positions of both structures': pos => pos && pos.length === (positions2.length + positions1.length),
       'all positions of structure1 should be fetched': pos => allPositionsOk([...positions2, ...positions1], pos),
       'no duplicates were returned': pos => noDuplicates([...positions2, ...positions1])
@@ -383,45 +385,71 @@ export function testDeletePosition({structureTree}) {
     // Create 2 positions for structure 1
     // and 3 positions for structure 2
     /////////////////////////////////////
-    const postionEtab1_1 = getOrCreatePosition(`IT Position - Delete - MEtab1 01`, structure1, session);
-    const postionEtab1_2 = getOrCreatePosition(`IT Position - Delete - MEtab1 02`, structure1, session);
-    const postionEtab2_1 = getOrCreatePosition(`IT Position - Delete - MEtab2 01`, structure2, session);
-    const postionEtab2_2 = getOrCreatePosition(`IT Position - Delete - MEtab2 02`, structure2, session);
-    const postionEtab2_3 = getOrCreatePosition(`IT Position - Delete - MEtab2 03`, structure2, session);
+    const postionEtab1_1 = getOrCreatePosition(`IT Position - Delete - MEtab1 01`, structure1);
+    const postionEtab1_2 = getOrCreatePosition(`IT Position - Delete - MEtab1 02`, structure1);
+    const postionEtab2_1 = getOrCreatePosition(`IT Position - Delete - MEtab2 01`, structure2);
+    const postionEtab2_2 = getOrCreatePosition(`IT Position - Delete - MEtab2 02`, structure2);
+    const postionEtab2_3 = getOrCreatePosition(`IT Position - Delete - MEtab2 03`, structure2);
     
     //////////////////////////////////
     // Get "random" users
     //////////////////////////////////
-    const users = getUsersOfSchool(structure1, session)
+    const users = getUsersOfSchool(structure1)
     const teacher = getRandomUserWithProfile(users, 'Teacher', [adml1]);
 
 
     /////////////////////////////////
     // Tests
     /////////////////////////////////
-    logout(session);
-    let res = deletePosition(postionEtab2_1);
+    logout();
+    let res = deletePosition(postionEtab2_1.id);
     assertCondition(() => res.status === 401, "An unauthenticated user should not be able to delete a position");
     session = <Session>authenticateWeb(teacher.login)
-    res = deletePosition(postionEtab2_1, session);
+    res = deletePosition(postionEtab2_1.id);
     assertCondition(() => res.status === 401, "A user who is not ADML should not be able to delete a position");
     session = <Session>authenticateWeb(adml1.login)
-    res = deletePosition(postionEtab2_1, session);
+    res = deletePosition(postionEtab2_1.id);
     assertCondition(() => res.status === 401, "An ADML of another structure should not be able to delete this position");
-    res = deletePosition(postionEtab1_1, session);
+    res = deletePosition(postionEtab1_1.id);
     assertOk(res, "An ADML of a structure should be able to delete a position");
 
     session = <Session>authenticateWeb(headAdml.login)
-    res = deletePosition(postionEtab1_2, session);
+    res = deletePosition(postionEtab1_2.id);
     assertOk(res, "An ADML of a head structure should be able to delete a position of an administered structure");
 
     session = <Session>authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD)
-    res = deletePosition(postionEtab2_2, session);
+    res = deletePosition(postionEtab2_2.id);
     assertOk(res, "An ADMC should be able to delete any position");
 
     session = <Session>authenticateWeb(headAdml.login);
 })
 };
+
+// Integration Test to specifically check that when two adml are merged
+// then we still can correctly retrieve the positions related to the
+// structure of the resulting adml.
+// It covers the bugfix of WB-3640
+export function testGetPositionsAfterMergingAdml({structureTree}) {
+  const {structures: [structure1], admls: [adml1], headAdml} = structureTree
+  describe("", () => {
+    authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD);
+
+    ////////////////////////////////////
+    // Create 2 ADML for structure 1
+    // and merge them
+    const admlToMerge1 = getAdmlsOrMakThem(structure1, 'Teacher', 1, [headAdml, adml1])[0]
+    const admlToMerge2 = getAdmlsOrMakThem(structure1, 'Teacher', 1, [headAdml, adml1, admlToMerge1])[0]
+
+    console.log("ID structure 1 : ", structure1.id)
+    console.log("ADML ids : ", admlToMerge1.id, " and ", admlToMerge2.id)
+    mergeUsers(admlToMerge1.id, admlToMerge2.id, true)
+
+    authenticateWeb(admlToMerge1.login)
+    let res = getPositionsOfStructure(structure1)
+
+    assertOk(res, "An ADML that has got merged with another ADML account should be able to retrieve the user positions of its structure.")
+  })
+}
 
 function allPositionsOk(expected, actual) {
   const actualIds = new Set();
@@ -450,7 +478,7 @@ function assertSearchCriteriaContainSpecifiedPositionsAndNotOther(expected, unwa
     const actualIds = criteriaPositions.map(e => e.id)
     const ok = check(criteriaPositions, {
       'should contain all expected positions' : () => expected.filter(exp => actualIds.indexOf(exp.id) < 0).length === 0,
-      'should contain none of the unwanted positions' : () => actualIds.filter(act => unwantedPredicate({id: act.id})).length >= 0
+      'should contain none of the unwanted positions' : () => actualIds.filter(act => unwantedPredicate({id: act})).length >= 0
     });
     if(!ok) {
       console.warn("actualIds", actualIds)


### PR DESCRIPTION
# Description

Lorsque l'on merge deux comptes adml dupliqués, désormais on ne crée qu'une **unique** relation `HAS_FUNCTION` vers le noeud de la Fonction ADML, et cette relation a pour scope l'union des scopes de structure pour lesquels les deux comptes avaient la fonction ADML.

## Fixes

https://edifice-community.atlassian.net/browse/WB-3640

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [x] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [x] tests
- [ ] timeline
- [ ] workspace

## Tests

Un test d'intégration k6 associé à ce bugfix a été ajouté

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: