### PR TITLE
fix: WB-3639, filter shares with visible users and groups

### DIFF
--- a/common/src/main/java/org/entcore/common/share/impl/GenericShareService.java
+++ b/common/src/main/java/org/entcore/common/share/impl/GenericShareService.java
@@ -459,15 +459,15 @@ public abstract class GenericShareService implements ShareService {
 	 * @param userId Id of the user who wants to perform the update
 	 * @param originalShares Actual shares of the user
 	 * @param shareUpdates Shares that the user wants to apply
-	 * @return A {@code Future} that completes with {@code true} iff all the detailed conditions
-	 * above were met and {@code false} otherwise.
+	 * @return A {@code Future} that completes with a set of visible shares iff all the detailed conditions
+	 * above were met and an empty set otherwise.
 	 */
-	private Future<Boolean> checkCanApplyShares(
+	private Future<Set<String>> getVisibleShares(
 		final String userId,
 		final String resourceId,
 		final JsonArray originalShares,
 		final Map<String, Set<String>> shareUpdates) {
-		final Promise<Boolean> promise = Promise.promise();
+		final Promise<Set<String>> promise = Promise.promise();
 		final String customReturn = "RETURN DISTINCT visibles.id as id, has(visibles.login) as isUser";
 
 		// Parallelizing the process of fetching the visibles
@@ -505,7 +505,7 @@ public abstract class GenericShareService implements ShareService {
 							.collect(Collectors.toSet());
 					// Check that original shares are untouched or that the ones that are modified, are modified accordingly to
 					// users/groups visibility
-					boolean ok = true;
+					boolean sharesAreValid = true;
 					final Set<String> originalUsersAndGroups = new HashSet<>();
 					for (Object originalShare : originalShares) {
 						final JsonObject share = (JsonObject) originalShare;
@@ -525,38 +525,23 @@ public abstract class GenericShareService implements ShareService {
 								log.debug("OK - desired rights and original rights are the same for " + idOfShare);
 							} else {
 								log.warn("KO - desired rights and original rights differ for " + idOfShare + " but the user has no visibility on it");
-								ok = false;
+								sharesAreValid = false;
 								break;
 							}
 						}
 					}
-					if(ok) {
-						// Check that added groups or users do not concern users or groups that the user does not have access to
+					if(sharesAreValid) {
 						final Set<String> unmatchedUserIds = shareUpdates.keySet().stream()
 								.filter(id -> !originalUsersAndGroups.contains(id)) // Added users and groups
 								.filter(id -> !visibleUsersAndGroups.contains(id))
 								.collect(Collectors.toSet());
-						if(unmatchedUserIds.isEmpty()) {
-							promise.complete(true);
-						} else if(unmatchedUserIds.size() > 1) {
-							// If there is more than 2 invisible users, we know that at least one of them is not visible at all so we cannot
-							// share the resource
-							log.warn("KO - tried to add rights to a user/group " + unmatchedUserIds + " not visible to user");
-							promise.complete(false);
-						} else {
-							//
-							getResourceOwnerUserId(resourceId).onSuccess(creatorId -> {
-								if(unmatchedUserIds.contains(creatorId)) {
-									promise.complete(true);
-								} else {
-									// For workspace, check if we want to add the owner of the resource
-									log.warn("KO - tried to add rights to a user/group " + unmatchedUserIds + " not visible to user");
-									promise.complete(false);
-								}
-							}).onFailure(promise::fail);
+						if(!unmatchedUserIds.isEmpty()) {
+							// Warning if added groups or users do not concern users or groups that the user does not have access to
+							log.warn("WARNING - tried to add rights on resource " + resourceId + "to a user/group " + unmatchedUserIds + " not visible to user");
 						}
+						promise.complete(visibleUsersAndGroups);
 					} else {
-						promise.complete(ok);
+						promise.complete(Collections.emptySet());
 					}
 				});
 		return promise.future();
@@ -600,11 +585,13 @@ public abstract class GenericShareService implements ShareService {
 																			final Map<String, Set<String>> membersActions,
 																			final Set<String> shareBookmarkIds) {
 		getOriginalShares(resourceId, userId)
-		.compose(shares -> checkCanApplyShares(userId, resourceId, shares, membersActions))
-		.onSuccess(e -> {
-			if(e) {
+		.compose(shares -> getVisibleShares(userId, resourceId, shares, membersActions))
+		.onSuccess(visibleShares -> {
+			if(!visibleShares.isEmpty()) {
 				//		final String preFilter = "AND m.id IN {members} ";
-				final Set<String> members = membersActions.keySet();
+				final Set<String> members = membersActions.keySet().stream()
+						.filter(visibleShares::contains)
+						.collect(Collectors.toSet());
 				final JsonObject params = new JsonObject().put("members", new JsonArray(new ArrayList<>(members)));
 				//		final String customReturn = "RETURN DISTINCT visibles.id as id, has(visibles.login) as isUser";
 				//		UserUtils.findVisibles(eb, userId, customReturn, params, true, true, false, null, preFilter, res -> {

--- a/tests/src/test/js/it/scenarios/workspace/share.ts
+++ b/tests/src/test/js/it/scenarios/workspace/share.ts
@@ -11,6 +11,7 @@ import {
   linkRoleToUsers,
   uploadFile,
   shareFile,
+  getShares,
   getBroadcastGroup,
   createBroadcastGroup,
   addCommRuleToGroup,
@@ -67,34 +68,34 @@ export function setup() {
   let chapeau;
   describe("[Workspace-Init] Initialize data", () => {
     const session: Session = <Session>authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD);
-    chapeau = createEmptyStructure(`Chapeau - ${schoolName}`, false, session)
-    const commonBG = createBroadcastGroup(broadcastGroupNameChapeau, chapeau, session)
-    structure1 = initSchool(schoolName, session)
-    structure2 = initSchool(schoolName2, session)
-    attachStructureAsChild(chapeau, structure1, session)
-    attachStructureAsChild(chapeau, structure2, session)
-    const teacherRole1 = getTeacherRole(structure1, session)
-    const teacherRole2 = getTeacherRole(structure2, session)
-    const parentRole2 = getParentRole(structure2, session)
-    const studentRole2 = getStudentRole(structure2, session)
+    chapeau = createEmptyStructure(`Chapeau - ${schoolName}`, false)
+    const commonBG = createBroadcastGroup(broadcastGroupNameChapeau, chapeau)
+    structure1 = initSchool(schoolName)
+    structure2 = initSchool(schoolName2)
+    attachStructureAsChild(chapeau, structure1)
+    attachStructureAsChild(chapeau, structure2)
+    const teacherRole1 = getTeacherRole(structure1)
+    const teacherRole2 = getTeacherRole(structure2)
+    const parentRole2 = getParentRole(structure2)
+    const studentRole2 = getStudentRole(structure2)
     const groupIds = [
       teacherRole1.id,
       teacherRole2.id
     ]
-    addCommRuleToGroup(commonBG.id, groupIds, session)
-    addCommRuleToGroup(parentRole2.id, [teacherRole1.id], session)
-    addCommRuleToGroup(studentRole2.id, [parentRole2.id], session)
+    addCommRuleToGroup(commonBG.id, groupIds)
+    addCommRuleToGroup(parentRole2.id, [teacherRole1.id])
+    addCommRuleToGroup(studentRole2.id, [parentRole2.id])
     if(aafImport) {
-      triggerImport(session)
+      triggerImport()
       sleep(aafImportPause)
     }
   });
   return { structure1, structure2, chapeau};
 }
 
-function initSchool(structureName, session) {
+function initSchool(structureName) {
   const structure = initStructure(structureName);
-  const role = createAndSetRole('Espace documentaire', session);
+  const role = createAndSetRole('Espace documentaire');
   const groups = [
     `Teachers from group ${structure.name}.`,
     `Enseignants du groupe ${structure.name}.`,
@@ -103,10 +104,10 @@ function initSchool(structureName, session) {
     `Relatives from group ${structure.name}.`,
     `Parents du groupe ${structure.name}.`
   ]
-  linkRoleToUsers(structure, role, groups, session);
-  const teacherRole = getTeacherRole(structure, session)
-  const broadcastGroup = createBroadcastGroup(broadcastGroupName, structure, session);
-  addCommunicationBetweenGroups(teacherRole.id, broadcastGroup.id, session)
+  linkRoleToUsers(structure, role, groups);
+  const teacherRole = getTeacherRole(structure)
+  const broadcastGroup = createBroadcastGroup(broadcastGroupName, structure);
+  addCommunicationBetweenGroups(teacherRole.id, broadcastGroup.id)
   return structure
 }
 
@@ -142,15 +143,39 @@ function checkShareKo(res, checkName) {
   }
 }
 
+function checkPresentShares(res, sharesType, expectedSharesToBePresent, checkName) {
+  const checks = {}
+  checks[checkName] = (r) => {
+    return expectedSharesToBePresent
+        .every(expectedShare => r[sharesType].visibles.map(actualShare => actualShare.id).includes(expectedShare))
+  }
+  const ok = check(res, checks)
+  if (!ok) {
+    console.error(checkName, res)
+  }
+}
+
+function checkAbsentShares(res, sharesType, expectedSharesToBeAbsent, checkName) {
+  const checks = {}
+  checks[checkName] = (r) => {
+    return expectedSharesToBeAbsent
+        .every(expectedShare => !r[sharesType].visibles.map(actualShare => actualShare.id).includes(expectedShare))
+  }
+  const ok = check(res, checks)
+  if (!ok) {
+    console.error(checkName, res)
+  }
+}
+
 function testSharesViaProfileGroupInDifferentSchools(data) {
   const { structure1, structure2 } = data;
   describe('[Workspace] Test shares via profile groups in two different schools', () => {
     let res;
-    const session = <Session>authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD);
-    const users1 = getUsersOfSchool(structure1, session);
-    const users2 = getUsersOfSchool(structure2, session);
-    const parentRole2 = getParentRole(structure2, session)
-    const studentRole2 = getStudentRole(structure2, session)
+    authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD);
+    const users1 = getUsersOfSchool(structure1);
+    const users2 = getUsersOfSchool(structure2);
+    const parentRole2 = getParentRole(structure2)
+    const studentRole2 = getStudentRole(structure2)
     const teacher1 = getRandomUserWithProfile(users1, 'Teacher');
     const teacher12 = getRandomUserWithProfile(users1, 'Teacher', [teacher1]);
     const parent = getRandomUserWithProfile(users2, 'Relative')
@@ -158,31 +183,35 @@ function testSharesViaProfileGroupInDifferentSchools(data) {
     console.log("Teacher 1.2 - ", teacher12.login);
     console.log("Parent - ", parent.login);
     // Teacher upload a file
-    let teacherSession = <Session>authenticateWeb(teacher1.login, 'password');
-    const uploadedFile = uploadFile(fileToUpload, teacherSession);
+    authenticateWeb(teacher1.login, 'password');
+    const uploadedFile = uploadFile(fileToUpload);
     const fileId = uploadedFile._id;
     // Share this file to parents 2 as a manager -> ok
     const shares = {bookmarks: {}, groups: {}, users: {}}
     shares.groups[parentRole2.id] = WS_MANAGER_SHARE;
-    res = shareFile(fileId, shares, teacherSession);
+    res = shareFile(fileId, shares);
     checkShareOk(res, 'teacher of school 1 shares to parents group of school 2')
+    res = getShares(fileId)
+    checkPresentShares(res, "groups", [parentRole2.id], "parents group of school 2 appears in shares")
     // Parent of school 2 tries to share it to students of school 2 -> ok
     let parentSession = <Session>authenticateWeb(parent.login, 'password');
     shares.groups[studentRole2.id] = WS_READER_SHARE;
-    res = shareFile(fileId, shares, parentSession)
+    res = shareFile(fileId, shares)
     checkShareOk(res, 'parent of school 2 shares to students of school 2')
+    res = getShares(fileId)
+    checkPresentShares(res, "groups", [studentRole2.id], "student group of school 2 appears in shares")
     // Teacher 2 of school 1 tries to modify shares of students of school 2 -> ko
     shares.groups[studentRole2.id] = WS_MANAGER_SHARE;
-    let teacher12Session = <Session>authenticateWeb(teacher12.login, 'password')
-    res = shareFile(fileId, shares, teacher12Session)
+    authenticateWeb(teacher12.login, 'password')
+    res = shareFile(fileId, shares)
     checkShareKo(res, 'other teacher of school 1 tries to modify shares of student of school 2')
     // Parent of school 2 tries to do the same thing -> ok
     switchSession(parentSession);
-    res = shareFile(fileId, shares, teacher12Session)
+    res = shareFile(fileId, shares)
     checkShareOk(res, 'parent of school 2 tries to modify shares of student of school 2')
     // Parent of school 2 tries to add teacher of school 1 (i.e. the creator) as a manager -> ok
     shares.users[teacher1.id] = WS_MANAGER_SHARE
-    res = shareFile(fileId, shares, teacher12Session)
+    res = shareFile(fileId, shares)
     checkShareOk(res, 'parent of school 2 tries to add creator as a manager')
   })
 }
@@ -190,11 +219,11 @@ function testSharesViaBroadcastGroupInDifferentSchools(data) {
   const { structure1, structure2, chapeau } = data;
   describe('[Workspace] Test shares to broadcast group in two different schools', () => {
     let res;
-    const session = <Session>authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD);
-    const users1 = getUsersOfSchool(structure1, session);
-    const users2 = getUsersOfSchool(structure2, session);
-    const broadcastGroup = getBroadcastGroup(broadcastGroupNameChapeau, chapeau, session);
-    const broadcastGroupSchool1 = getBroadcastGroup(broadcastGroupName, structure1, session);
+    authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD);
+    const users1 = getUsersOfSchool(structure1);
+    const users2 = getUsersOfSchool(structure2);
+    const broadcastGroup = getBroadcastGroup(broadcastGroupNameChapeau, chapeau);
+    const broadcastGroupSchool1 = getBroadcastGroup(broadcastGroupName, structure1);
     const teachers1 = users1.filter(u => u.type === 'Teacher')
     const teachers2 = users2.filter(u => u.type === 'Teacher')
     const students1 = users1.filter(u => u.type === 'Student')
@@ -212,29 +241,33 @@ function testSharesViaBroadcastGroupInDifferentSchools(data) {
     console.log("Student 1 - ", firstStudent1.login);
     console.log("Student 2 - ", firstStudent2.login);
     // Teacher upload a file
-    let teacherSession = <Session>authenticateWeb(teacher1.login, 'password');
-    const uploadedFile = uploadFile(fileToUpload, teacherSession);
+    authenticateWeb(teacher1.login, 'password');
+    const uploadedFile = uploadFile(fileToUpload);
     const fileId = uploadedFile._id;
     // Share this file to teacher 2 as a manager
     const shares = {bookmarks: {}, groups: {}, users: {}}
     shares.groups[broadcastGroup.id] = WS_MANAGER_SHARE;
-    res = shareFile(fileId, shares, teacherSession);
+    res = shareFile(fileId, shares);
     checkShareOk(res, 'teacher of school 1 shares to chapeau broadcast group')
+    res = getShares(fileId)
+    checkPresentShares(res, "groups", [broadcastGroup.id], "chapeau broadcast group appears in shares")
     // Teacher of school 2 shares it to one of the student of school 2 => ok
-    let teacher2Session = <Session>authenticateWeb(teacher2.login, 'password');
+    authenticateWeb(teacher2.login, 'password');
     shares.users[firstStudent2.id] = WS_MANAGER_SHARE;
-    res = shareFile(fileId, shares, teacher2Session);
+    res = shareFile(fileId, shares);
     checkShareOk(res, 'teacher of school 2 shares to student of school 2')
+    res = getShares(fileId)
+    checkPresentShares(res, "users", [firstStudent2.id], "student of school 2 appears in shares")
     // Student of school 2 tries to share it to student of school 1 -> ko
-    let studentSession = <Session>authenticateWeb(firstStudent1.login, 'password');
+    authenticateWeb(firstStudent1.login, 'password');
     shares.users[firstStudent1.id] = WS_READER_SHARE;
-    res = shareFile(fileId, shares, studentSession)
+    res = shareFile(fileId, shares)
     checkShareKo(res, 'student of school 2 shares to student of school 1')
     delete shares.users[firstStudent1.id]
     // Student of school 2 tries to share it to broadcast group of school 1 -> ko
     shares.groups[broadcastGroupSchool1.id] = WS_MANAGER_SHARE;
-    res = shareFile(fileId, shares, studentSession)
-    checkShareKo(res, 'student of school 2 shares to student of school 1')
+    res = shareFile(fileId, shares)
+    checkShareKo(res, 'student of school 2 shares to broadcast group of school 1')
   })
 }
 
@@ -242,9 +275,9 @@ function testSharesViaBroadcastGroupInSameSchool(data) {
   const { structure1 } = data;
   describe('[Workspace] Test shares to broadcast group in the same school', () => {
     let res;
-    const session = <Session>authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD);
-    const users = getUsersOfSchool(structure1, session);
-    const broadcastGroup = getBroadcastGroup(broadcastGroupName, structure1, session);
+    authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD);
+    const users = getUsersOfSchool(structure1);
+    const broadcastGroup = getBroadcastGroup(broadcastGroupName, structure1);
     const students = users.filter(u => u.type === 'Student')
     const teacher = getRandomUserWithProfile(users, 'Teacher');
     const classId = teacher.classes[0].id
@@ -258,37 +291,47 @@ function testSharesViaBroadcastGroupInSameSchool(data) {
     console.log("Student 3 - ", thirdStudent.login);
     // Teacher upload a file
     let teacherSession = <Session>authenticateWeb(teacher.login, 'password');
-    const uploadedFile = uploadFile(fileToUpload, teacherSession);
+    const uploadedFile = uploadFile(fileToUpload);
     const fileId = uploadedFile._id;
     // Share this file to firstStudent as a manager
     const shares = {bookmarks: {}, groups: {}, users: {}}
     shares.users[firstStudent.id] = WS_MANAGER_SHARE;
-    res = shareFile(fileId, shares, teacherSession);
+    res = shareFile(fileId, shares);
     checkShareOk(res, 'teacher shares to first student')
-    // First student tries to share it to the list -> ko
+    res = getShares(fileId)
+    checkPresentShares(res, 'users', [firstStudent.id], 'first student appears in shares')
+    // First student tries to share it to the list -> not shared because not visible
     let firstStudentSession = <Session>authenticateWeb(firstStudent.login, 'password');
     shares.groups[broadcastGroup.id] = WS_READER_SHARE;
-    res = shareFile(fileId, shares, firstStudentSession)
-    checkShareKo(res, 'student shares to broadcast group')
+    res = shareFile(fileId, shares)
+    checkShareOk(res, 'student tries to share to broadcast group')
+    res = getShares(fileId)
+    checkAbsentShares(res, 'groups', [broadcastGroup.id], 'broadcast group does not appear in shares')
     // First student tries to share it to secondStudent -> ok
     delete shares.groups[broadcastGroup.id];
     shares.users[secondStudent.id] = WS_READER_SHARE;
-    res = shareFile(fileId, shares, firstStudentSession)
+    res = shareFile(fileId, shares)
     checkShareOk(res, 'student shares to second student')
+    res = getShares(fileId)
+    checkPresentShares(res, 'users', [secondStudent.id], 'second student appears in shares')
     // Teacher shares it with the list -> ok
     shares.groups[broadcastGroup.id] = WS_READER_SHARE;
     switchSession(teacherSession)
-    res = shareFile(fileId, shares, teacherSession)
+    res = shareFile(fileId, shares)
     checkShareOk(res, 'teacher shares to broadcast group')
+    res = getShares(fileId)
+    checkPresentShares(res, 'groups', [broadcastGroup.id], 'broadcast group appears in shares')
     // First student tries to share it to third student -> ok
     shares.users[thirdStudent.id] = WS_READER_SHARE;
     switchSession(firstStudentSession)
-    res = shareFile(fileId, shares, firstStudentSession)
+    res = shareFile(fileId, shares)
     checkShareOk(res, 'student shares to third student')
+    res = getShares(fileId)
+    checkPresentShares(res, 'users', [thirdStudent.id], 'third student appears in shares')
     // thrid student tries to remove share to the list -> ko
     delete shares.groups[broadcastGroup.id];
-    let thirdStudentSession = <Session>authenticateWeb(thirdStudent.login, 'password')
-    res = shareFile(fileId, shares, thirdStudentSession)
+    authenticateWeb(thirdStudent.login, 'password')
+    res = shareFile(fileId, shares)
     checkShareKo(res, 'non manager cannot remove shares')
   })
 }


### PR DESCRIPTION
# Description

Au moment de partager une ressource via un favori de partage, depuis ce [ticket](https://edifice-community.atlassian.net/browse/WB-2242) on vérifie les droits de communication (techniquement les "visibles").
Si on perd les droits de partage vers un des membres du favori (utlisateur ou groupe), le partage est impossible. Ça n'est pas un comportement souhaité.

Désormais on récupère la liste des utilisateurs ou groupes visibles (pour lesquels on a les droits de com) et on n'effectue le partage que pour les membres du favoris de partage qui sont visibles.

PR associée : https://github.com/edificeio/edifice-k6-commons/pull/5

## Fixes

https://edifice-community.atlassian.net/browse/WB-3639

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Tests d'intégration K6
Test devs manuels en environnement de recette.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: