### PR TITLE
Feat wb 3837 original format existence

### DIFF
--- a/conversation/backend/src/main/java/org/entcore/conversation/service/impl/SqlConversationService.java
+++ b/conversation/backend/src/main/java/org/entcore/conversation/service/impl/SqlConversationService.java
@@ -675,7 +675,8 @@ public class SqlConversationService implements ConversationService{
 		String selectQuery =
 			"SELECT " +
 				"m.*, " +
-				(apiVersion>0 ? "um.folder_id as folder_id, um.trashed as trashed, um.unread as unread, " : "") +
+				(apiVersion>0 ? "um.folder_id as folder_id, um.trashed as trashed, um.unread as unread, " +
+								"CASE WHEN count(distinct om.message_id) = 0 THEN false ELSE true END AS original_format_exists, " : "") +
 				"CASE WHEN COUNT(distinct att) = 0 THEN '[]' ELSE json_agg(distinct att.*) END AS attachments " +
 			"FROM " + messageTable + " m " +
 			"JOIN " + userMessageTable + " um " +
@@ -683,8 +684,10 @@ public class SqlConversationService implements ConversationService{
 			"LEFT JOIN " + userMessageAttachmentTable + " uma USING (user_id, message_id) " +
 			"LEFT JOIN " + attachmentTable + " att " +
 				"ON att.id = uma.attachment_id " +
+			"LEFT JOIN " + originalMessageTable + " om " +
+				"ON m.id = om.message_id " +
 			"WHERE um.user_id = ? AND m.id = ?  " +
-			(apiVersion>0 ? "GROUP BY m.id, um.folder_id, um.trashed, um.unread" : "GROUP BY m.id");
+			(apiVersion>0 ? "GROUP BY m.id, um.folder_id, um.trashed, um.unread, om.message_id" : "GROUP BY m.id");
 
 		JsonArray values = new JsonArray()
 			.add(user.getUserId())

--- a/conversation/backend/src/main/resources/sql/019-conversation-originalmessages.sql
+++ b/conversation/backend/src/main/resources/sql/019-conversation-originalmessages.sql
@@ -6,3 +6,5 @@ CREATE TABLE conversation.originalmessages (
 CREATE INDEX idx_originalmessages ON conversation.originalmessages (message_id);
 
 ALTER TABLE conversation.messages ADD content_version INTEGER DEFAULT 0;
+
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON conversation.originalmessages TO "apps";

--- a/tests/src/test/js/it/scenarios/conversation/transform.ts
+++ b/tests/src/test/js/it/scenarios/conversation/transform.ts
@@ -201,7 +201,7 @@ function testTransformEmptyMessageContent(data) {
     const messageId = JSON.parse(res.body).id;
     // Teacher retrieves message with empty body
     res = getMessage(messageId, false)
-    checkMessageOk(res, teacher.id, [], "", 'Teacher fetches message')
+    checkMessageOk(res, teacher.id, [], "", false, 'Teacher fetches message')
   });
 }
 

--- a/tests/src/test/js/it/scenarios/conversation/transform.ts
+++ b/tests/src/test/js/it/scenarios/conversation/transform.ts
@@ -99,7 +99,7 @@ function checkTransformOk(res, checkName) {
   }
 }
 
-function checkMessageOk(res, senderId, recipientId, body, checkName) {
+function checkMessageOk(res, senderId, recipientId, body, hasOriginal, checkName) {
   const checks = {}
   checks[`${checkName} - HTTP status`] = (r) => r.status === 200
   checks[`${checkName} - Content is transformed`] = (r) => {
@@ -123,6 +123,10 @@ function checkMessageOk(res, senderId, recipientId, body, checkName) {
   checks[`${checkName} - Body is correct`] = (r) => {
     const message = JSON.parse(r.body)
     return message.body === body
+  }
+  checks[`${checkName} - Check original format`] = (r) => {
+    const message = JSON.parse(r.body)
+    return message.original_format_exists === hasOriginal
   }
   const ok = check(res, checks);
   if(!ok) {
@@ -169,7 +173,7 @@ function testTransformMessageContent(data) {
     // Teacher 2 retrieves message
     authenticateWeb(teacher2.login)
     res = getMessage(messageId, false)
-    checkMessageOk(res, teacher1.id, teacher2.id, transformedRichContent, 'Teacher 2 fetches message sent by teacher 1')
+    checkMessageOk(res, teacher1.id, teacher2.id, transformedRichContent, false, 'Teacher 2 fetches message sent by teacher 1')
     // Teacher 2 fails fetching message original format (because it has been directely created with transformed content)
     res = getMessage(messageId, true)
     checkMessageOriginalKo(res, messageId, 'Teacher 2 fails to fetch original format of message')


### PR DESCRIPTION
# Description

Lorsqu'on appelle la nouvelle api de récupération des détails d'un message, on remonte l'information sur l'existence ou non du format original du message (avant transformation tiptap) dans un champ `original_format_exists`
Cela permet au front d'afficher le bouton d'affichage de l'ancien format seulement si nécessaire.

En testant sur ode1, ce cas a révélé qu'il manquait des privilèges pour le user "apps" sur la table conversation.originalmessages. 

## Fixes

https://edifice-community.atlassian.net/browse/WB-3837

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [x] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Enrichissement des TI k6 associés
Par la nature même des TI, on ne peut pas avoir de cas de messages pour lesquels un format original préexiste.
Le cas avec format original préexistant a été testé directement sur recette-ode1.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: