### PR TITLE
feat(conversation): #WB-3467, additional renderView of the new web fr…

### DIFF
--- a/conversation/backend/src/main/java/org/entcore/conversation/controllers/ConversationController.java
+++ b/conversation/backend/src/main/java/org/entcore/conversation/controllers/ConversationController.java
@@ -52,17 +52,15 @@ import org.entcore.conversation.Conversation;
 import org.entcore.conversation.filters.MessageOwnerFilter;
 import org.entcore.conversation.filters.MessageUserFilter;
 import org.entcore.conversation.filters.MultipleMessageUserFilter;
+import org.entcore.conversation.filters.SystemOrUserFolderFilter;
 import org.entcore.conversation.filters.VisiblesFilter;
 import org.entcore.conversation.filters.FoldersFilter;
 import org.entcore.conversation.filters.FoldersMessagesFilter;
 import org.entcore.conversation.service.ConversationService;
 import org.entcore.conversation.service.impl.Neo4jConversationService;
-import org.entcore.conversation.service.impl.SqlConversationService;
-import org.entcore.conversation.util.DecodedDisplayName;
 
 import fr.wseduc.webutils.Either;
 import fr.wseduc.webutils.Utils;
-import fr.wseduc.security.ActionType;
 import fr.wseduc.security.SecuredAction;
 
 import io.vertx.core.Handler;
@@ -89,6 +87,8 @@ import static fr.wseduc.webutils.request.RequestUtils.bodyToJson;
 import static org.entcore.common.http.response.DefaultResponseHandler.*;
 import static org.entcore.common.user.UserUtils.getUserInfos;
 import org.entcore.conversation.util.DecodedDisplayName;
+
+import fr.wseduc.security.ActionType;
 
 public class ConversationController extends BaseController {
 	public static final String RESOURCE_NAME = "message";
@@ -130,12 +130,30 @@ public class ConversationController extends BaseController {
 		this.threshold = config.getInteger("alertStorage", 80);
 	}
 
+	private void renderViewWeb(HttpServerRequest request) {
+		renderView(request, new JsonObject(), "index.html", null);
+		eventHelper.onAccess(request);
+	}
+
 	@Get("conversation")
 	@SecuredAction("conversation.view")
 	@Cache(value = "/conversation/count/INBOX",useQueryParams = true,scope = CacheScope.USER, operation = CacheOperation.INVALIDATE)
 	public void view(HttpServerRequest request) {
-		renderView(request, new JsonObject(), "index.html", null);
-		eventHelper.onAccess(request);
+		renderViewWeb(request);
+	}
+
+	@Get("conversation/:folderId")
+	@SecuredAction(value = "", type = ActionType.RESOURCE)
+	@ResourceFilter(SystemOrUserFolderFilter.class)
+	public void viewFolder(HttpServerRequest request) {
+		renderViewWeb(request);
+	}
+
+	@Get("conversation/:folderId/:messageId")
+	@SecuredAction(value = "", type = ActionType.RESOURCE)
+	@ResourceFilter(SystemOrUserFolderFilter.class)
+	public void viewMessage(HttpServerRequest request) {
+		renderViewWeb(request);
 	}
 
 	@Post("draft")


### PR DESCRIPTION
…ontend

# Description

Additional renderView of the new web frontend application.

* Previous angularJS app was available at a unique URL `/conversation/conversation#`, the fragment (#...) being used by the front router to display the correct sub-page of the mono-page app, for example `/conversation/conversation#/inbox`

* New React app follows a more classical routing, without fragments. 
  [Sub-pages URLs](https://edifice-community.atlassian.net/wiki/spaces/ODE/pages/4194402383/Messagerie+2024+-+Sp+cifications+Front+Web#Harmonisation-des-routes-c%C3%B4t%C3%A9-frontend), which can be stored in user's bookmarks, must be rendered by the backend.


## Fixes

[#WB-3467](https://edifice-community.atlassian.net/browse/WB-3467)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [X] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley: