### PR TITLE
feat(portal): add appointments i18n

### DIFF
--- a/portal/src/main/resources/i18n/en.json
+++ b/portal/src/main/resources/i18n/en.json
@@ -11,6 +11,7 @@
   "admin.title": "Administration console",
   "admin.wizard": "Import des comptes",
   "agenda-widget": "Agenda Widget",
+  "appointments": "Appointments",
   "apps.drag": "Déposez ici vos applications préférées.",
   "archive": "My Data",
   "archives": "Export",

--- a/portal/src/main/resources/i18n/fr.json
+++ b/portal/src/main/resources/i18n/fr.json
@@ -24,6 +24,7 @@
   "alttext": "Texte alternatif",
   "alttext.help": "Description de l’image",
   "apply": "Appliquer",
+  "appointments": "Rendez-vous",
   "apps.authenticatedConnector.lightbox.title": "Attention",
   "apps.authenticatedConnector.lightbox.content": "Vous allez accéder pour la première fois à un connecteur nécessitant une authentification. Les données d'authentification vont être transmises. Souhaitez-vous continuer ?",
   "apps.bookmarks.empty": "Sélectionner vos applications favorites",


### PR DESCRIPTION
# Description

This pull request includes updates to the internationalization (i18n) files for the English and French languages. The changes involve adding a new translation key for "appointments" in both languages.

Updates to i18n files:

* [`portal/src/main/resources/i18n/en.json`](diffhunk://#diff-48858710d91e45e1a1fe11bdbcef69638245d208ec2e78d37c96a0c13b3f3c2aR14): Added the translation key "appointments" with the value "Appointments".
* [`portal/src/main/resources/i18n/fr.json`](diffhunk://#diff-73555a44993276414f2f58382f463fb22cc3ddacdf634db93a51a30cfef2aab1R27): Added the translation key "appointments" with the value "Rendez-vous".

## Fixes

(Enter here Jira or Redmine ticket(s) links)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [x] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: