### PR TITLE
fix(common): #ENABLING-174 fix dates handling while reindexing mongo resources

### DIFF
--- a/common/src/main/java/org/entcore/common/explorer/impl/ExplorerSubResourceMongo.java
+++ b/common/src/main/java/org/entcore/common/explorer/impl/ExplorerSubResourceMongo.java
@@ -8,6 +8,8 @@ import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.mongo.BulkOperation;
 import io.vertx.ext.mongo.MongoClient;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
 import org.bson.conversions.Bson;
 import org.entcore.common.explorer.ExplorerStream;
 import org.entcore.common.explorer.IngestJobStateUpdateMessage;
@@ -20,6 +22,8 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
+
+import static org.entcore.common.utils.DateUtils.formatUtcDateTime;
 
 /**
  * Assuming that {@code TSub} is the name of the class of your plugin and {@code TXXX} the name of the classes depending on
@@ -137,16 +141,14 @@ public abstract class ExplorerSubResourceMongo extends ExplorerSubResource {
         final Date from = request.getFrom();
         final Date to = request.getTo();
         if (from != null) {
-            final LocalDateTime localFrom = Instant.ofEpochMilli(from.getTime())
-                    .atZone(ZoneId.systemDefault())
-                    .toLocalDateTime();
-            indexFilters.add(Filters.gte(getCreatedAtColumn(), toMongoDate(localFrom)));
+            indexFilters.add(new BsonDocument().append(getCreatedAtColumn(),
+              new BsonDocument().append("$gte",
+                new BsonDocument().append("$date", new BsonString(formatUtcDateTime(from))))));
         }
         if (to != null) {
-            final LocalDateTime localTo = Instant.ofEpochMilli(to.getTime())
-                    .atZone(ZoneId.systemDefault())
-                    .toLocalDateTime();
-            indexFilters.add(Filters.lt(getCreatedAtColumn(), toMongoDate(localTo)));
+            indexFilters.add(new BsonDocument().append(getCreatedAtColumn(),
+              new BsonDocument().append("$lt",
+                new BsonDocument().append("$date", new BsonString(formatUtcDateTime(to))))));
         }
         if(request.getIds() != null && !request.getIds().isEmpty()) {
             indexFilters.add(Filters.in(getIdColumn(), request.getIds()));


### PR DESCRIPTION
# Description

Depuis le passage à vertx 4, la gestion des dates via le driver asynchrone est problématique et nécessite quelques adaptations de code.
Cette PR corrige l'un de ses problèmes où le driver n'arrivait pas à désérialiser les dates de début et de fin de réindexation des ressources mongo.

## Fixes

ENABLING-174

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Launch a reindexation by date (start and end)
2. Check the logs that no errors occurred
3. Check after the reindexation is done that the resources have been correctly reindexed

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: