### PR TITLE
feat(conversation): #WB-3434, progress bar component,  displaying the used storage space compared to the allowed quota

### DIFF
--- a/conversation/frontend/src/components/ProgressBar.css
+++ b/conversation/frontend/src/components/ProgressBar.css
@@ -1,0 +1,7 @@
+.progress {
+    height: 20px;
+}
+.progress .label {
+    line-height: 18px;
+    font-weight: 600;
+}

--- a/conversation/frontend/src/components/ProgressBar.tsx
+++ b/conversation/frontend/src/components/ProgressBar.tsx
@@ -1,0 +1,30 @@
+import { Dropdown, IconButton, IconButtonProps } from '@edifice.io/react';
+import { Fragment, RefAttributes } from 'react';
+
+export type ProgressBarProps = {
+  label: string;
+  labelPlacement?: 'start' | 'center' | 'end';
+  className?: string;
+  bars: {
+    progress: number;
+    style?: 'plain' | 'stripes' | 'animated-stripes';
+    className?: string;
+  }[];
+};
+
+export function ProgressBar(props: ProgressBarProps) {
+  return (
+    <div
+      className="progress"
+      role="progressbar"
+      aria-label="Success example"
+      aria-valuenow="25"
+      aria-valuemin="0"
+      aria-valuemax="100"
+    >
+      <div className="progress-bar bg-success" style="width: 25%">
+        25%
+      </div>
+    </div>
+  );
+}

--- a/conversation/frontend/src/components/ProgressBar.tsx
+++ b/conversation/frontend/src/components/ProgressBar.tsx
@@ -2,7 +2,6 @@ import { clsx } from 'clsx';
 import './ProgressBar.css';
 
 type BarColor = 'info' | 'warning' | 'danger';
-type BarFill = 'plain' | 'stripes' | 'animated-stripes';
 
 export type ProgressBarProps = {
   /** Label to display. */
@@ -21,22 +20,24 @@ export type ProgressBarProps = {
      */
     overflow?: boolean;
   };
+  /** Invisible Label, for accessibility purposes. Default to the value of `label`.  */
+  ariaLabel?: string;
   /** Progress to display, in percent from 0 to 100. */
   progress: number;
   progressOptions?: {
     /** Keyword defining the color of the bar. */
     color?: BarColor;
-    /** Style of bar. */
-    fill?: BarFill;
   };
 };
 
 export function ProgressBar({
   label,
   labelOptions,
+  ariaLabel,
   progressOptions,
   ...props
 }: ProgressBarProps) {
+  // Ensure progress is between 0 and 100, inclusive.
   const progress = Math.min(100, Math.max(0, Math.round(props.progress)));
 
   let overflow = false;
@@ -44,13 +45,9 @@ export function ProgressBar({
     overflow = true;
   }
 
-  let color: BarColor = 'info',
-    fill: BarFill = 'plain';
+  let color: BarColor = 'info';
   if (progressOptions?.color) {
     color = progressOptions.color;
-  }
-  if (progressOptions?.fill) {
-    fill = progressOptions.fill;
   }
 
   const barClassName = clsx('progress-bar', {
@@ -58,8 +55,6 @@ export function ProgressBar({
     'bg-secondary-300': color === 'info',
     'bg-orange-300': color === 'warning',
     'bg-red-300': color === 'danger',
-    'progress-bar-striped': fill === 'stripes' || fill === 'animated-stripes',
-    'progress-bar-animated': fill === 'animated-stripes',
     'w-100': typeof labelOptions?.justify === 'string',
   });
 
@@ -67,8 +62,8 @@ export function ProgressBar({
     <div
       className="progress border"
       role="progressbar"
-      aria-label="Success example"
-      aria-valuenow={25}
+      aria-label={ariaLabel ?? label}
+      aria-valuenow={progress}
       aria-valuemin={0}
       aria-valuemax={100}
     >
@@ -76,7 +71,7 @@ export function ProgressBar({
         <div
           className={barClassName}
           style={{
-            background: `linear-gradient(to right, transparent ${progress}%, white ${100 - progress}%)`,
+            background: `linear-gradient(to right, transparent ${progress}%, white ${progress}%, white ${100 - progress}%)`,
           }}
         >
           <div

--- a/conversation/frontend/src/components/ProgressBar.tsx
+++ b/conversation/frontend/src/components/ProgressBar.tsx
@@ -1,4 +1,8 @@
 import { clsx } from 'clsx';
+import './ProgressBar.css';
+
+type BarColor = 'info' | 'warning' | 'danger';
+type BarFill = 'plain' | 'stripes' | 'animated-stripes';
 
 export type ProgressBarProps = {
   /** Label to display. */
@@ -6,8 +10,8 @@ export type ProgressBarProps = {
   /** Options to customize the label. */
   labelOptions?: {
     /**
-     * Force the position of the label within the bar container.
-     * When `undefined`, the label is centered in the progress, not container.
+     * Force the position of the label within the bar *container*.
+     * When `undefined`, the label is centered inside the *progress bar*, not the container.
      */
     justify?: 'start' | 'center' | 'end';
     /**
@@ -21,9 +25,9 @@ export type ProgressBarProps = {
   progress: number;
   progressOptions?: {
     /** Keyword defining the color of the bar. */
-    color?: 'info' | 'warning' | 'danger';
+    color?: BarColor;
     /** Style of bar. */
-    fill?: 'plain' | 'stripes' | 'animated-stripes';
+    fill?: BarFill;
   };
 };
 
@@ -33,26 +37,30 @@ export function ProgressBar({
   progressOptions,
   ...props
 }: ProgressBarProps) {
-  const progress = Math.round(props.progress);
+  const progress = Math.min(100, Math.max(0, Math.round(props.progress)));
 
   let overflow = false;
-  if (labelOptions) {
-    if (labelOptions.overflow === true || labelOptions.justify) {
-      overflow = true;
-    }
+  if (labelOptions?.overflow === true || labelOptions?.justify) {
+    overflow = true;
   }
 
-  let color: 'info' | 'warning' | 'danger' = 'info';
-  if (progressOptions) {
-    if (progressOptions.color) {
-      color = progressOptions.color;
-    }
+  let color: BarColor = 'info',
+    fill: BarFill = 'plain';
+  if (progressOptions?.color) {
+    color = progressOptions.color;
+  }
+  if (progressOptions?.fill) {
+    fill = progressOptions.fill;
   }
 
-  const barClassName = clsx('progress-bar text-gray-800', {
+  const barClassName = clsx('progress-bar', {
     'overflow-visible': overflow,
-    'bg-warning': color === 'warning',
-    'bg-danger': color === 'danger',
+    'bg-secondary-300': color === 'info',
+    'bg-orange-300': color === 'warning',
+    'bg-red-300': color === 'danger',
+    'progress-bar-striped': fill === 'stripes' || fill === 'animated-stripes',
+    'progress-bar-animated': fill === 'animated-stripes',
+    'w-100': typeof labelOptions?.justify === 'string',
   });
 
   return (
@@ -63,11 +71,28 @@ export function ProgressBar({
       aria-valuenow={25}
       aria-valuemin={0}
       aria-valuemax={100}
-      style={{ height: '20px' }}
     >
-      <div className={barClassName} style={{ width: `${progress}%` }}>
-        {label}
-      </div>
+      {labelOptions?.justify ? (
+        <div
+          className={barClassName}
+          style={{
+            background: `linear-gradient(to right, transparent ${progress}%, white ${100 - progress}%)`,
+          }}
+        >
+          <div
+            className={clsx(
+              'label text-gray-800 mx-8',
+              labelOptions?.justify && 'align-self-' + labelOptions.justify,
+            )}
+          >
+            {label}
+          </div>
+        </div>
+      ) : (
+        <div className={barClassName} style={{ width: `${progress}%` }}>
+          <div className="label text-gray-800">{label}</div>
+        </div>
+      )}
     </div>
   );
 }

--- a/conversation/frontend/src/components/ProgressBar.tsx
+++ b/conversation/frontend/src/components/ProgressBar.tsx
@@ -1,29 +1,72 @@
-import { Dropdown, IconButton, IconButtonProps } from '@edifice.io/react';
-import { Fragment, RefAttributes } from 'react';
+import { clsx } from 'clsx';
 
 export type ProgressBarProps = {
+  /** Label to display. */
   label: string;
-  labelPlacement?: 'start' | 'center' | 'end';
-  className?: string;
-  bars: {
-    progress: number;
-    style?: 'plain' | 'stripes' | 'animated-stripes';
-    className?: string;
-  }[];
+  /** Options to customize the label. */
+  labelOptions?: {
+    /**
+     * Force the position of the label within the bar container.
+     * When `undefined`, the label is centered in the progress, not container.
+     */
+    justify?: 'start' | 'center' | 'end';
+    /**
+     * Allow the label to overflow the progress bar, bleeding inside the container.
+     * Otherwise, the label is clipped to the progress.
+     * Default to `false`, but forced to `true` when `justify` is defined.
+     */
+    overflow?: boolean;
+  };
+  /** Progress to display, in percent from 0 to 100. */
+  progress: number;
+  progressOptions?: {
+    /** Keyword defining the color of the bar. */
+    color?: 'info' | 'warning' | 'danger';
+    /** Style of bar. */
+    fill?: 'plain' | 'stripes' | 'animated-stripes';
+  };
 };
 
-export function ProgressBar(props: ProgressBarProps) {
+export function ProgressBar({
+  label,
+  labelOptions,
+  progressOptions,
+  ...props
+}: ProgressBarProps) {
+  const progress = Math.round(props.progress);
+
+  let overflow = false;
+  if (labelOptions) {
+    if (labelOptions.overflow === true || labelOptions.justify) {
+      overflow = true;
+    }
+  }
+
+  let color: 'info' | 'warning' | 'danger' = 'info';
+  if (progressOptions) {
+    if (progressOptions.color) {
+      color = progressOptions.color;
+    }
+  }
+
+  const barClassName = clsx('progress-bar text-gray-800', {
+    'overflow-visible': overflow,
+    'bg-warning': color === 'warning',
+    'bg-danger': color === 'danger',
+  });
+
   return (
     <div
-      className="progress"
+      className="progress border"
       role="progressbar"
       aria-label="Success example"
-      aria-valuenow="25"
-      aria-valuemin="0"
-      aria-valuemax="100"
+      aria-valuenow={25}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      style={{ height: '20px' }}
     >
-      <div className="progress-bar bg-success" style="width: 25%">
-        25%
+      <div className={barClassName} style={{ width: `${progress}%` }}>
+        {label}
       </div>
     </div>
   );

--- a/conversation/frontend/src/components/index.ts
+++ b/conversation/frontend/src/components/index.ts
@@ -1,1 +1,2 @@
 export * from './FolderActionDropDown';
+export * from './ProgressBar';

--- a/conversation/frontend/src/features/Menu/components/DesktopMenu.tsx
+++ b/conversation/frontend/src/features/Menu/components/DesktopMenu.tsx
@@ -4,14 +4,23 @@ import {
   IconSend,
   IconWrite,
 } from '@edifice.io/react/icons';
-import { Menu, SortableTree, TreeItem } from '@edifice.io/react';
+import {
+  Menu,
+  SortableTree,
+  TreeItem,
+  useEdificeClient,
+} from '@edifice.io/react';
 import { NOOP } from '@edifice.io/utilities';
 import { useNavigate, useRouteLoaderData } from 'react-router-dom';
 import { Folder } from '~/models';
 import { useMenuData } from '../hooks/useMenuData';
-import { t } from 'i18next';
 import './DesktopMenu.css';
-import { FolderActionDropDown } from '~/components';
+import {
+  FolderActionDropDown,
+  ProgressBar,
+  ProgressBarProps,
+} from '~/components';
+import { useTranslation } from 'react-i18next';
 
 type FolderTreeItem = TreeItem & { folder: Folder };
 
@@ -39,6 +48,8 @@ export function DesktopMenu() {
     foldersTree: Folder[];
     actions: Record<string, boolean>;
   };
+  const { appCode } = useEdificeClient();
+  const { t } = useTranslation(appCode);
   const {
     counters,
     renderBadge,
@@ -51,6 +62,18 @@ export function DesktopMenu() {
   }
 
   const userFolders = buildTree(foldersTree);
+
+  const progressBarProps: ProgressBarProps = {
+    label: 'Tagada',
+    progress: 90,
+    labelOptions: {
+      justify: 'end',
+    },
+    progressOptions: {
+      fill: 'stripes',
+      color: 'danger',
+    },
+  };
 
   const navigateTo = (systemFolderId: string) => {
     navigate(`/${systemFolderId}`);
@@ -129,7 +152,10 @@ export function DesktopMenu() {
       <Menu.Item>
         <div className="w-100 border-bottom pt-8 mb-12"></div>
       </Menu.Item>
-      <Menu.Item>TODO Espace utilisé</Menu.Item>
+      <Menu.Item>
+        <b>{t('used.space')}</b>
+        <ProgressBar {...progressBarProps} />
+      </Menu.Item>
     </Menu>
   );
 }

--- a/conversation/frontend/src/features/Menu/components/DesktopMenu.tsx
+++ b/conversation/frontend/src/features/Menu/components/DesktopMenu.tsx
@@ -64,14 +64,14 @@ export function DesktopMenu() {
   const userFolders = buildTree(foldersTree);
 
   const progressBarProps: ProgressBarProps = {
-    label: 'Tagada',
-    progress: 90,
+    label: 'TODO',
+    progress: 45.8,
     labelOptions: {
       justify: 'end',
     },
     progressOptions: {
-      fill: 'stripes',
-      color: 'danger',
+      fill: 'animated-stripes',
+      color: 'warning',
     },
   };
 

--- a/conversation/frontend/src/features/Menu/components/DesktopMenu.tsx
+++ b/conversation/frontend/src/features/Menu/components/DesktopMenu.tsx
@@ -21,6 +21,7 @@ import {
   ProgressBarProps,
 } from '~/components';
 import { useTranslation } from 'react-i18next';
+import { useUsedSpace } from '~/hooks';
 
 type FolderTreeItem = TreeItem & { folder: Folder };
 
@@ -40,6 +41,8 @@ function buildTree(folders: Folder[]) {
       return item;
     });
 }
+/** Converts a value in bytes to mega-bytes (rounded) */
+const bytesToMegabytes = (bytes: number) => Math.round(bytes / (1024 * 1024));
 
 /** The navigation menu among folders, intended for desktop resolutions */
 export function DesktopMenu() {
@@ -50,12 +53,15 @@ export function DesktopMenu() {
   };
   const { appCode } = useEdificeClient();
   const { t } = useTranslation(appCode);
+  const { t: common_t } = useTranslation('common');
   const {
     counters,
     renderBadge,
     selectedSystemFolderId,
     selectedUserFolderId,
   } = useMenuData();
+
+  const { usage, quota } = useUsedSpace();
 
   if (!foldersTree || !actions) {
     return null;
@@ -64,13 +70,15 @@ export function DesktopMenu() {
   const userFolders = buildTree(foldersTree);
 
   const progressBarProps: ProgressBarProps = {
-    label: 'TODO',
-    progress: 45.8,
+    label:
+      quota > 0
+        ? `${bytesToMegabytes(usage)} / ${bytesToMegabytes(quota)} ${common_t('mb')}`
+        : '',
+    progress: quota > 0 ? (usage * 100) / quota : 0,
     labelOptions: {
       justify: 'end',
     },
     progressOptions: {
-      fill: 'animated-stripes',
       color: 'warning',
     },
   };

--- a/conversation/frontend/src/hooks/index.ts
+++ b/conversation/frontend/src/hooks/index.ts
@@ -1,1 +1,2 @@
+export * from './useUsedSpace';
 export * from './useSelectedFolder';

--- a/conversation/frontend/src/hooks/useUsedSpace.ts
+++ b/conversation/frontend/src/hooks/useUsedSpace.ts
@@ -1,0 +1,29 @@
+import { IQuotaAndUsage } from '@edifice.io/client';
+import { useEdificeClient } from '@edifice.io/react';
+
+/**
+ * Custom hook to retrieve the used space and quota information.
+ *
+ * This hook uses the `useEdificeClient` hook to get the client instance and session query.
+ * If the client is not initialized, it returns default values for usage and quota.
+ * Otherwise, it extracts the quota and usage information from the session query data.
+ *
+ * @returns An object containing the `usage` and `quota` values.
+ * @property {number} usage - The amount of space used, in bytes.
+ * @property {number} quota - The total quota available, in bytes.
+ */
+export function useUsedSpace() {
+  const { init, sessionQuery } = useEdificeClient();
+
+  if (!init) {
+    return {
+      usage: 0,
+      quota: 0,
+    };
+  }
+  const quotaAndUsage = sessionQuery?.data.quotaAndUsage as IQuotaAndUsage;
+  return {
+    usage: quotaAndUsage.storage,
+    quota: quotaAndUsage.quota,
+  };
+}

--- a/portal/src/main/resources/i18n/fr.json
+++ b/portal/src/main/resources/i18n/fr.json
@@ -670,6 +670,7 @@
   "mediacentre": "Médiacentre",
   "max.file.size": "52428800",
   "maxicours": "Maxicours",
+  "mb": "Mo",
   "medialibrary.backtolist": "Retour à la liste",
   "medialibrary.compression.info": "Privilégiez des images qui pèsent moins de 500 ko pour éviter de ralentir le chargement des pages. Utilisez le curseur pour ajuster la taille de l'image.",
   "media.library.compression.max": "Fichier lourd",


### PR DESCRIPTION
# Description

The ProgressBar component should evolve in a future lot, to include more details.

## Fixes

WB-3434

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [X] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

none

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley: