### PR TITLE
fix: WB-3838, handle message content transformation with empty body

### DIFF
--- a/conversation/backend/src/main/java/org/entcore/conversation/service/impl/SqlConversationService.java
+++ b/conversation/backend/src/main/java/org/entcore/conversation/service/impl/SqlConversationService.java
@@ -197,8 +197,9 @@ public class SqlConversationService implements ConversationService{
 	private Future<Void> updateMessageWithTransformedContent(JsonObject message, HttpServerRequest request) {
 		Promise<Void> updatedMessagePromise = Promise.promise();
 		Future<ContentTransformerResponse> contentTransformerResponseFuture ;
-		if (message.containsKey("body")) {
+		if (message.containsKey("body") && !StringUtils.isEmpty(message.getString("body"))) {
 			contentTransformerResponseFuture = transformMessageContent(message.getString("body"), message.getString("id"), request);
+		// no content to transform
 		} else {
 			contentTransformerResponseFuture = Future.succeededFuture();
 		}
@@ -770,21 +771,34 @@ public class SqlConversationService implements ConversationService{
 		}
 		// transform and persist message content if needed
 		else if (message.getInteger("content_version") == 0) {
-			transformMessageContent(message.getString("body"), messageId, request)
-					.onSuccess(transformerResponse -> updateMessageContent(messageId, transformerResponse.getCleanHtml(), transformerResponse.getContentVersion())
-							.onSuccess(res -> {
-								message.put("body", transformerResponse.getCleanHtml());
-								message.put("content_version", transformerResponse.getContentVersion());
-								updatedMessagePromise.complete();
-							})
-							.onFailure(throwable -> {
-								log.error("Failed to update message with transformed content", throwable);
-								updatedMessagePromise.fail(throwable);
-							}))
-					.onFailure(throwable -> {
-						log.error("Failed to transform message content", throwable);
-						updatedMessagePromise.fail(throwable);
-					});
+			if (message.containsKey("body") && !StringUtils.isEmpty(message.getString("body"))) {
+				transformMessageContent(message.getString("body"), messageId, request)
+						.onSuccess(transformerResponse -> updateMessageContent(messageId, transformerResponse.getCleanHtml(), transformerResponse.getContentVersion())
+								.onSuccess(res -> {
+									message.put("body", transformerResponse.getCleanHtml());
+									message.put("content_version", transformerResponse.getContentVersion());
+									updatedMessagePromise.complete();
+								})
+								.onFailure(throwable -> {
+									log.error("Failed to update message with transformed content", throwable);
+									updatedMessagePromise.fail(throwable);
+								}))
+						.onFailure(throwable -> {
+							log.error("Failed to transform message content", throwable);
+							updatedMessagePromise.fail(throwable);
+						});
+			// no content to transform, update only content version
+			} else {
+				updateMessageContent(messageId, "", 1)
+						.onSuccess(res -> {
+							message.put("content_version", 1);
+							updatedMessagePromise.complete();
+						})
+						.onFailure(throwable -> {
+							log.error("Failed to update message with content version", throwable);
+							updatedMessagePromise.fail(throwable);
+						});
+			}
 		// message content has already been transformed
 		} else {
 			updatedMessagePromise.complete();

--- a/tests/src/test/resources/data/conversation/transformed_rich_content.html
+++ b/tests/src/test/resources/data/conversation/transformed_rich_content.html
@@ -1,0 +1,1 @@
+<p>Hello world,</p><p>​</p><p>​This is a <span><strong>test</strong></span></p><p><span><strong>​</strong></span></p><p><span>​</span></p><p>​</p><p>This is a signature</p>


### PR DESCRIPTION
# Description

Handles content transformation when message has empty body

## Fixes

https://edifice-community.atlassian.net/browse/WB-3838

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [x] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [x] tests
- [ ] timeline
- [ ] workspace

## Tests

Enriched K6 it tests

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: