### PR TITLE
fix: WB-3666, optimize voluminous shares request

### DIFF
--- a/common/src/main/java/org/entcore/common/share/impl/GenericShareService.java
+++ b/common/src/main/java/org/entcore/common/share/impl/GenericShareService.java
@@ -491,10 +491,6 @@ public abstract class GenericShareService implements ShareService {
 				.map(futures -> futures.list().stream()
 						.map(result -> (JsonArray) result)
 						.collect(Collectors.toList()))
-				.onFailure(th -> {
-					log.error("Failed fetching visibles", th);
-					promise.fail("Failed fetching visibles : " + th.getMessage());
-				})
 				.onSuccess(visibleChunks -> {
 					final JsonArray visibleArray = new JsonArray();
 					visibleChunks.forEach(visibleArray::addAll);

--- a/common/src/main/java/org/entcore/common/share/impl/GenericShareService.java
+++ b/common/src/main/java/org/entcore/common/share/impl/GenericShareService.java
@@ -19,18 +19,20 @@
 
 package org.entcore.common.share.impl;
 
-import static fr.wseduc.webutils.Utils.getOrElse;
-import static fr.wseduc.webutils.Utils.isEmpty;
-import static org.entcore.common.neo4j.Neo4jResult.validResultHandler;
-import static org.entcore.common.user.UserUtils.findVisibleProfilsGroups;
-import static org.entcore.common.user.UserUtils.findVisibleUsers;
-import static org.entcore.common.validation.StringValidation.cleanId;
-
-import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
+import com.google.common.collect.Lists;
+import fr.wseduc.webutils.Either;
+import fr.wseduc.webutils.I18n;
+import fr.wseduc.webutils.security.ActionType;
+import fr.wseduc.webutils.security.SecuredAction;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.Promise;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import org.entcore.common.neo4j.Neo4j;
 import org.entcore.common.neo4j.Neo4jResult;
 import org.entcore.common.neo4j.StatementsBuilder;
@@ -39,18 +41,16 @@ import org.entcore.common.share.ShareService;
 import org.entcore.common.user.UserUtils;
 import org.entcore.common.validation.StringValidation;
 
-import fr.wseduc.webutils.Either;
-import fr.wseduc.webutils.I18n;
-import fr.wseduc.webutils.security.ActionType;
-import fr.wseduc.webutils.security.SecuredAction;
-import io.vertx.core.CompositeFuture;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.eventbus.EventBus;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static fr.wseduc.webutils.Utils.getOrElse;
+import static fr.wseduc.webutils.Utils.isEmpty;
+import static org.entcore.common.neo4j.Neo4jResult.validResultHandler;
+import static org.entcore.common.user.UserUtils.findVisibleProfilsGroups;
+import static org.entcore.common.user.UserUtils.findVisibleUsers;
+import static org.entcore.common.validation.StringValidation.cleanId;
 
 public abstract class GenericShareService implements ShareService {
 
@@ -469,76 +469,98 @@ public abstract class GenericShareService implements ShareService {
 		final Map<String, Set<String>> shareUpdates) {
 		final Promise<Boolean> promise = Promise.promise();
 		final String customReturn = "RETURN DISTINCT visibles.id as id, has(visibles.login) as isUser";
-		final JsonObject extraParams = new JsonObject()
-			.put("expectedIdsOfUsersAndGroups", getIdOfGroupsAndUsersConcernedByShares(originalShares, shareUpdates));
-		UserUtils.findVisibles(eb, userId, customReturn,
-			extraParams,
-			true, true, false,
-			"fr", "AND (m.id IN {expectedIdsOfUsersAndGroups}) ",visibleResponse -> {
-			final Set<String> visibleUsersAndGroups = visibleResponse.stream()
-				.map(entry -> ((JsonObject) entry).getString("id"))
-				.collect(Collectors.toSet());
-			// Check that original shares are untouched or that the ones that are modified are modified accordingly to
-			// users/groups visibility
-			boolean ok = true;
-			final Set<String> originalUsersAndGroups = new HashSet<>();
-			for (Object originalShare : originalShares) {
-				final JsonObject share = (JsonObject) originalShare;
-				final String idOfShare = getUserOrGroupIdOfShare(share);
-				originalUsersAndGroups.add(idOfShare);
-				if(visibleUsersAndGroups.contains(idOfShare)) {
-					log.debug(idOfShare + " is visible so it can be changed");
-				} else {
-					final Set<String> originalRights = share.stream()
-						.filter(e -> !e.getKey().equals("userId") && !e.getKey().equals("groupId") && (Boolean) e.getValue())
-						.map(Map.Entry::getKey)
-						.collect(Collectors.toSet());
-					final Set<String> desiredRights = shareUpdates.getOrDefault(idOfShare, Collections.emptySet());
-					if(desiredRights.isEmpty()) {
-						log.debug("OK - manager can remove shares");
-					} else if(desiredRights.equals(originalRights)) {
-						log.debug("OK - desired rights and original rights are the same for " + idOfShare);
-					} else {
-						log.warn("KO - desired rights and original rights differ for " + idOfShare + " but the user has no visibility on it");
-						ok = false;
-						break;
-					}
-				}
-			}
-			if(ok) {
-				// Check that added groups or users do not concern users or groups that the user does not have access to
-				final Set<String> unmatchedUserIds = shareUpdates.keySet().stream()
-					.filter(id -> !originalUsersAndGroups.contains(id)) // Added users and groups
-					.filter(id -> !visibleUsersAndGroups.contains(id))
-					.collect(Collectors.toSet());
-				if(unmatchedUserIds.isEmpty()) {
-					promise.complete(true);
-				} else if(unmatchedUserIds.size() > 1) {
-					// If there is more than 2 invisible users, we know that at least one of them is not visible at all so we cannot
-					// share the resource
-					log.warn("KO - tried to add rights to a user/group " + unmatchedUserIds + " not visible to user");
-					promise.complete(false);
-				} else {
-					//
-					getResourceOwnerUserId(resourceId).onSuccess(creatorId -> {
-						if(unmatchedUserIds.contains(creatorId)) {
-							promise.complete(true);
+
+		// Parallelizing the process of fetching the visibles
+		final int partitionSize = 50;
+		final List<List<String>> idsOfShareChunks = Lists.partition(getIdOfGroupsAndUsersConcernedByShares(originalShares, shareUpdates), partitionSize);
+		final List<Future<JsonArray>> visibleFutures = new ArrayList<>();
+		idsOfShareChunks.forEach(idsOfShareChunk -> {
+			final Promise<JsonArray> visiblePromise = Promise.promise();
+			final JsonArray idsOfShare = new JsonArray();
+			idsOfShareChunk.forEach(idsOfShare::add);
+			final JsonObject extraParams = new JsonObject()
+					.put("expectedIdsOfUsersAndGroups", idsOfShare);
+			UserUtils.findVisibles(eb, userId, customReturn,
+					extraParams,
+					true, true, false,
+					"fr", "AND (m.id IN {expectedIdsOfUsersAndGroups}) ",
+					visiblePromise::complete);
+			visibleFutures.add(visiblePromise.future());
+		});
+		Future.all(visibleFutures)
+				.map(futures -> futures.list().stream()
+						.map(result -> (JsonArray) result)
+						.collect(Collectors.toList()))
+				.onFailure(th -> {
+					log.error("Failed fetching visibles", th);
+					promise.fail("Failed fetching visibles : " + th.getMessage());
+				})
+				.onSuccess(visibleChunks -> {
+					final JsonArray visibleArray = new JsonArray();
+					visibleChunks.forEach(visibleArray::addAll);
+					final Set<String> visibleUsersAndGroups = visibleArray.stream()
+							.map(entry -> ((JsonObject) entry).getString("id"))
+							.collect(Collectors.toSet());
+					// Check that original shares are untouched or that the ones that are modified, are modified accordingly to
+					// users/groups visibility
+					boolean ok = true;
+					final Set<String> originalUsersAndGroups = new HashSet<>();
+					for (Object originalShare : originalShares) {
+						final JsonObject share = (JsonObject) originalShare;
+						final String idOfShare = getUserOrGroupIdOfShare(share);
+						originalUsersAndGroups.add(idOfShare);
+						if(visibleUsersAndGroups.contains(idOfShare)) {
+							log.debug(idOfShare + " is visible so it can be changed");
 						} else {
-							// For workspace, check if we want to add the owner of the resource
+							final Set<String> originalRights = share.stream()
+									.filter(e -> !e.getKey().equals("userId") && !e.getKey().equals("groupId") && (Boolean) e.getValue())
+									.map(Map.Entry::getKey)
+									.collect(Collectors.toSet());
+							final Set<String> desiredRights = shareUpdates.getOrDefault(idOfShare, Collections.emptySet());
+							if(desiredRights.isEmpty()) {
+								log.debug("OK - manager can remove shares");
+							} else if(desiredRights.equals(originalRights)) {
+								log.debug("OK - desired rights and original rights are the same for " + idOfShare);
+							} else {
+								log.warn("KO - desired rights and original rights differ for " + idOfShare + " but the user has no visibility on it");
+								ok = false;
+								break;
+							}
+						}
+					}
+					if(ok) {
+						// Check that added groups or users do not concern users or groups that the user does not have access to
+						final Set<String> unmatchedUserIds = shareUpdates.keySet().stream()
+								.filter(id -> !originalUsersAndGroups.contains(id)) // Added users and groups
+								.filter(id -> !visibleUsersAndGroups.contains(id))
+								.collect(Collectors.toSet());
+						if(unmatchedUserIds.isEmpty()) {
+							promise.complete(true);
+						} else if(unmatchedUserIds.size() > 1) {
+							// If there is more than 2 invisible users, we know that at least one of them is not visible at all so we cannot
+							// share the resource
 							log.warn("KO - tried to add rights to a user/group " + unmatchedUserIds + " not visible to user");
 							promise.complete(false);
+						} else {
+							//
+							getResourceOwnerUserId(resourceId).onSuccess(creatorId -> {
+								if(unmatchedUserIds.contains(creatorId)) {
+									promise.complete(true);
+								} else {
+									// For workspace, check if we want to add the owner of the resource
+									log.warn("KO - tried to add rights to a user/group " + unmatchedUserIds + " not visible to user");
+									promise.complete(false);
+								}
+							}).onFailure(promise::fail);
 						}
-					}).onFailure(promise::fail);
-				}
-			} else {
-				promise.complete(ok);
-			}
-		});
+					} else {
+						promise.complete(ok);
+					}
+				});
 		return promise.future();
 	}
 
-	private JsonArray getIdOfGroupsAndUsersConcernedByShares(final JsonArray originalShares, final Map<String, Set<String>> shareUpdates) {
-		final JsonArray prefilteredIds = new JsonArray();
+	private List<String> getIdOfGroupsAndUsersConcernedByShares(final JsonArray originalShares, final Map<String, Set<String>> shareUpdates) {
 		final Set<String> ids = new HashSet<>();
 		for (Object originalShare : originalShares) {
 			final JsonObject share = (JsonObject) originalShare;
@@ -546,10 +568,7 @@ public abstract class GenericShareService implements ShareService {
 			ids.add(idOfShare);
 		}
 		ids.addAll(shareUpdates.keySet());
-		for (String id : ids) {
-			prefilteredIds.add(id);
-		}
-		return prefilteredIds;
+		return new ArrayList<>(ids);
 	}
 
 	private String getUserOrGroupIdOfShare(final JsonObject share) {

--- a/common/src/main/java/org/entcore/common/user/UserUtils.java
+++ b/common/src/main/java/org/entcore/common/user/UserUtils.java
@@ -41,6 +41,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.http.HttpServerRequest;
@@ -218,7 +219,7 @@ public class UserUtils {
 			m.put("additionnalParams", additionnalParams);
 		}
 		m.put("userId", userId);
-		eb.request(COMMUNICATION_USERS, m, new Handler<AsyncResult<Message<JsonArray>>>() {
+		eb.request(COMMUNICATION_USERS, m, new DeliveryOptions().setSendTimeout(60000), new Handler<AsyncResult<Message<JsonArray>>>() {
 
 			@Override
 			public void handle(AsyncResult<Message<JsonArray>> res) {


### PR DESCRIPTION
# Description

Lorsque les favoris de partage contiennent un nombre important d'utilisateurs, la requête de recherche des utilisateurs visibles peut atteindre un timeout.
Actions réalisées : 
- élévation de la limite du timeout pour l'appel à la méthode findVisibles (30s → 1m)
- mise en parallèle de l'appel à la méthode findVisible par lots d'id

Avec ces changements on parvient à répondre dans cas reproductible en recette-release : le partage à un favoris contenant plus de 4000 utilisateurs.

## Fixes

https://edifice-community.atlassian.net/browse/WB-3666

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Tests manuels directement sur recette-release (environnement pour lequel le bug était reproductible)

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: