### PR TITLE
fix(dev): #ENABLING-217, fetch modname from pre exported module version for js watch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ admin/src/main/ts/.proxyRemoteConfig.js
 .env
 dependency-reduced-pom.xml
 .flattened-pom.xml
+.version.properties

--- a/build.sh
+++ b/build.sh
@@ -218,10 +218,12 @@ localDep () {
 }
 
 watch () {
+  docker compose run --rm maven sh -c "mvn $MVN_OPTS help:evaluate -Dexpression=project.groupId -q -DforceStdout -pl $MODULE && echo -n '~$MODULE~' &&  mvn $MVN_OPTS help:evaluate -Dexpression=project.version -pl $MODULE -q -DforceStdout" > .version.properties
   docker compose run --rm \
     $USER_OPTION \
     -v $PWD/../$SPRINGBOARD:/home/node/$SPRINGBOARD \
     node sh -c "npx gulp watch-$MODULE $NODE_OPTION --springboard=../$SPRINGBOARD 2>/dev/null"
+  rm -f .version.properties
 }
 
 # ex: ./build.sh -m=workspace -s=paris watch

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -91,10 +91,7 @@ gulp.task('build', build);
 
 
 function getModName(fileContent, app){
-    var getProp = function(prop){
-        return fileContent.split(prop + '=')[1].split(/\r*\n/)[0];
-    }
-    return getProp('modowner') + '~' + app + '~' + getProp('version');
+    return fileContent.trim();
 }
 
 let springboardPath = '../recette';
@@ -107,7 +104,7 @@ apps.forEach((app) => {
     gulp.task('watch-' + app, () => {
         gulp.watch('./' + app + '/src/main/resources/public/ts/**/*.ts', () => startWebpack('dev'));
 
-        fs.readFile("./gradle.properties", "utf8", function(error, content){
+        fs.readFile("./.version.properties", "utf8", function(error, content){
             var modName = getModName(content, app);
             gulp.watch(['./' + app + '/src/main/resources/public/template/**/*.html', '!./' + app + '/src/main/resources/public/template/entcore/*.html'], () => {
                 console.log('Copying resources to ' + springboardPath + '/mods/' + modName);


### PR DESCRIPTION
# Description

Now that we moved from gradle to maven, gulp `watch` task cannot leverage the properties of gradle.properties to get he name of the module to build. This PR fixes that by :
1. adding a step right before the gulp task is launched that will call `mvn` to output the module name to watch in a temporary file `.version.properties`
2. modifying the task `watch` by reading from `.version.properties` instead of `gradle.properties`
3. removing the `.version.properties` after the `watch` task is done

## Fixes

ENABLING-217

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)