### PR TITLE
feat(conversation): #WB-3454, tests for the rename folder modal

### DIFF
--- a/conversation/backend/src/main/resources/i18n/fr.json
+++ b/conversation/backend/src/main/resources/i18n/fr.json
@@ -56,7 +56,7 @@
   "folder.new.name.placeholder": "Nom du dossier",
   "folder.new.subfolder.label": "Créer en tant que sous-dossier",
   "folder.new.subfolder.placeholder": "Sélectionner un dossier parent",
-  "folder.trash.body": "Vous êtes sur le point de supprimer un dossier, les messages qu’il contient seront placés dans la corbeille.",
+  "folder.trash.body": "Êtes-vous sûr de vouloir supprimer ce dossier ? Le dossier sera définitivement supprimé et les messages qu’il contient seront placés à la corbeille.",
   "folder.title": "Titre du dossier",
   "folder.rename": "Renommer le dossier",
   "folder.rename.title": "Renommer",

--- a/conversation/frontend/src/features/Menu/components/MobileMenu.tsx
+++ b/conversation/frontend/src/features/Menu/components/MobileMenu.tsx
@@ -71,10 +71,10 @@ function asFolderItem(
     name: t(folder),
     folder: {
       id: folder,
+      parent_id: null,
       depth: 1,
       nbUnread: counters[folder],
       name: t(folder),
-      trashed: false,
       nbMessages: 0,
     },
   };

--- a/conversation/frontend/src/features/Modals/RenameFolderModal.test.tsx
+++ b/conversation/frontend/src/features/Modals/RenameFolderModal.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Test suite for the RenameFolderModal component.
+ *
+ * This suite includes tests to verify the following functionalities:
+ * - Successful rendering of the component.
+ * - Validation to prevent creating a folder with only blank characters.
+ * - Validation to prevent creating a folder with a duplicate name.
+ * - Successful update of a folder with a valid name.
+ *
+ * Mocks:
+ * - Mock `success` and `error` functions from the `useToast` hook.
+ *
+ * Tests:
+ * - `should render successfully`: Verifies that the component renders correctly with required elements.
+ * - `should forbid renaming a folder named with only blank characters`: Ensures that renaming a folder with only blank characters triggers an error toast.
+ * - `should forbid renaming a folder with the same name as another folder`: Ensures that renaming a folder with a duplicate name triggers an error toast.
+ * - `should rename a folder`: Ensures that creating a folder with a valid name triggers a success toast.
+ */
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, renderHook, screen, waitFor } from '~/mocks/setup';
+import { RenameFolderModal } from './RenameFolderModal';
+import { mockFolderTree } from '~/mocks';
+import { useAppActions } from '~/store';
+
+/**
+ * Mock `success` and `error` functions from useToast hook.
+ */
+const mocks = vi.hoisted(() => ({
+  useToast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@edifice.io/react', async () => {
+  const actual =
+    await vi.importActual<typeof import('@edifice.io/react')>(
+      '@edifice.io/react',
+    );
+  return {
+    ...actual,
+    useToast: () => {
+      const useToast = actual.useToast();
+      return {
+        ...useToast,
+        success: mocks.useToast.success,
+        error: mocks.useToast.error,
+      };
+    },
+  };
+});
+
+describe('RenameFolderModal component', () => {
+  beforeEach(async () => {
+    const { result } = renderHook(useAppActions);
+    const setSelectedFolders = await waitFor(() => {
+      expect(result.current.setSelectedFolders).toBeDefined();
+      return result.current.setSelectedFolders;
+    });
+    setSelectedFolders([mockFolderTree[1]]); // Select folder_B to rename it
+  });
+
+  afterEach(async () => {
+    const { result } = renderHook(useAppActions);
+    const setSelectedFolders = await waitFor(() => {
+      expect(result.current.setSelectedFolders).toBeDefined();
+      return result.current.setSelectedFolders;
+    });
+    setSelectedFolders([]);
+    vi.clearAllMocks();
+  });
+
+  it('should render successfully', async () => {
+    const { baseElement } = render(<RenameFolderModal />);
+    expect(baseElement).toBeTruthy();
+
+    const inputNewName = await screen.findByPlaceholderText<HTMLInputElement>(
+      'folder.rename.name.placeholder',
+    );
+    expect(inputNewName).toBeRequired();
+  });
+
+  it('should forbid renaming a folder named with only blank characters', async () => {
+    render(<RenameFolderModal />);
+    const inputNewName = await screen.findByPlaceholderText<HTMLInputElement>(
+      'folder.rename.name.placeholder',
+    );
+    fireEvent.change(inputNewName, { target: { value: '   ' } });
+    expect(inputNewName.value).toStrictEqual('   ');
+
+    const btnSave = await screen.findByText<HTMLButtonElement>('save');
+    fireEvent.click(btnSave);
+
+    // Wait for one event loop
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mocks.useToast.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('should forbid renaming a folder with the same name as another folder', async () => {
+    render(<RenameFolderModal />);
+    const inputNewName = await screen.findByPlaceholderText<HTMLInputElement>(
+      'folder.rename.name.placeholder',
+    );
+    fireEvent.change(inputNewName, { target: { value: 'Root folder A' } });
+    expect(inputNewName.value).toStrictEqual('Root folder A');
+
+    const btnSave = await screen.findByText<HTMLButtonElement>('save');
+    fireEvent.click(btnSave);
+
+    // Wait for one event loop
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mocks.useToast.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('should rename a folder', async () => {
+    render(<RenameFolderModal />);
+    const inputNewName = await screen.findByPlaceholderText<HTMLInputElement>(
+      'folder.rename.name.placeholder',
+    );
+    fireEvent.change(inputNewName, { target: { value: 'Ja Ja !' } });
+
+    const btnSave = await screen.findByText<HTMLButtonElement>('save');
+    fireEvent.click(btnSave);
+
+    // Wait for one event loop
+    await new Promise((r) => setTimeout(r, 500));
+
+    expect(mocks.useToast.success).toHaveBeenCalledTimes(1);
+  });
+});

--- a/conversation/frontend/src/mocks/index.ts
+++ b/conversation/frontend/src/mocks/index.ts
@@ -1,6 +1,6 @@
-import { Message } from '~/models';
+import { Folder, Message } from '~/models';
 
-export const mockFolderTree = [
+export const mockFolderTree: Array<Folder> = [
   {
     id: 'folder_A',
     parent_id: null,

--- a/conversation/frontend/src/models/folder.ts
+++ b/conversation/frontend/src/models/folder.ts
@@ -10,10 +10,10 @@ export type SystemFolder =
 
 export type Folder = {
   id: string;
+  parent_id: string | null;
   name: string;
   depth: number;
   subFolders?: Folder[];
   nbMessages: number;
   nbUnread: number;
-  trashed: boolean;
 };

--- a/conversation/frontend/src/services/queries/folder.ts
+++ b/conversation/frontend/src/services/queries/folder.ts
@@ -181,30 +181,30 @@ export const useCreateFolder = () => {
 
         if (parentId) {
           // Look for the parent folder in the tree.
-          const found = searchFolder(parentId, foldersTree);
-          if (!found?.folder) break;
+          const parent = searchFolder(parentId, foldersTree);
+          if (!parent?.folder) break;
 
-          if (!found.folder.subFolders) {
-            found.folder.subFolders = [];
+          if (!parent.folder.subFolders) {
+            parent.folder.subFolders = [];
           }
           // Update parent folder data.
-          found.folder.subFolders.push({
+          parent.folder.subFolders.push({
             id,
+            parent_id: parentId,
             depth: 2,
             name,
             nbMessages: 0,
             nbUnread: 0,
-            trashed: false,
           });
         } else {
           // Push new folder at root level (depth=1)
           foldersTree.push({
             id,
+            parent_id: null,
             depth: 1,
             name,
             nbMessages: 0,
             nbUnread: 0,
-            trashed: false,
           });
 
           // Optimistic update


### PR DESCRIPTION
# Description

Tests de la modale de renommage de dossier.
+ modification d'un wording décidé la semaine dernière

## Fixes

[WB-3454](https://edifice-community.atlassian.net/browse/WB-3454)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [X] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

 - `should render successfully`: Verifies that the component renders correctly with required elements.
 - `should forbid renaming a folder named with only blank characters`: Ensures that renaming a folder with only blank characters triggers an error toast.
 - `should forbid renaming a folder with the same name as another folder`: Ensures that renaming a folder with a duplicate name triggers an error toast.
 - `should rename a folder`: Ensures that creating a folder with a valid name triggers a success toast.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley:

[WB-3454]: https://edifice-community.atlassian.net/browse/WB-3454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ