### PR TITLE
feat(conversation): #WB-3817,  endpoint to delete folders while trash…

### DIFF
--- a/conversation/backend/src/main/java/org/entcore/conversation/controllers/ApiController.java
+++ b/conversation/backend/src/main/java/org/entcore/conversation/controllers/ApiController.java
@@ -18,18 +18,21 @@
 
 package org.entcore.conversation.controllers;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.entcore.common.http.filter.ResourceFilter;
 import static org.entcore.common.http.response.DefaultResponseHandler.arrayResponseHandler;
-import org.entcore.common.user.UserInfos;
 import static org.entcore.common.user.UserUtils.getAuthenticatedUserInfos;
 import static org.entcore.common.utils.StringUtils.isEmpty;
+import org.entcore.conversation.filters.FoldersFilter;
 import org.entcore.conversation.filters.MessageUserFilter;
 import org.entcore.conversation.filters.SystemOrUserFolderFilter;
 import org.entcore.conversation.service.ConversationService;
-import org.entcore.conversation.util.MessageUtil;
 
+import fr.wseduc.rs.Delete;
 import fr.wseduc.rs.Get;
 import fr.wseduc.security.ActionType;
 import fr.wseduc.security.SecuredAction;
@@ -39,7 +42,6 @@ import fr.wseduc.webutils.http.BaseController;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public class ApiController extends BaseController {
@@ -127,6 +129,37 @@ public class ApiController extends BaseController {
 		});
 	}
 
+	/** Delete a folder (and trash its messages) */
+	@Delete("api/folders/:folderId")
+	@SecuredAction(value = "", type = ActionType.RESOURCE)
+	@ResourceFilter(FoldersFilter.class)
+	public void deleteFolder(final HttpServerRequest request) {
+		final String folderId = request.params().get("folderId");
+		deleteFolders(request, Stream.of(folderId).collect(Collectors.toList()))
+		.onComplete( result -> {
+			if( result.failed() ) {
+				badRequest(request, result.cause().getMessage());
+			} else {
+				ok(request);
+			}
+		});
+	}
+
+	private Future<JsonObject> deleteFolders(final HttpServerRequest request, final List<String> folderIds) {
+		return getAuthenticatedUserInfos(eb, request)
+		.compose( user -> {
+			Promise<JsonObject> promise = Promise.promise();
+			conversationService.deleteFoldersButTrashMessages(folderIds, user, either -> {
+				if(either.isLeft()) {
+					promise.fail(either.left().getValue());
+				} else {
+					promise.complete(either.right().getValue());
+				}
+			});
+			return promise.future();
+		});
+	}
+	
 	/** Utility method to read a query param and convert it to an Integer. */
 	private Integer parseQueryParam(final HttpServerRequest request, String param, final Integer defaultValue) {
 		final String paramValue = getOrElse(request.params().get(param), "" + defaultValue, false);

--- a/conversation/backend/src/main/java/org/entcore/conversation/controllers/ApiController.java
+++ b/conversation/backend/src/main/java/org/entcore/conversation/controllers/ApiController.java
@@ -38,6 +38,7 @@ import fr.wseduc.security.SecuredAction;
 import fr.wseduc.webutils.I18n;
 import static fr.wseduc.webutils.Utils.getOrElse;
 import fr.wseduc.webutils.http.BaseController;
+import fr.wseduc.webutils.http.Renders;
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonObject;
@@ -138,7 +139,7 @@ public class ApiController extends BaseController {
 			if( result.failed() ) {
 				badRequest(request, result.cause().getMessage());
 			} else {
-				ok(request);
+				Renders.render(request, result.result(), 200);
 			}
 		});
 	}

--- a/conversation/backend/src/main/java/org/entcore/conversation/controllers/ApiController.java
+++ b/conversation/backend/src/main/java/org/entcore/conversation/controllers/ApiController.java
@@ -129,7 +129,7 @@ public class ApiController extends BaseController {
 		});
 	}
 
-	/** Delete a folder (and trash its messages) */
+	/** Delete a folder (and trash its messages) recursively */
 	@Delete("api/folders/:folderId")
 	@SecuredAction(value = "", type = ActionType.RESOURCE)
 	@ResourceFilter(FoldersFilter.class)

--- a/conversation/backend/src/main/java/org/entcore/conversation/service/ConversationService.java
+++ b/conversation/backend/src/main/java/org/entcore/conversation/service/ConversationService.java
@@ -140,6 +140,7 @@ public interface ConversationService {
 	void trashFolder(String folderId, UserInfos user, Handler<Either<String, JsonObject>> result);
 	void restoreFolder(String folderId, UserInfos user, Handler<Either<String, JsonObject>> result);
 	void deleteFolder(String folderId, Boolean deleteAll, UserInfos user, Handler<Either<String, JsonArray>> result);
+	void deleteFoldersButTrashMessages(List<String> folderIds, UserInfos user, Handler<Either<String, JsonObject>> result);
 
 	//Attachments
 	void addAttachment(String messageId, UserInfos user, JsonObject uploaded, Handler<Either<String, JsonObject>> result);

--- a/conversation/backend/src/main/java/org/entcore/conversation/service/ConversationService.java
+++ b/conversation/backend/src/main/java/org/entcore/conversation/service/ConversationService.java
@@ -140,7 +140,17 @@ public interface ConversationService {
 	void trashFolder(String folderId, UserInfos user, Handler<Either<String, JsonObject>> result);
 	void restoreFolder(String folderId, UserInfos user, Handler<Either<String, JsonObject>> result);
 	void deleteFolder(String folderId, Boolean deleteAll, UserInfos user, Handler<Either<String, JsonArray>> result);
-	void deleteFoldersButTrashMessages(List<String> folderIds, UserInfos user, Handler<Either<String, JsonObject>> result);
+
+	/**
+	 * Deletes the specified folders (and subfolders, recursively) for a user,
+	 * and put any message they contain into the trash folder.
+	 *
+	 * @param folderIds A list of folder IDs to be deleted.
+	 * @param user The user information.
+	 * @return A Future JsonObject with the following props :
+	 *   `trashedMessageIds`: array of message IDs put into the trash folder.
+	 */
+	Future<JsonObject> deleteFoldersAndTrashMessages(List<String> folderIds, UserInfos user);
 
 	//Attachments
 	void addAttachment(String messageId, UserInfos user, JsonObject uploaded, Handler<Either<String, JsonObject>> result);

--- a/conversation/frontend/src/services/api/folderService.ts
+++ b/conversation/frontend/src/services/api/folderService.ts
@@ -75,6 +75,8 @@ export const createFolderService = (baseURL: string) => ({
   },
 
   trash(folderId: string) {
-    return odeServices.http().put<void>(`${baseURL}/folder/trash/${folderId}`);
+    return odeServices
+      .http()
+      .delete<void>(`${baseURL}/api/folders/${folderId}`);
   },
 });

--- a/conversation/frontend/vite.config.ts
+++ b/conversation/frontend/vite.config.ts
@@ -68,7 +68,7 @@ export default ({ mode }: { mode: string }) => {
           proxyObj,
         '^/(?=auth|appregistry|cas|userbook|directory|communication|portal|session|timeline|workspace|infra)':
           proxyObj,
-        '^/conversation/(?=api|messages/|folders/|folder$|folder/trash|trash$|restore$|delete$|count/|toggleUnread|i18n)':
+        '^/conversation/(?=api/|messages/|folders/|folder$|folder/trash|trash$|restore$|delete$|count/|toggleUnread|i18n)':
           proxyObj,
       },
       port: 4200,

--- a/tests/src/test/js/it/scenarios/conversation/_folders.ts
+++ b/tests/src/test/js/it/scenarios/conversation/_folders.ts
@@ -1,0 +1,53 @@
+import { getHeaders } from "../../../node_modules/edifice-k6-commons/dist/index.js";
+import { check } from "k6";
+import http, { RefinedResponse } from "k6/http";
+
+const rootUrl = __ENV.ROOT_URL;
+
+export function createFolder(payload: {
+  name: string;
+  parentId?: string;
+}): RefinedResponse<any> {
+  const headers = getHeaders();
+  headers["content-type"] = "application/json";
+  return http.post(`${rootUrl}/conversation/folder`, JSON.stringify(payload), {
+    headers,
+  });
+}
+
+export function checkCreateFolderOk(
+  res: RefinedResponse<any>,
+  checkName: string
+) {
+  const checks = {};
+  checks[`${checkName} - HTTP status`] = (r) => r.status === 201;
+  const ok = check(res, checks);
+  if (!ok) {
+    console.error(checkName, res);
+  }
+}
+
+export function moveIntoFolder(intoFolderId: string, messageIds: string[]) {
+  const headers = getHeaders();
+  headers["content-type"] = "application/json";
+  return http.put(
+    `${rootUrl}/conversation/move/userfolder/${intoFolderId}`,
+    JSON.stringify({ id: messageIds }),
+    { headers }
+  );
+}
+export function checkMoveIntoFolderOk(
+  res: RefinedResponse<any>,
+  checkName: string
+) {
+  const checks = {};
+  checks[`${checkName} - HTTP status`] = (r) => r.status === 200;
+  const ok = check(res, checks);
+  if (!ok) {
+    console.error(checkName, res);
+  }
+}
+
+export function deleteFolder(folderId: string) {
+  return http.del(`${rootUrl}/conversation/api/folders/${folderId}`);
+}

--- a/tests/src/test/js/it/scenarios/conversation/folders.ts
+++ b/tests/src/test/js/it/scenarios/conversation/folders.ts
@@ -61,6 +61,7 @@ export const options = {
   },
   scenarios: {
     conversationFoldersTest: {
+      exec: "testDeleteFoldersAndTrashMessages",
       executor: "per-vu-iterations",
       vus: 1,
       maxDuration: maxDuration,
@@ -115,9 +116,9 @@ function checkDeleteFolderOk(res, draftId, checkName) {
   }
 }
 
-function testDeleteFoldersAndTrashMessages(data) {
+export function testDeleteFoldersAndTrashMessages(data) {
   const { structure } = data;
-  describe("[Conversation] Test - Create draft and send message", () => {
+  describe("[Conversation] Delete a folder while trashing its messages", () => {
     authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD);
     const users = getUsersOfSchool(structure);
     const teacher1 = getRandomUserWithProfile(users, "Teacher");
@@ -157,7 +158,3 @@ function testDeleteFoldersAndTrashMessages(data) {
     checkDeleteFolderOk(res, draftId, "Teacher deletes the first folders");
   });
 }
-
-export default (data) => {
-  testDeleteFoldersAndTrashMessages(data);
-};

--- a/tests/src/test/js/it/scenarios/conversation/folders.ts
+++ b/tests/src/test/js/it/scenarios/conversation/folders.ts
@@ -1,0 +1,163 @@
+/**
+ * K6 test script for testing conversation folder functionalities.
+ *
+ * This script performs the following actions:
+ * - Authenticates a user.
+ * - Initializes a school structure and assigns roles to users.
+ * - Creates folders and subfolders.
+ * - Creates a draft message and moves it into a subfolder.
+ * - Deletes folders and verifies that the draft message is trashed.
+ *
+ * Environment Variables:
+ * - `MAX_DURATION`: Maximum duration for the test scenario.
+ * - `DATA_SCHOOL_NAME`: Name of the school for the test data.
+ * - `DATA_ROOT_PATH`: Root path for the test data.
+ * - `GRACEFUL_STOP`: Graceful stop duration for the test scenario.
+ * - `ADMC_LOGIN`: Admin login for authentication.
+ * - `ADMC_PASSWORD`: Admin password for authentication.
+ *
+ * Functions:
+ * - `setup()`: Initializes the test data and returns the school structure.
+ * - `initSchool()`: Initializes the school structure and assigns roles to users.
+ * - `checkCreateDraftOk(res, checkName)`: Checks if the draft message creation was successful.
+ * - `checkDeleteFolderOk(res, draftId, checkName)`: Checks if the folder deletion was successful and the draft message is trashed.
+ * - `testDeleteFoldersAndTrashMessages(data)`: Main test function that performs the folder and message operations.
+ *
+ * Exported Default Function:
+ * - `(data)`: Executes the `testDeleteFoldersAndTrashMessages` function with the provided data.
+ */
+import { check } from "k6";
+import { describe } from "https://jslib.k6.io/k6chaijs/4.3.4.0/index.js";
+
+import {
+  authenticateWeb,
+  getUsersOfSchool,
+  createAndSetRole,
+  linkRoleToUsers,
+  triggerImport,
+  initStructure,
+  getRandomUserWithProfile,
+  DraftMessage,
+  createDraftMessage,
+  getMessage,
+} from "../../../node_modules/edifice-k6-commons/dist/index.js";
+import {
+  checkCreateFolderOk,
+  checkMoveIntoFolderOk,
+  createFolder,
+  deleteFolder,
+  moveIntoFolder,
+} from "./_folders.ts";
+
+const maxDuration = __ENV.MAX_DURATION || "1m";
+const schoolName = __ENV.DATA_SCHOOL_NAME || "Conversation - Tests";
+const dataRootPath = __ENV.DATA_ROOT_PATH;
+const gracefulStop = parseInt(__ENV.GRACEFUL_STOP || "2s");
+
+export const options = {
+  setupTimeout: "1h",
+  thresholds: {
+    checks: ["rate == 1.00"],
+  },
+  scenarios: {
+    conversationFoldersTest: {
+      executor: "per-vu-iterations",
+      vus: 1,
+      maxDuration: maxDuration,
+      gracefulStop,
+    },
+  },
+};
+
+export function setup() {
+  let structure;
+  describe("[Conversation-Init] Initialize data", () => {
+    authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD);
+    structure = initSchool();
+  });
+  return { structure };
+}
+
+function initSchool() {
+  const structure = initStructure(schoolName);
+  const role = createAndSetRole("Messagerie");
+  const groups = [
+    `Teachers from group ${structure.name}.`,
+    `Enseignants du groupe ${structure.name}.`,
+  ];
+  linkRoleToUsers(structure, role, groups);
+  return structure;
+}
+
+function checkCreateDraftOk(res, checkName) {
+  const checks = {};
+  checks[`${checkName} - HTTP status`] = (r) => r.status === 201;
+  const ok = check(res, checks);
+  if (!ok) {
+    console.error(checkName, res);
+  }
+}
+
+function checkDeleteFolderOk(res, draftId, checkName) {
+  const checks = {};
+  checks[`${checkName} - HTTP status`] = (r) => r.status === 200;
+  checks[`${checkName} - Draft in subfolder is trashed`] = (r) => {
+    const body = JSON.parse(r.body);
+    return (
+      body.trashedMessageIds instanceof Array &&
+      body.trashedMessageIds.length === 1 &&
+      body.trashedMessageIds[0] === draftId
+    );
+  };
+  const ok = check(res, checks);
+  if (!ok) {
+    console.error(checkName, res);
+  }
+}
+
+function testDeleteFoldersAndTrashMessages(data) {
+  const { structure } = data;
+  describe("[Conversation] Test - Create draft and send message", () => {
+    authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD);
+    const users = getUsersOfSchool(structure);
+    const teacher1 = getRandomUserWithProfile(users, "Teacher");
+    authenticateWeb(teacher1.login);
+    const draftMessage = <DraftMessage>{
+      to: [],
+      cc: [],
+      cci: [],
+      subject: "message from teacher 1",
+      body: "<div>No real body</div>",
+    };
+
+    // Teacher creates a first folder
+    let res = createFolder({ name: "Folder 1" });
+    checkCreateFolderOk(res, "Teacher creates a first folder");
+    const folder1Id = JSON.parse(res.body as string).id;
+    // Teacher creates a subfolder
+    res = createFolder({ name: "Folder 1.1", parentId: folder1Id });
+    checkCreateFolderOk(res, "Teacher creates a subfolder");
+    const folder11Id = JSON.parse(res.body as string).id;
+    // Teacher creates a second folder
+    res = createFolder({ name: "Folder 2" });
+    checkCreateFolderOk(res, "Teacher creates a second folder");
+    const folder2Id = JSON.parse(res.body as string).id;
+
+    // Teacher creates draft message
+    res = createDraftMessage(draftMessage);
+    checkCreateDraftOk(res, "Teacher creates draft message");
+    const draftId = JSON.parse(res.body as string).id;
+
+    // Teacher puts draft message into subfolder
+    res = moveIntoFolder(folder11Id, [draftId]);
+    checkMoveIntoFolderOk(res, "Teacher puts message into subfolder");
+
+    // Teacher deletes the first folder with subfolders recursively.
+    res = deleteFolder(folder1Id);
+    checkDeleteFolderOk(res, draftId, "Teacher deletes the first folders");
+  });
+}
+
+export default (data) => {
+  testDeleteFoldersAndTrashMessages(data);
+};


### PR DESCRIPTION
…ing their messages

# Description

Ajout d'un endpoint pour supprimer un dossier et ses sous-dossiers, plaçant les messages qu'ils contiennent dans la corbeille.

## Fixes

[WB-3817](https://edifice-community.atlassian.net/browse/WB-3817)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [X] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [X] tests
- [ ] timeline
- [ ] workspace

## Tests

 * - Authenticates a user.
 * - Initializes a school structure and assigns roles to users.
 * - Creates folders and subfolders.
 * - Creates a draft message and moves it into a subfolder.
 * - Deletes folders and verifies that the draft message is trashed.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley:

[WB-3817]: https://edifice-community.atlassian.net/browse/WB-3817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ