### PR TITLE
feat(conversation):#WB-3826 navigation bar and dropdown action list on message detail

### DIFF
--- a/conversation/frontend/src/components/DisplayActionDropDown.tsx
+++ b/conversation/frontend/src/components/DisplayActionDropDown.tsx
@@ -32,17 +32,23 @@ import {
 } from '~/services';
 import { useConfirmModalStore } from '~/store';
 
-export interface MessageNavigationProps {
+export interface DisplayActionDropDownProps {
   message: Message;
-  variant?: 'outline' | 'ghost';
+  appearance?: {
+    variant?: 'outline' | 'ghost';
+    btnColor?: 'tertiary' | 'primary';
+  };
   actions?: string[];
 }
 
 export function DisplayActionDropDown({
   message,
-  variant = 'outline',
   actions,
-}: MessageNavigationProps) {
+  appearance = {
+    variant: 'outline',
+    btnColor: 'primary',
+  },
+}: DisplayActionDropDownProps) {
   const { t } = useI18n();
   const markAsUnreadQuery = useMarkUnread();
   const navigate = useNavigate();
@@ -164,59 +170,73 @@ export function DisplayActionDropDown({
     navigate(`../..`, { relative: 'path' });
   };
 
+  const hasActionsList = (idAction: string) => {
+    return !actions || actions.includes(idAction);
+  };
+
   const options = [
     {
-      label: t('tag.unread'),
-      icon: <IconUnreadMail />,
-      action: () => {
-        handleMarkAsUnreadClick();
-      },
-      hidden: !canMarkUnread,
-    },
-    {
       label: t('replyall'),
+      id: 'replyall',
       icon: <IconUndoAll />,
       action: () => {
         alert('reply all');
       },
-      hidden: !canReplyAll,
+      hidden: !hasActionsList('replyall') || !canReplyAll,
     },
     {
       label: t('transfer'),
+      id: 'transfer',
       icon: <IconRedo />,
       action: () => {
         alert('transfer');
       },
-      hidden: message.state === 'DRAFT' || message.trashed,
+      hidden:
+        !hasActionsList('transfer') ||
+        message.state === 'DRAFT' ||
+        message.trashed,
+    },
+    {
+      label: t('tag.unread'),
+      id: 'unread',
+      icon: <IconUnreadMail />,
+      action: handleMarkAsUnreadClick,
+      hidden: !hasActionsList('unread') || !canMarkUnread,
     },
     {
       label: t('draft.save'),
+      id: 'save',
       icon: <IconSave />,
       action: handleDraftSaveClick,
-      hidden: message.state !== 'DRAFT' && !message.trashed,
+      hidden:
+        !hasActionsList('save') ||
+        (message.state !== 'DRAFT' && !message.trashed),
     },
     {
       label: t('trash'),
+      id: 'trash',
       icon: <IconDelete />,
       action: () => {
         moveToTrashQuery.mutate({ id: message.id });
         navigate(`../..`, { relative: 'path' });
       },
-      hidden: message.trashed,
+      hidden: !hasActionsList('trash') || message.trashed,
     },
     {
       label: t('delete'),
+      id: 'delete',
       icon: <IconDelete />,
       action: handleDeleteClick,
-      hidden: !message.trashed,
+      hidden: !hasActionsList('delete') || !message.trashed,
     },
     {
       label: t('print'),
+      id: 'print',
       icon: <IconPrint />,
       action: () => {
         alert('print');
       },
-      hidden: message.state === 'DRAFT',
+      hidden: !hasActionsList('print') || message.state === 'DRAFT',
     },
   ];
 
@@ -227,8 +247,8 @@ export function DisplayActionDropDown({
         .map((option) => (
           <Button
             key={option.id}
-            color="primary"
-            variant={variant}
+            color={appearance.btnColor}
+            variant={appearance.variant}
             leftIcon={option.icon}
             onClick={option.action}
           >
@@ -240,32 +260,54 @@ export function DisplayActionDropDown({
           triggerProps: JSX.IntrinsicAttributes &
             Omit<IconButtonProps, 'ref'> &
             RefAttributes<HTMLButtonElement>,
-        ) => (
-          <div data-testid="dropdown">
-            <IconButton
-              {...triggerProps}
-              type="button"
-              size="sm"
-              aria-label=""
-              color="primary"
-              variant={variant}
-              icon={<IconOptions />}
-            />
-            <Dropdown.Menu>
-              {options
-                .filter((o) => !o.hidden)
-                .map((option) => (
-                  <Dropdown.Item
-                    key={option.label}
-                    icon={option.icon}
-                    onClick={() => option.action()}
-                  >
-                    {option.label}
-                  </Dropdown.Item>
-                ))}
-            </Dropdown.Menu>
-          </div>
-        )}
+        ) => {
+          // If no options availables
+          const visibleOptions = options.filter((o) => !o.hidden);
+          if (visibleOptions.length === 0) {
+            return null;
+          }
+
+          return (
+            <div data-testid="dropdown">
+              <IconButton
+                {...triggerProps}
+                type="button"
+                size="sm"
+                color={appearance.btnColor}
+                variant={appearance.variant}
+                icon={<IconOptions />}
+              />
+              <Dropdown.Menu>
+                {visibleOptions.flatMap((option, index, array) => {
+                  const elements = [
+                    <Dropdown.Item
+                      key={option.id}
+                      icon={option.icon}
+                      onClick={option.action}
+                    >
+                      {option.label}
+                    </Dropdown.Item>,
+                  ];
+
+                  // Separator
+                  const separatorAfterIds = ['replyall', 'transfer'];
+                  if (
+                    separatorAfterIds.includes(option.id) &&
+                    array
+                      .slice(index + 1)
+                      .some((o) => !separatorAfterIds.includes(o.id))
+                  ) {
+                    elements.push(
+                      <Dropdown.Separator key={`separator-${option.id}`} />,
+                    );
+                  }
+
+                  return elements;
+                })}
+              </Dropdown.Menu>
+            </div>
+          );
+        }}
       </Dropdown>
     </div>
   );

--- a/conversation/frontend/src/components/DisplayActionDropDown.tsx
+++ b/conversation/frontend/src/components/DisplayActionDropDown.tsx
@@ -32,7 +32,17 @@ import {
 } from '~/services';
 import { useConfirmModalStore } from '~/store';
 
-export function DisplayActionDropDown({ message }: { message: Message }) {
+export interface MessageNavigationProps {
+  message: Message;
+  variant?: 'outline' | 'ghost';
+  actions?: string[];
+}
+
+export function DisplayActionDropDown({
+  message,
+  variant = 'outline',
+  actions,
+}: MessageNavigationProps) {
   const { t } = useI18n();
   const markAsUnreadQuery = useMarkUnread();
   const navigate = useNavigate();
@@ -218,7 +228,7 @@ export function DisplayActionDropDown({ message }: { message: Message }) {
           <Button
             key={option.id}
             color="primary"
-            variant="outline"
+            variant={variant}
             leftIcon={option.icon}
             onClick={option.action}
           >
@@ -238,7 +248,7 @@ export function DisplayActionDropDown({ message }: { message: Message }) {
               size="sm"
               aria-label=""
               color="primary"
-              variant="outline"
+              variant={variant}
               icon={<IconOptions />}
             />
             <Dropdown.Menu>

--- a/conversation/frontend/src/features/message/MessageNavigation.tsx
+++ b/conversation/frontend/src/features/message/MessageNavigation.tsx
@@ -1,0 +1,10 @@
+import { DisplayActionDropDown } from "~/components/DisplayActionDropDown";
+import { MessageProps } from ".";
+
+export function MessageNavigation({ message }: MessageProps) {
+  return <nav className="border-bottom mb-16 px-16 py-4 d-flex">
+    <div className="ms-auto">
+      <DisplayActionDropDown message={message} variant="ghost" />
+    </div>
+  </nav>
+}

--- a/conversation/frontend/src/features/message/MessageNavigation.tsx
+++ b/conversation/frontend/src/features/message/MessageNavigation.tsx
@@ -2,9 +2,18 @@ import { DisplayActionDropDown } from "~/components/DisplayActionDropDown";
 import { MessageProps } from ".";
 
 export function MessageNavigation({ message }: MessageProps) {
-  return <nav className="border-bottom mb-16 px-16 py-4 d-flex">
-    <div className="ms-auto">
-      <DisplayActionDropDown message={message} variant="ghost" />
-    </div>
-  </nav>
+  const actionDropDownProps = {
+    message,
+    appearance: {
+      variant: 'ghost' as const,
+      btnColor: 'tertiary' as const,
+    },
+  };
+  return (
+    <nav className="border-bottom mb-16 px-16 py-4 d-flex">
+      <div className="ms-auto">
+        <DisplayActionDropDown {...actionDropDownProps} />
+      </div>
+    </nav>
+  );
 }

--- a/conversation/frontend/src/features/message/MessageNavigation.tsx
+++ b/conversation/frontend/src/features/message/MessageNavigation.tsx
@@ -10,7 +10,7 @@ export function MessageNavigation({ message }: MessageProps) {
     },
   };
   return (
-    <nav className="border-bottom mb-16 px-16 py-4 d-flex">
+    <nav className="border-bottom px-16 py-4 d-flex">
       <div className="ms-auto">
         <DisplayActionDropDown {...actionDropDownProps} />
       </div>

--- a/conversation/frontend/src/features/message/index.tsx
+++ b/conversation/frontend/src/features/message/index.tsx
@@ -10,7 +10,7 @@ export interface MessageProps {
 
 export function Message({ message }: MessageProps) {
   return (
-    <article>
+    <article className="d-flex gap-16 flex-column">
       <MessageNavigation message={message} />
       <div className="p-16 ps-md-24 pt-0">
         <MessageHeader message={message} />

--- a/conversation/frontend/src/features/message/index.tsx
+++ b/conversation/frontend/src/features/message/index.tsx
@@ -18,7 +18,10 @@ export function Message({ message }: MessageProps) {
           <MessageBody message={message} editMode={false} />
         </div>
         <footer className="d-flex justify-content-end gap-12 pt-24 border-top">
-          <DisplayActionDropDown message={message} />
+          <DisplayActionDropDown
+            message={message}
+            actions={['reply', 'reply-all', 'transfer']}
+          />
         </footer>
       </div>
     </article>

--- a/conversation/frontend/src/features/message/index.tsx
+++ b/conversation/frontend/src/features/message/index.tsx
@@ -2,6 +2,7 @@ import { DisplayActionDropDown } from '~/components/DisplayActionDropDown';
 import { MessageBody } from '~/components/MessageBody';
 import { MessageHeader } from '~/features/message/MessageHeader';
 import { Message as MessageData } from '~/models';
+import { MessageNavigation } from './MessageNavigation';
 
 export interface MessageProps {
   message: MessageData;
@@ -9,14 +10,17 @@ export interface MessageProps {
 
 export function Message({ message }: MessageProps) {
   return (
-    <article className="p-16 ps-md-24">
-      <MessageHeader message={message} />
-      <div className="ps-md-48 my-md-24">
-        <MessageBody message={message} editMode={false} />
+    <article>
+      <MessageNavigation message={message} />
+      <div className="p-16 ps-md-24 pt-0">
+        <MessageHeader message={message} />
+        <div className="ps-md-48 my-md-24">
+          <MessageBody message={message} editMode={false} />
+        </div>
+        <footer className="d-flex justify-content-end gap-12 pt-24 border-top">
+          <DisplayActionDropDown message={message} />
+        </footer>
       </div>
-      <footer className="d-flex justify-content-end gap-12 pt-24 border-top">
-        <DisplayActionDropDown message={message} />
-      </footer>
     </article>
   );
 }


### PR DESCRIPTION
# Description

Il y a 2 listes d'actions disponible dans la vue détail du message.
Une en haut situé dans un bandeau de navigation avec toutes les actions possible par rapport au message courant. Avec un séparateur entre "répondre à tous et transférer" des autres actions.
Une liste en bas de message juste avec "répondre, répondre à tous et transférer".

## Fixes

(Enter here Jira or Redmine ticket(s) links)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [x] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: