### PR TITLE
fix(common): #ENABLING-199, better check of dates type when importing resources into mongo

### DIFF
--- a/common/src/main/java/org/entcore/common/folders/impl/DocumentHelper.java
+++ b/common/src/main/java/org/entcore/common/folders/impl/DocumentHelper.java
@@ -154,30 +154,29 @@ public class DocumentHelper {
 		}
 	}
 
-	public static JsonObject setModified(JsonObject doc, Date date)
-	{
-		try
-		{
-			// Check that the dates are in string format
-			String m = doc.getString("modified");
-			String c = doc.getString("created");
-
-			//If we get there, the dates should be strings
+	public static JsonObject setModified(JsonObject doc, Date date) {
+		Object modified = doc.getValue("modified");
+		Object created = doc.getValue("created");
+		// Check that the dates are in string format
+		// we also check for nullity to keep the same behaviour as in vertx 3
+		if((modified == null || modified instanceof String) &&
+			(created == null || created instanceof String)) {
 			String now = MongoDb.formatDate(date != null ? date : new Date());
 
 			doc.put("modified", now);
 
-			if(c == null)
+			if(created == null) {
 				doc.put("created", now);
-		}
-		catch(Exception e)
-		{
+			}
+		} else {
+			// It appears that those dates were in fact objects
 			JsonObject now = MongoDb.now();
 
 			doc.put("modified", now);
 
-			if(doc.getJsonObject("created") == null)
-					doc.put("created", now);
+			if(created == null) {
+				doc.put("created", now);
+			}
 		}
 
 		return doc;


### PR DESCRIPTION
# Description

Since the migration from Vertx 3 to Vertx 4, the change in the method JsonObject.getString introduced a regression in the way we handle `modified` and `created` dates in imported resources. This caused imported resources to not be editable.
This PR changes the way we determine if a field in a JsonObject is a String to circumvent this problem.

## Fixes

EN-199

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Duplicate a scrapbook
2. Edit the scrapbook

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: