### PR TITLE
feat: WB-3821, requesting conversation-specific content transformations

### DIFF
--- a/conversation/backend/src/main/java/org/entcore/conversation/service/impl/SqlConversationService.java
+++ b/conversation/backend/src/main/java/org/entcore/conversation/service/impl/SqlConversationService.java
@@ -81,6 +81,7 @@ public class SqlConversationService implements ConversationService{
 
 	private final IContentTransformerClient contentTransformerClient;
 	private final IContentTransformerEventRecorder contentTransformerEventRecorder;
+	private final Set<String> CONVERSATION_TRANSFORMATION_EXTENSIONS = new HashSet<>(Arrays.asList("conversation-history"));
 
 	public SqlConversationService(Vertx vertx, String schema, IContentTransformerClient contentTransformerClient, IContentTransformerEventRecorder contentTransformerEventRecorder) {
 		this.eb = Server.getEventBus(vertx);
@@ -834,7 +835,8 @@ public class SqlConversationService implements ConversationService{
 				new HashSet<>(Arrays.asList(ContentTransformerFormat.HTML, ContentTransformerFormat.JSON)),
 				0,
 				originalMessageContent,
-				null)
+				null,
+				CONVERSATION_TRANSFORMATION_EXTENSIONS)
 				).onSuccess(transformerResponse -> {
 					contentTransformerEventRecorder.recordTransformation(messageId, "message", transformerResponse, request);
 					transformedMessagePromise.complete(transformerResponse);

--- a/conversation/backend/src/main/java/org/entcore/conversation/service/impl/SqlConversationService.java
+++ b/conversation/backend/src/main/java/org/entcore/conversation/service/impl/SqlConversationService.java
@@ -81,7 +81,7 @@ public class SqlConversationService implements ConversationService{
 
 	private final IContentTransformerClient contentTransformerClient;
 	private final IContentTransformerEventRecorder contentTransformerEventRecorder;
-	private final Set<String> CONVERSATION_TRANSFORMATION_EXTENSIONS = new HashSet<>(Arrays.asList("conversation-history"));
+	private final Set<String> CONVERSATION_TRANSFORMATION_EXTENSIONS = Collections.singleton("conversation-history");
 
 	public SqlConversationService(Vertx vertx, String schema, IContentTransformerClient contentTransformerClient, IContentTransformerEventRecorder contentTransformerEventRecorder) {
 		this.eb = Server.getEventBus(vertx);

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <testContainerVersion>1.19.3</testContainerVersion>
         <modPostgresVersion>2.0-SNAPSHOT</modPostgresVersion>
         <modMongoVersion>4.0-SNAPSHOT</modMongoVersion>
-        <webUtilsVersion>3.0-SNAPSHOT</webUtilsVersion>
+        <webUtilsVersion>3.0-develop-b2school-SNAPSHOT</webUtilsVersion>
         <mongodbHelperVersion>4.0-develop-b2school-SNAPSHOT</mongodbHelperVersion>
         <jodaTimeVersion>2.9.4</jodaTimeVersion>
         <scramVersion>2.1</scramVersion>


### PR DESCRIPTION
# Description

In order to correctly format the former conversation history, a [new dedicated tip tap extension](https://github.com/edificeio/edifice-frontend-framework/commit/8ef0c3a4cb7e5dd05d680dd92040bda109df30e8) has been implemented.

This extension must be applied only for conversation content transformation, and an evolution in the content transformer client has been made to do so.

Related PR : 
- https://github.com/edificeio/edifice-tiptap-transformer/pull/21
- https://github.com/edificeio/web-utils/pull/33

## Fixes

https://edifice-community.atlassian.net/browse/WB-3821

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [x] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: