### PR TITLE
fix(common): #WB2-1957, skip creating ACCESS EVENT for mobile webview

### DIFF
--- a/common/src/main/java/org/entcore/common/events/EventHelper.java
+++ b/common/src/main/java/org/entcore/common/events/EventHelper.java
@@ -22,6 +22,12 @@ public class EventHelper {
     }
 
     public void onAccess(final HttpServerRequest request) {
+        // #WB2-1957: Skip creating ACCESS EVENT for mobile webview
+        final String xApp = request.getParam("xApp");
+        if ("mobile".equals(xApp)) {
+            return;
+        }
+
         try {
             store.createAndStoreEvent(ACCESS_EVENT, request);
         } catch (Exception e) {


### PR DESCRIPTION
# Description

Do not create ACCESS EVENT for mobile webview. The ACCESS EVENT is handled already via the app so it was redundant to also create an ACCESS EVENT for the webview.

Mobile webview uses the `xApp=mobile` query param, so if the param is present then we do not create ACCESS EVENT.

This behaviour will be applied to all mobile apps using webview so that's why we consider the `onAccess` method of the `EventHelper` to be the right place to handle this.

## Fixes

(Enter here Jira or Redmine ticket(s) links)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: