### PR TITLE
feat(admin,auth,directory): WB-3778, improved management of federated users

### DIFF
--- a/admin/src/main/resources/i18n/fr.json
+++ b/admin/src/main/resources/i18n/fr.json
@@ -854,6 +854,7 @@
   "pager.page": "Lignes :",
   "pager.page.previous": "Précédent",
   "pager.page.next": "Suivant",
+  "notify.connection.federated": "Cet utilisateur se connecte via une identité fédérée. Seuls ses numéros de téléphone et son adresse email sont modifiables ici.",
   "notify.error.footer": "Erreur technique : <p>{{error}}</p>",
   "notify.user.update.title": "Modifications effectuées",
   "notify.user.update.content": "Les données de l'utilisateur {{user}} ont bien été mises à jour.",

--- a/admin/src/main/resources/i18n/fr.json
+++ b/admin/src/main/resources/i18n/fr.json
@@ -854,7 +854,7 @@
   "pager.page": "Lignes :",
   "pager.page.previous": "Précédent",
   "pager.page.next": "Suivant",
-  "notify.connection.federated": "Cet utilisateur se connecte via une identité fédérée. Seuls ses numéros de téléphone et son adresse email sont modifiables ici.",
+  "notify.connection.federated": "Cet utilisateur se connecte via un guichet externe (fédération d’identité). Il n’est donc pas possible de générer un message ou PDF de publipostage, ni générer de code de renouvellement de mot de passe pour ce compte.",
   "notify.error.footer": "Erreur technique : <p>{{error}}</p>",
   "notify.user.update.title": "Modifications effectuées",
   "notify.user.update.content": "Les données de l'utilisateur {{user}} ont bien été mises à jour.",

--- a/admin/src/main/ts/src/app/core/store/models/userdetails.model.ts
+++ b/admin/src/main/ts/src/app/core/store/models/userdetails.model.ts
@@ -64,6 +64,7 @@ export class UserDetailsModel extends Model<UserDetailsModel> {
     structureNodes?: Array<any>;
     removedFromStructures?: Array<String>;
     userPositions?: Array<UserPosition>;
+    federated?: boolean;
 
     toggleBlock() {
         return this.http.put(`/auth/block/${this.id}`, { block: !this.blocked }).then(() => {

--- a/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.html
+++ b/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.html
@@ -1,10 +1,14 @@
 <ode-panel-section section-title="users.connection.section.infos" [folded]="false">
+  <div class="message is-info" *ngIf="disabledFlag==='disabled'">
+    <div class="message-body">&nbsp;<s5l>notify.connection.federated</s5l></div>
+  </div>
+  
   <div class="message is-info" *ngIf="isForbidden">
     <div class="message-body">&nbsp;<s5l>notify.user.email.info</s5l></div>
   </div>
-  
+
   <form #loginForm="ngForm">
-    <fieldset>
+    <fieldset [attr.disabled]="disabledFlag">
       <ode-form-field label="login">
         <span *ngIf="isAdmc == false">{{ details.login }}</span>
         <div *ngIf="isAdmc">
@@ -86,7 +90,7 @@
   </form>
 
   <form #connectionForm="ngForm">
-    <fieldset>
+    <fieldset [attr.disabled]="disabledFlag">
       <ode-form-field label="loginAlias">
         <div>
           <input
@@ -121,7 +125,7 @@
   </form>
 
   <form>
-    <fieldset>
+    <fieldset [attr.disabled]="disabledFlag">
       <ode-form-field label="activation.code" *ngIf="details.activationCode">
         <span>{{ details.activationCode }}</span>
       </ode-form-field>
@@ -172,7 +176,7 @@
     </fieldset>
   </form>
   <form>
-    <fieldset>
+    <fieldset [attr.disabled]="disabledFlag">
       <ode-form-field
         label="send.reset.password"
         *ngIf="!details.activationCode"
@@ -282,7 +286,7 @@
   </form>
 
   <form>
-    <fieldset>
+    <fieldset [attr.disabled]="disabledFlag">
       <ode-form-field
         label="password.renewal.code"
         *ngIf="!details.activationCode"

--- a/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.ts
+++ b/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.ts
@@ -297,6 +297,11 @@ export class UserConnectionSectionComponent
     return this.isAdml && this.details && (this.details.isAdmc() || this.details.isAdml()) && this.details.id != this.myID;
   }
 
+  /* WB-3778 disable connection info of federated users. */
+  get disabledFlag(): string|undefined {
+    return this.details?.federated === true ? "disabled" : undefined;
+  }
+
   get isMyAdmlAccount(): boolean {
     return this.isAdml && this.details.id === this.myID;
   }

--- a/auth/src/main/java/org/entcore/auth/controllers/AuthController.java
+++ b/auth/src/main/java/org/entcore/auth/controllers/AuthController.java
@@ -1403,6 +1403,7 @@ public class AuthController extends BaseController {
 					return;
 				}
 				userAuthAccount.findByMailAndFirstNameAndStructure(mail, firstName, structure,
+						checkFederatedLogin,
 						new io.vertx.core.Handler<Either<String, JsonArray>>() {
 							@Override
 							public void handle(Either<String, JsonArray> event) {

--- a/auth/src/main/java/org/entcore/auth/users/DefaultUserAuthAccount.java
+++ b/auth/src/main/java/org/entcore/auth/users/DefaultUserAuthAccount.java
@@ -342,14 +342,14 @@ public class DefaultUserAuthAccount extends TemplatedEmailRenders implements Use
 	}
 
 	@Override
-	public void findByMailAndFirstNameAndStructure(final String email, String firstName, String structure, final Handler<Either<String,JsonArray>> handler) {
+	public void findByMailAndFirstNameAndStructure(final String email, String firstName, String structure, boolean checkFederatedLogin, final Handler<Either<String,JsonArray>> handler) {
 		boolean setFirstname = firstName != null && !firstName.trim().isEmpty();
 		boolean setStructure = structure != null && !structure.trim().isEmpty();
 
 		String query = "MATCH (u:User)-[:IN]->(:ProfileGroup)-[:DEPENDS]->(s:Structure) WHERE u.emailSearchField = {mail} " +
+				(checkFederatedLogin ? "AND (NOT(HAS(u.federated)) OR u.federated = false) " : "") +
 				(setFirstname ? " AND u.firstNameSearchField = {firstName}" : "") +
 				(setStructure ? " AND s.id = {structure}" : "") +
-				//" AND u.activationCode IS NULL RETURN DISTINCT u.login as login, u.mobile as mobile, s.name as structureName, s.id as structureId";
 				" RETURN DISTINCT u.login as login, u.activationCode as activationCode, u.mobile as mobile, s.name as structureName, s.id as structureId";
 		//Feat #20790 match only lowercases values
 		JsonObject params = new JsonObject().put("mail", email.toLowerCase());

--- a/auth/src/main/java/org/entcore/auth/users/UserAuthAccount.java
+++ b/auth/src/main/java/org/entcore/auth/users/UserAuthAccount.java
@@ -20,8 +20,8 @@
 package org.entcore.auth.users;
 
 import org.entcore.auth.pojo.SendPasswordDestination;
-import fr.wseduc.webutils.Either;
 
+import fr.wseduc.webutils.Either;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonArray;
@@ -70,7 +70,7 @@ public interface UserAuthAccount {
 
 	void findByMail(String email, Handler<Either<String, JsonObject>> handler);
 
-	void findByMailAndFirstNameAndStructure(final String email, String firstName, String structure, final Handler<Either<String,JsonArray>> handler);
+	void findByMailAndFirstNameAndStructure(final String email, String firstName, String structure, boolean checkFederatedLogin, final Handler<Either<String,JsonArray>> handler);
 
 	void findByLogin(String login, String resetCode,boolean checkFederatedLogin, Handler<Either<String, JsonObject>> handler);
 

--- a/directory/src/main/java/org/entcore/directory/controllers/ClassController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/ClassController.java
@@ -153,6 +153,7 @@ public class ClassController extends BaseController {
 		final String classId = request.params().get("classId");
 		JsonArray types = new JsonArray(request.params().getAll("type"));
 		boolean collectRelative = "true".equals(request.params().get("collectRelative"));
+		boolean withFederated = "true".equals(request.params().get("withFederated"));
 	 	Handler<Either<String, JsonArray>> handler;
 		if ("csv".equals(request.params().get("format"))) {
 			handler = new Handler<Either<String, JsonArray>>() {
@@ -191,7 +192,7 @@ public class ClassController extends BaseController {
 		} else {
 			handler = arrayResponseHandler(request);
 		}
-		classService.findUsers(classId, types, collectRelative, handler);
+		classService.findUsers(classId, types, collectRelative, withFederated, handler);
 	}
 
 	@Put("/class/add-self")

--- a/directory/src/main/java/org/entcore/directory/services/ClassService.java
+++ b/directory/src/main/java/org/entcore/directory/services/ClassService.java
@@ -20,8 +20,9 @@
 package org.entcore.directory.services;
 
 
-import fr.wseduc.webutils.Either;
 import org.entcore.common.user.UserInfos;
+
+import fr.wseduc.webutils.Either;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -34,7 +35,7 @@ public interface ClassService {
 
 	void remove(String classId, Handler<Either<String, JsonObject>> result);
 
-	void findUsers(String classId, JsonArray expectedTypes, boolean collectRelative, Handler<Either<String, JsonArray>> results);
+	void findUsers(String classId, JsonArray expectedTypes, boolean collectRelative, boolean withFederated, Handler<Either<String, JsonArray>> results);
 
 	void get(String classId, Handler<Either<String, JsonObject>> result);
 

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultClassService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultClassService.java
@@ -77,8 +77,8 @@ public class DefaultClassService implements ClassService {
 	}
 
 	@Override
-	public void findUsers(String classId, JsonArray expectedTypes, boolean collectRelative,
-						  Handler<Either<String, JsonArray>> results) {
+	public void findUsers(String classId, JsonArray expectedTypes, boolean collectRelative, 
+						  boolean withFederated, Handler<Either<String, JsonArray>> results) {
 		JsonObject params = new JsonObject().put("classId", classId);
 		//=== Filter by type
 		String filterPart = "";
@@ -100,6 +100,7 @@ public class DefaultClassService implements ClassService {
 				"RETURN distinct m.lastName as lastName, m.firstName as firstName, m.id as id, " +
 				"(LENGTH(m.email)>0 AND EXISTS(m.email)) as hasEmail, " +
 				"CASE WHEN m.loginAlias IS NOT NULL THEN m.loginAlias ELSE m.login END as login, m.login as originalLogin, m.activationCode as activationCode, m.displayName as displayName, m.birthDate as birthDate, m.lastLogin as lastLogin, " +
+				(withFederated ? "m.federated as federated, " : "") +
 				"p.name as type, m.blocked as blocked, m.source as source, relativeList " +
 				"ORDER BY type, lastName ";
 		neo.execute(query, params, validResultHandler(results));

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultMassMailService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultMassMailService.java
@@ -274,7 +274,7 @@ public class DefaultMassMailService extends Renders implements MassMailService {
         String filter =
                 " MATCH (s:Structure {id: {structureId}})<-[:DEPENDS]-(g:ProfileGroup)<-[:IN]-(u:User), " +
                         "(g)-[:HAS_PROFILE]-(p: Profile) ";
-        String condition = "";
+        String condition = "WHERE (NOT(HAS(u.federated)) OR u.federated = false) ";
         String optional =
                 " OPTIONAL MATCH (s)<-[:BELONGS]-(c:Class)<-[:DEPENDS]-(:ProfileGroup)<-[:IN]-(u) " +
                         "OPTIONAL MATCH (u)<-[:RELATED]-(child: User)-[:IN]->(:ProfileGroup)-[:DEPENDS]->(c) ";
@@ -285,14 +285,14 @@ public class DefaultMassMailService extends Renders implements MassMailService {
         if (filterObj.containsKey("activated")) {
             String activated = filterObj.getString("activated", "false");
             if ("false".equals(activated.toLowerCase())) {
-                condition = "WHERE NOT(u.activationCode IS NULL) ";
+                condition = "AND NOT(u.activationCode IS NULL) ";
             } else if ("true".equals(activated.toLowerCase())) {
-                condition = "WHERE (u.activationCode IS NULL) ";
+                condition = "AND (u.activationCode IS NULL) ";
             } else {
-                condition = "WHERE 1 = 1 ";
+                // third case => empty condition
             }
         } else {
-            condition = "WHERE NOT(u.activationCode IS NULL) ";
+            condition = "AND NOT(u.activationCode IS NULL) ";
         }
 
         //Profiles
@@ -424,9 +424,9 @@ public class DefaultMassMailService extends Renders implements MassMailService {
         String filter =
                 "MATCH (s:Structure)<-[:DEPENDS]-(g:ProfileGroup)<-[:IN]-(u:User {id: {userId}}), " +
                         "(g)-[:HAS_PROFILE]-(p: Profile) ";
-        String condition = "";
+        String condition = "WHERE (NOT(HAS(u.federated)) OR u.federated = false) ";
         if (!userInfos.getFunctions().containsKey(SUPER_ADMIN)) {
-            condition = "WHERE " + DefaultSchoolService.EXCLUDE_ADMC_QUERY_FILTER;
+            condition = "AND " + DefaultSchoolService.EXCLUDE_ADMC_QUERY_FILTER;
         }
 
         String optional =
@@ -462,7 +462,7 @@ public class DefaultMassMailService extends Renders implements MassMailService {
         String filter =
                 "MATCH (s:Structure {id: {structureId}})<-[:DEPENDS]-(g:ProfileGroup)<-[:IN]-(u:User), " +
                         "(g)-[:HAS_PROFILE]-(p: Profile) ";
-        String condition = "";
+        String condition = "WHERE (NOT(HAS(u.federated)) OR u.federated = false) ";
         String optional =
                 "OPTIONAL MATCH (s)<-[:BELONGS]-(c:Class)<-[:DEPENDS]-(:ProfileGroup)<-[:IN]-(u) " +
                         "OPTIONAL MATCH (u)<-[:RELATED]-(child: User)-[:IN]->(:ProfileGroup)-[:DEPENDS]->(c) " +
@@ -479,13 +479,13 @@ public class DefaultMassMailService extends Renders implements MassMailService {
             UserInfos.Function f = userInfos.getFunctions().get(ADMIN_LOCAL);
             List<String> scope = f.getScope();
             if (scope != null && !scope.isEmpty()) {
-                condition += "WHERE s.id IN {scope} ";
+                condition += "AND s.id IN {scope} ";
                 params.put("scope", new JsonArray(scope));
             }
         }
 
         if (!userInfos.getFunctions().containsKey(SUPER_ADMIN)) {
-            condition += (condition.isEmpty() ? "WHERE " : "AND ") + DefaultSchoolService.EXCLUDE_ADMC_QUERY_FILTER;
+            condition += "AND "+ DefaultSchoolService.EXCLUDE_ADMC_QUERY_FILTER;
         }
 
         //With clause

--- a/directory/src/main/resources/public/template/admin/toaster.html
+++ b/directory/src/main/resources/public/template/admin/toaster.html
@@ -1,8 +1,14 @@
 <section class="toggle-buttons" ng-class="{ hide: !hasSelectedUsers() }">
     <div class="toggle block-container">
         <div class="row">
-            <button workflow="directory.allowClassAdminResetPassword" translate content="directory.resetPassword" ng-click="resetPasswords()" ng-if="selectedUsersAreActivated()"></button>
-            <button workflow="directory.allowClassAdminResetPassword" translate content="directory.temporaryPassword" ng-click="generateTemporaryPasswords()"></button>
+            <button workflow="directory.allowClassAdminResetPassword" translate content="directory.resetPassword" 
+                    ng-disabled="selectedUsersAreFederated()"
+                    ng-click="resetPasswords()" 
+                    ng-if="selectedUsersAreActivated()">
+            </button>
+            <button workflow="directory.allowClassAdminResetPassword" translate content="directory.temporaryPassword" 
+                    ng-disabled="selectedUsersAreFederated()"
+                    ng-click="generateTemporaryPasswords()"></button>
             <button workflow="directory.allowClassAdminBlockUsers" ng-click="openLightbox('admin/actions/block')" ng-if="selectedUsersAreNotBlocked()" translate
                 content="admin.block">
             </button>
@@ -12,7 +18,7 @@
             <button workflow="directory.allowClassAdminDeleteUsers" ng-if="canRemoveSelection()" ng-click="openLightbox('admin/actions/delete')">
                 <i18n>remove</i18n>
             </button>
-            <button ng-click="goToExport(true)">
+            <button ng-click="goToExport(true)" ng-disabled="selectedUsersAreFederated()">
                 <i18n>classAdmin.export.toaster</i18n>
             </button>
             <button workflow="directory.allowClassAdminUnlinkUsers" ng-click="onToasterUnlinkUsers()">

--- a/directory/src/main/resources/public/ts/admin/delegates/actions.ts
+++ b/directory/src/main/resources/public/ts/admin/delegates/actions.ts
@@ -9,6 +9,7 @@ export interface ActionsDelegateScope extends EventDelegateScope {
     selectedUsersAreNotActivated(): boolean;
     selectedUsersAreBlocked(): boolean;
     selectedUsersAreNotBlocked(): boolean;
+    selectedUsersAreFederated(): boolean;
     confirmRemove();
     canRemoveSelection(): boolean
     blockUsers(): void;
@@ -50,6 +51,9 @@ export function ActionsDelegate($scope: ActionsDelegateScope) {
     }
     $scope.selectedUsersAreBlocked = function () {
         return selection.findIndex((u) => !u.blocked) == -1;
+    }
+    $scope.selectedUsersAreFederated = function () {
+        return selection.findIndex((u) => u.federated!==true) === -1;
     }
     $scope.canRemoveSelection = function () {
         return selection.filter((user) => {

--- a/directory/src/main/resources/public/ts/admin/delegates/userExport.ts
+++ b/directory/src/main/resources/public/ts/admin/delegates/userExport.ts
@@ -139,6 +139,8 @@ export function ExportDelegate($scope: ExportDelegateScope) {
                 return ($scope.userExport.profiles.indexOf(u.type) > -1);
             });
         }
+        // Filter federated users out of massmailing reports.
+        _usersForMailing = _usersForMailing.filter(u => u.federated !== true);
         _usersWithoutMails = _usersForMailing.filter(s => !s.safeHasEmail);
         _usersWithMails = _usersForMailing.filter(s => s.safeHasEmail);
     }

--- a/directory/src/main/resources/public/ts/admin/model.ts
+++ b/directory/src/main/resources/public/ts/admin/model.ts
@@ -103,6 +103,7 @@ export class User extends Model {
     hasEmail: boolean;
     //from directory/class-admin/:id
     lockedEmail?: boolean;  // defined only in some cases
+    federated?: boolean|null;  // defined only in some cases
     //
     constructor(data?: Partial<User>) {
         super({});

--- a/directory/src/main/resources/public/ts/admin/service.ts
+++ b/directory/src/main/resources/public/ts/admin/service.ts
@@ -171,7 +171,7 @@ export const directoryService = {
         return schoolClass;
     },
     async fetchUsersForClass(classId: string, { collectRelative } = { collectRelative: true }): Promise<User[]> {
-        const resHttp = await http.get(`/directory/class/${classId}/users?collectRelative=${collectRelative}`);
+        const resHttp = await http.get(`/directory/class/${classId}/users?withFederated=true&collectRelative=${collectRelative}`);
         const res: User[] = resHttp.data;
         const sorted = res.map(r => new User(r)).sort(User.sortByLastname());
         return sorted;


### PR DESCRIPTION
# Description

Un utilisateur est en fédération d’identité _ssi_ son noeud neo4j porte le champ `federated=true`
Ce champ est affecté à l’utilisateur lors de sa 1ère connexion en fédération d'identité.
=> Ce ticket consiste à minimiser les risques qu’un utilisateur, qui devrait être fédéré, se connecte par la mire de connexion de l'ENT la première fois.

Pour un utilisateur en fédération d'identité, cette PR
* empêche de générer les fiches de connexions depuis la console admin,
* empêche de générer les fiches de connexions depuis le paramétrage de la classe,
* empêche d'utiliser la fonction "mot de passe oublié",
* empêche d'utiliser la fonction "identifiant oublié",

## Fixes

[WB-3778](https://edifice-community.atlassian.net/browse/WB-3778)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [X] admin
- [ ] app-registry
- [ ] archive
- [X] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [X] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley: