### PR TITLE
fix: #SUPPORT-2556, fix NPE while initializing GenericShareService for workers deployed by other verticles

### DIFF
--- a/common/src/main/java/org/entcore/common/share/impl/GenericShareService.java
+++ b/common/src/main/java/org/entcore/common/share/impl/GenericShareService.java
@@ -80,7 +80,9 @@ public abstract class GenericShareService implements ShareService {
 		this.groupedActions = groupedActions;
 		final String main = vertx.getOrCreateContext().config().getString("main");
 		final String module = isNotEmpty(main) ? main.substring(main.lastIndexOf(".") + 1) : "unknown_module";
-		this.eventStore = EventStoreFactory.getFactory().getEventStore(module);
+		final EventStoreFactory factory = EventStoreFactory.getFactory();
+		factory.setVertx(vertx);
+		this.eventStore = factory.getEventStore(module);
 	}
 
 	protected Future<Set<String>> userIdsForGroupIds(Set<String> groupsIds, String currentUserId) {


### PR DESCRIPTION
# Description

Correction d'une NPE qui survient lorsqu'un verticle n'a pas appelé `EventStoreFactory.getFactory().setVertx(vertx)` avant d'instantier un `ShareService`.

## Fixes

SUPPORT-2556

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Vérifier que le job `CreateDailyPresenceWorker` s'exécute bien.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: