### PR TITLE
Feat/wb 3428

### DIFF
--- a/conversation/frontend/src/features/Menu/DesktopMenu.css
+++ b/conversation/frontend/src/features/Menu/DesktopMenu.css
@@ -1,0 +1,3 @@
+.user-folder {
+    line-height: 24px;
+}

--- a/conversation/frontend/src/features/Menu/DesktopMenu.tsx
+++ b/conversation/frontend/src/features/Menu/DesktopMenu.tsx
@@ -5,11 +5,23 @@ import {
   IconSmiley,
   IconWrite,
 } from '@edifice.io/react/icons';
-import { Menu } from '@edifice.io/react';
+import { Button, Menu, SortableTree, TreeItem } from '@edifice.io/react';
 import { NOOP } from '@edifice.io/utilities';
 import { useLoaderData } from 'react-router-dom';
 import { Folder } from '~/models';
 import { t } from 'i18next';
+
+function buildTree(folders: Folder[]) {
+  return folders
+    .sort((a, b) => (a.name < b.name ? -1 : a.name == b.name ? 0 : 1))
+    .map(({ id, name, subFolders }) => {
+      const item = { id, name } as TreeItem;
+      if (subFolders) {
+        item.children = buildTree(subFolders);
+      }
+      return item;
+    });
+}
 
 export function DesktopMenu() {
   // See `layout` loader
@@ -22,9 +34,26 @@ export function DesktopMenu() {
     return null;
   }
 
+  const userFolders = buildTree(foldersTree);
+
+  function renderUserFolder({
+    node,
+  }: {
+    node: TreeItem;
+    hasChildren?: boolean;
+    isChild?: boolean;
+  }) {
+    return (
+      <div className="w-100 d-flex">
+        {node.name}
+        <IconSmiley />
+      </div>
+    );
+  }
+
   return (
     <>
-      <Menu label="generic.folders">
+      <Menu label={t('generic.folders')}>
         <Menu.Item>
           <Menu.Button
             leftIcon={<IconDepositeInbox />}
@@ -56,9 +85,17 @@ export function DesktopMenu() {
           </Menu.Button>
         </Menu.Item>
       </Menu>
-      TODO {JSON.stringify(foldersTree)}
       <div className="w-100 border-bottom"></div>
-      TODO Mes dossiers
+      <Menu label={t('user.folders')}>
+        <b>{t('user.folders')}</b>
+        <SortableTree
+          nodes={userFolders}
+          onSortable={NOOP}
+          onTreeItemClick={NOOP}
+          renderNode={renderUserFolder}
+          selectedNodeId={'1'}
+        />
+      </Menu>
       <div className="w-100 border-bottom"></div>
       TODO Espace utilisé
     </>

--- a/conversation/frontend/src/features/Menu/DesktopMenu.tsx
+++ b/conversation/frontend/src/features/Menu/DesktopMenu.tsx
@@ -5,12 +5,14 @@ import {
   IconSmiley,
   IconWrite,
 } from '@edifice.io/react/icons';
-import { Button, Menu, SortableTree, TreeItem } from '@edifice.io/react';
+import { Menu, SortableTree, TreeItem } from '@edifice.io/react';
 import { NOOP } from '@edifice.io/utilities';
-import { useLoaderData } from 'react-router-dom';
+import { useLoaderData, useNavigate } from 'react-router-dom';
 import { Folder } from '~/models';
 import { t } from 'i18next';
+import { useSelectedFolder } from '~/hooks';
 
+/** Build a tree of TreeItems from Folders  */
 function buildTree(folders: Folder[]) {
   return folders
     .sort((a, b) => (a.name < b.name ? -1 : a.name == b.name ? 0 : 1))
@@ -24,16 +26,22 @@ function buildTree(folders: Folder[]) {
 }
 
 export function DesktopMenu() {
+  const navigate = useNavigate();
   // See `layout` loader
   const { foldersTree, actions } = useLoaderData() as {
     foldersTree: Folder[];
     actions: Record<string, boolean>;
   };
+  const folder = useSelectedFolder();
+
+  const selectedSystemFolderId =
+    typeof folder === 'string' ? folder : undefined;
+  const selectedUserFolderId =
+    typeof folder === 'object' ? folder.name : undefined;
 
   if (!foldersTree || !actions) {
     return null;
   }
-
   const userFolders = buildTree(foldersTree);
 
   function renderUserFolder({
@@ -44,60 +52,75 @@ export function DesktopMenu() {
     isChild?: boolean;
   }) {
     return (
-      <div className="w-100 d-flex">
-        {node.name}
-        <IconSmiley />
-      </div>
+      <span
+        className="w-100 d-flex justify-content-between align-content-center"
+        style={{ lineHeight: '24px' }}
+      >
+        <div className="overflow-x-hidden text-no-wrap text-truncate">
+          {node.name}
+        </div>
+        <IconSmiley width={20} height={24} />
+      </span>
     );
   }
 
+  const navigateTo = (systemFolderId: string) => {
+    navigate(`/${systemFolderId}`);
+  };
+
   return (
-    <>
-      <Menu label={t('generic.folders')}>
-        <Menu.Item>
-          <Menu.Button
-            leftIcon={<IconDepositeInbox />}
-            onClick={NOOP}
-            rightIcon={<IconSmiley />}
-          >
-            {t('inbox')}
-          </Menu.Button>
-          <Menu.Button
-            leftIcon={<IconSend />}
-            onClick={NOOP}
-            rightIcon={<IconSmiley />}
-          >
-            {t('outbox')}
-          </Menu.Button>
-          <Menu.Button
-            leftIcon={<IconWrite />}
-            onClick={NOOP}
-            rightIcon={<IconSmiley />}
-          >
-            {t('draft')}
-          </Menu.Button>
-          <Menu.Button
-            leftIcon={<IconDelete />}
-            onClick={NOOP}
-            rightIcon={<IconSmiley />}
-          >
-            {t('trash')}
-          </Menu.Button>
-        </Menu.Item>
-      </Menu>
-      <div className="w-100 border-bottom"></div>
-      <Menu label={t('user.folders')}>
+    <Menu label={t('generic.folders')}>
+      <Menu.Item>
+        <Menu.Button
+          selected={selectedSystemFolderId === 'inbox'}
+          leftIcon={<IconDepositeInbox />}
+          onClick={() => navigateTo('inbox')}
+          rightIcon={<IconSmiley />}
+        >
+          {t('inbox')}
+        </Menu.Button>
+        <Menu.Button
+          selected={selectedSystemFolderId === 'outbox'}
+          leftIcon={<IconSend />}
+          onClick={() => navigateTo('outbox')}
+          rightIcon={<IconSmiley />}
+        >
+          {t('outbox')}
+        </Menu.Button>
+        <Menu.Button
+          selected={selectedSystemFolderId === 'draft'}
+          leftIcon={<IconWrite />}
+          onClick={() => navigateTo('draft')}
+          rightIcon={<IconSmiley />}
+        >
+          {t('draft')}
+        </Menu.Button>
+        <Menu.Button
+          selected={selectedSystemFolderId === 'trash'}
+          leftIcon={<IconDelete />}
+          onClick={() => navigateTo('trash')}
+          rightIcon={<IconSmiley />}
+        >
+          {t('trash')}
+        </Menu.Button>
+      </Menu.Item>
+      <Menu.Item>
+        <div className="w-100 border-bottom pt-8 mb-12"></div>
+      </Menu.Item>
+      <Menu.Item>
         <b>{t('user.folders')}</b>
         <SortableTree
           nodes={userFolders}
           onSortable={NOOP}
-          onTreeItemClick={NOOP}
+          onTreeItemClick={(folderId) => navigateTo(folderId)}
           renderNode={renderUserFolder}
-          selectedNodeId={'1'}
+          selectedNodeId={selectedUserFolderId}
         />
-      </Menu>
-      <div className="w-100 border-bottom"></div>
-      TODO Espace utilisé
-    </>
+      </Menu.Item>
+      <Menu.Item>
+        <div className="w-100 border-bottom pt-8 mb-12"></div>
+      </Menu.Item>
+      <Menu.Item>TODO Espace utilisé</Menu.Item>
+    </Menu>
   );
 }

--- a/conversation/frontend/src/features/Menu/DesktopMenu.tsx
+++ b/conversation/frontend/src/features/Menu/DesktopMenu.tsx
@@ -2,7 +2,6 @@ import {
   IconDelete,
   IconDepositeInbox,
   IconSend,
-  IconSmiley,
   IconWrite,
 } from '@edifice.io/react/icons';
 import { Badge, Menu, SortableTree, TreeItem } from '@edifice.io/react';
@@ -11,6 +10,8 @@ import { useNavigate, useRouteLoaderData } from 'react-router-dom';
 import { Folder } from '~/models';
 import { t } from 'i18next';
 import { useSelectedFolder } from '~/hooks';
+import { useMessagesCount } from '~/services';
+import './DesktopMenu.css';
 
 type FolderTreeItem = TreeItem & { folder: Folder };
 
@@ -40,6 +41,14 @@ export function DesktopMenu() {
   };
   const { folderId, userFolder } = useSelectedFolder();
 
+  const inboxCount =
+    useMessagesCount('inbox', { unread: true }).data?.count ?? 0;
+  const outboxCount =
+    useMessagesCount('outbox', { unread: true }).data?.count ?? 0;
+  const draftCount = useMessagesCount('draft').data?.count ?? 0;
+  const trashCount =
+    useMessagesCount('trash', { unread: true }).data?.count ?? 0;
+
   const selectedSystemFolderId =
     typeof folderId === 'string' && !userFolder ? folderId : undefined;
   const selectedUserFolderId =
@@ -50,6 +59,23 @@ export function DesktopMenu() {
   }
   const userFolders = buildTree(foldersTree);
 
+  function renderBadge(count: number) {
+    return (
+      <>
+        {count > 0 && (
+          <Badge
+            variant={{
+              level: 'warning',
+              type: 'notification',
+            }}
+          >
+            {count}
+          </Badge>
+        )}
+      </>
+    );
+  }
+
   function renderUserFolder({
     node,
   }: {
@@ -58,23 +84,11 @@ export function DesktopMenu() {
     isChild?: boolean;
   }) {
     return (
-      <span
-        className="w-100 d-flex justify-content-between align-content-center"
-        style={{ lineHeight: '24px' }}
-      >
+      <span className="user-folder w-100 d-flex justify-content-between align-content-center">
         <div className="overflow-x-hidden text-no-wrap text-truncate">
           {node.name}
         </div>
-        {node.folder.nbUnread > 0 && (
-          <Badge
-            variant={{
-              level: 'warning',
-              type: 'notification',
-            }}
-          >
-            {node.folder.nbUnread}
-          </Badge>
-        )}
+        {renderBadge(node.folder)}
       </span>
     );
   }
@@ -90,7 +104,7 @@ export function DesktopMenu() {
           selected={selectedSystemFolderId === 'inbox'}
           leftIcon={<IconDepositeInbox />}
           onClick={() => navigateTo('inbox')}
-          rightIcon={<IconSmiley />}
+          rightIcon={renderBadge(inboxCount)}
         >
           {t('inbox')}
         </Menu.Button>
@@ -98,7 +112,7 @@ export function DesktopMenu() {
           selected={selectedSystemFolderId === 'outbox'}
           leftIcon={<IconSend />}
           onClick={() => navigateTo('outbox')}
-          rightIcon={<IconSmiley />}
+          rightIcon={renderBadge(outboxCount)}
         >
           {t('outbox')}
         </Menu.Button>
@@ -106,7 +120,7 @@ export function DesktopMenu() {
           selected={selectedSystemFolderId === 'draft'}
           leftIcon={<IconWrite />}
           onClick={() => navigateTo('draft')}
-          rightIcon={<IconSmiley />}
+          rightIcon={renderBadge(draftCount)}
         >
           {t('draft')}
         </Menu.Button>
@@ -114,7 +128,7 @@ export function DesktopMenu() {
           selected={selectedSystemFolderId === 'trash'}
           leftIcon={<IconDelete />}
           onClick={() => navigateTo('trash')}
-          rightIcon={<IconSmiley />}
+          rightIcon={renderBadge(trashCount)}
         >
           {t('trash')}
         </Menu.Button>

--- a/conversation/frontend/src/features/Menu/MobileMenu.tsx
+++ b/conversation/frontend/src/features/Menu/MobileMenu.tsx
@@ -1,10 +1,9 @@
-import { useLoaderData } from 'react-router-dom';
+import { useRouteLoaderData } from 'react-router-dom';
 import { Folder } from '~/models';
 import { t } from 'i18next';
 
 export function MobileMenu() {
-  // See `layout` loader
-  const { foldersTree, actions } = useLoaderData() as {
+  const { foldersTree, actions } = useRouteLoaderData('layout') as {
     foldersTree: Folder[];
     actions: Record<string, boolean>;
   };

--- a/conversation/frontend/src/hooks/index.ts
+++ b/conversation/frontend/src/hooks/index.ts
@@ -1,7 +1,1 @@
-/*
- * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- This is a starter file and can be deleted.
- * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- All hooks shared across the application
- * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- */
+export * from './useSelectedFolder';

--- a/conversation/frontend/src/hooks/useSelectedFolder.ts
+++ b/conversation/frontend/src/hooks/useSelectedFolder.ts
@@ -1,0 +1,38 @@
+import { useParams, useRouteLoaderData } from 'react-router-dom';
+import { Folder } from '~/models';
+
+/** Build a tree of TreeItems from Folders  */
+function recursiveSearch(
+  folderId: string,
+  folders: Folder[],
+): Folder | undefined {
+  for (const f of folders) {
+    if (f.id === folderId) return f;
+    if (f.subFolders) {
+      const folder = recursiveSearch(folderId, f.subFolders);
+      if (folder) return folder;
+    }
+  }
+}
+
+export function useSelectedFolder(): string | Folder | undefined {
+  // See `layout` loader
+  const { foldersTree } = useRouteLoaderData('layout') as {
+    foldersTree: Folder[];
+  };
+  const { folderId } = useParams() as { folderId: string };
+
+  if (!folderId) return;
+
+  switch (folderId.toLowerCase()) {
+    case 'inbox':
+    case 'outbox':
+    case 'draft':
+    case 'trash':
+      return folderId.toLowerCase();
+    default:
+      break;
+  }
+
+  return recursiveSearch(folderId, foldersTree);
+}

--- a/conversation/frontend/src/hooks/useSelectedFolder.ts
+++ b/conversation/frontend/src/hooks/useSelectedFolder.ts
@@ -15,24 +15,38 @@ function recursiveSearch(
   }
 }
 
-export function useSelectedFolder(): string | Folder | undefined {
+/**
+ * Hook to extract the selected folder ID from the URL,
+ * and retrieve matching metadata from available loaders' queries.
+ * @returns {
+ * `folderId`: the folder ID extracted from the path. Undefined when not valid.
+ * `userFolder`: the matching user's folder metadata. Undefined for system folders.
+ * }
+ */
+export function useSelectedFolder(): {
+  folderId?: string;
+  userFolder?: Folder;
+} {
   // See `layout` loader
   const { foldersTree } = useRouteLoaderData('layout') as {
     foldersTree: Folder[];
   };
   const { folderId } = useParams() as { folderId: string };
 
-  if (!folderId) return;
+  if (!folderId) return {};
 
   switch (folderId.toLowerCase()) {
     case 'inbox':
     case 'outbox':
     case 'draft':
     case 'trash':
-      return folderId.toLowerCase();
+      return { folderId: folderId.toLowerCase() };
     default:
       break;
   }
 
-  return recursiveSearch(folderId, foldersTree);
+  return {
+    folderId,
+    userFolder: recursiveSearch(folderId, foldersTree),
+  };
 }

--- a/conversation/frontend/src/mocks/index.ts
+++ b/conversation/frontend/src/mocks/index.ts
@@ -29,6 +29,8 @@ export const mockFolderTree = [
   },
 ];
 
+export const mockCountOfMessagesInInbox = { count: 2 };
+
 export const mockMessagesOfInbox = [
   {
     id: 'f43d3783',

--- a/conversation/frontend/src/models/folder.ts
+++ b/conversation/frontend/src/models/folder.ts
@@ -1,3 +1,13 @@
+export const SYSTEM_FOLDER_ID = {
+  INBOX: 'inbox',
+  OUTBOX: 'outbox',
+  DRAFT: 'draft',
+  TRASH: 'trash',
+} as const;
+export const SYSTEM_FOLDER_IDS = Object.values(SYSTEM_FOLDER_ID) as string[];
+export type SystemFolder =
+  (typeof SYSTEM_FOLDER_ID)[keyof typeof SYSTEM_FOLDER_ID];
+
 export type Folder = {
   id: string;
   name: string;

--- a/conversation/frontend/src/models/index.ts
+++ b/conversation/frontend/src/models/index.ts
@@ -1,11 +1,3 @@
-/*
- * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- This is a starter file and can be deleted.
- * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- All types shared across the application
- * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- */
-
 export * from './user';
 export * from './group';
 export * from './folder';

--- a/conversation/frontend/src/routes/index.tsx
+++ b/conversation/frontend/src/routes/index.tsx
@@ -21,6 +21,7 @@ const routes = (_queryClient: QueryClient): RouteObject[] => [
       /* Layout = route without a path */
       // Manages folders tree and occupied space.
       {
+        id: 'layout',
         async lazy() {
           const { Component, loader } = await import('~/routes/layout');
           return {

--- a/conversation/frontend/src/routes/pages/folder-display.tsx
+++ b/conversation/frontend/src/routes/pages/folder-display.tsx
@@ -1,12 +1,13 @@
 import { QueryClient } from '@tanstack/react-query';
-import { useParams, Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
+import { useSelectedFolder } from '~/hooks';
 
 export const loader = (_queryClient: QueryClient) => async () => {
   return null;
 };
 
 export function Component() {
-  const { folderId } = useParams();
+  const { folderId } = useSelectedFolder();
 
   return (
     <>

--- a/conversation/frontend/src/services/api/folderService.test.ts
+++ b/conversation/frontend/src/services/api/folderService.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'vitest';
 import { folderService } from '.';
-import { mockFolderTree, mockMessagesOfInbox } from '~/mocks';
+import {
+  mockCountOfMessagesInInbox,
+  mockFolderTree,
+  mockMessagesOfInbox,
+} from '~/mocks';
 
 describe('Conversation Folder GET Methods', () => {
   test("makes a GET request to get user's folders tree with at depth 2", async () => {
@@ -9,6 +13,13 @@ describe('Conversation Folder GET Methods', () => {
     expect(response).toBeDefined();
     expect(response).toHaveLength(2);
     expect(response).toStrictEqual(mockFolderTree);
+  });
+
+  test('makes a GET request to count the number of unread messages in the inbox folder', async () => {
+    const response = await folderService.getCount('inbox', true);
+
+    expect(response).toBeDefined();
+    expect(response).toStrictEqual(mockCountOfMessagesInInbox);
   });
 
   test('makes a GET request to get list of messages from inbox', async () => {

--- a/conversation/frontend/src/services/api/folderService.ts
+++ b/conversation/frontend/src/services/api/folderService.ts
@@ -1,6 +1,6 @@
 import { odeServices } from 'edifice-ts-client';
 
-import { Folder, MessageMetadata } from '~/models';
+import { Folder, MessageMetadata, SYSTEM_FOLDER_IDS } from '~/models';
 
 /**
  * Creates a folder service with the specified base URL.
@@ -17,6 +17,26 @@ export const createFolderService = (baseURL: string) => ({
     return odeServices
       .http()
       .get<Folder[]>(`${baseURL}/api/folders?depth=${depth}`);
+  },
+
+  /**
+   * Count the number of messages in a system or user folder.
+   * @param folderId system folder, or a user's folder ID.
+   * @param unread (optional) truthy when only unread must be counted
+   * @returns count of [unread] messages
+   */
+  getCount(folderId: string, unread?: boolean) {
+    const queryParams = [] as string[];
+    // `restrain` query parameter applies to users folders only.
+    if (SYSTEM_FOLDER_IDS.findIndex((f) => f === folderId) === -1) {
+      queryParams.push('restrain');
+    }
+    if (typeof unread === 'boolean') {
+      queryParams.push(`unread=${unread}`);
+    }
+    return odeServices.http().get<{
+      count: number;
+    }>(`${baseURL}/count/${folderId}?${queryParams.join('&')}`);
   },
 
   /**

--- a/conversation/frontend/src/services/queries/folder.ts
+++ b/conversation/frontend/src/services/queries/folder.ts
@@ -22,6 +22,25 @@ export const folderQueryOptions = {
     });
   },
 
+  getMessagesCount(
+    folderId: string,
+    options?: {
+      /** (optional) Load un/read message only ? */
+      unread?: boolean;
+    },
+  ) {
+    return queryOptions({
+      queryKey: [
+        ...folderQueryOptions.base,
+        folderId,
+        'count',
+        options,
+      ] as const,
+      queryFn: () => folderService.getCount(folderId, options?.unread),
+      staleTime: 5000,
+    });
+  },
+
   getMessages(
     folderId: string,
     options?: {
@@ -69,6 +88,16 @@ export const useFolderMessages = (
   },
 ) => {
   return useQuery(folderQueryOptions.getMessages(folderId, options));
+};
+
+export const useMessagesCount = (
+  folderId: string,
+  options?: {
+    /** (optional) Load un/read message only ? */
+    unread?: boolean;
+  },
+) => {
+  return useQuery(folderQueryOptions.getMessagesCount(folderId, options));
 };
 
 export const useCreateFolder = () => {

--- a/conversation/frontend/vite.config.ts
+++ b/conversation/frontend/vite.config.ts
@@ -51,7 +51,7 @@ export default ({ mode }: { mode: string }) => {
           proxyObj,
         '^/(?=auth|appregistry|cas|userbook|directory|communication|portal|session|timeline|workspace|infra)':
           proxyObj,
-        '^/conversation/(?=api|messages/|folders/)': proxyObj,
+        '^/conversation/(?=api|messages/|folders/|count/)': proxyObj,
       },
       port: 4200,
       headers,


### PR DESCRIPTION
# Description

Navigation through a menu of system (inbox, outbox, draft and trash) and user's folders.
Displays unread messages in badges, excepting the draft folder which displays its total number of drafts.
Renders differently in desktop or mobile responsive modes.

## Fixes

[WB-3428](https://edifice-community.atlassian.net/browse/WB-3428)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: