### PR TITLE
feat(conversation): #WB-3925, add or remove attachments to draft messages

### DIFF
--- a/conversation/backend/src/main/resources/i18n/fr.json
+++ b/conversation/backend/src/main/resources/i18n/fr.json
@@ -1,5 +1,5 @@
 {
-  "add.attachment": "Ajouter une pièce jointe",
+  "add.attachment": "Pièce jointe",
   "add.signature": "Ajouter une signature",
   "at": "à :",
   "attachments": "Pièces jointes",

--- a/conversation/backend/src/main/resources/i18n/fr.json
+++ b/conversation/backend/src/main/resources/i18n/fr.json
@@ -4,6 +4,7 @@
   "at": "à :",
   "attachments": "Pièces jointes",
   "attachments.loading": "En cours de chargement",
+  "attachments.loaded": "Chargement effectué",
   "author.avatar": "Avatar de l'auteur",
   "cancel": "Annuler",
   "cc": "Cc :",

--- a/conversation/backend/src/main/resources/i18n/fr.json
+++ b/conversation/backend/src/main/resources/i18n/fr.json
@@ -148,6 +148,7 @@
   "recipient.avatar.group": "Plusieurs destinataires",
   "recipient.avatar.empty": "Aucun destinataire",
   "remove.attachment": "Supprimer la pièce jointe",
+  "remove.all.attachment": "Supprimer toutes les pièces jointes",
   "remove.from.folder": "Retirer du dossier",
   "remove.from.folder.confirm": "Le ou les messages que vous avez sélectionné vont être retirés du dossier et placés dans dans leur emplacement d’origine.",
   "remove.link": "Supprimer",

--- a/conversation/frontend/src/components/DisplayActionDropDown.tsx
+++ b/conversation/frontend/src/components/DisplayActionDropDown.tsx
@@ -124,8 +124,9 @@ export function DisplayActionDropDown({
     });
   };
 
-  const handleDraftSaveClick = () => {
-    createOrUpdateDraft();
+  const handleDraftSaveClick = async () => {
+    const promise = createOrUpdateDraft();
+    if (promise) navigate(`/draft/message/${(await promise).id}`);
   };
 
   const handleMarkAsUnreadClick = () => {

--- a/conversation/frontend/src/components/DisplayActionDropDown.tsx
+++ b/conversation/frontend/src/components/DisplayActionDropDown.tsx
@@ -126,7 +126,10 @@ export function DisplayActionDropDown({
 
   const handleDraftSaveClick = async () => {
     const promise = createOrUpdateDraft();
-    if (promise) navigate(`/draft/message/${(await promise).id}`);
+    if (promise) {
+      const { id } = await promise;
+      if (id) navigate(`/draft/message/${id}`);
+    }
   };
 
   const handleMarkAsUnreadClick = () => {

--- a/conversation/frontend/src/components/MessageBody.tsx
+++ b/conversation/frontend/src/components/MessageBody.tsx
@@ -38,11 +38,7 @@ export function MessageBody({
         extensions={extensions}
         onContentChange={handleContentChange}
       />
-      <MessageAttachments
-        attachments={message.attachments}
-        messageId={message.id}
-        editMode={editMode}
-      />
+      <MessageAttachments message={message} editMode={editMode} />
     </section>
   );
 }

--- a/conversation/frontend/src/components/message-attachments/MessageAttachment.tsx
+++ b/conversation/frontend/src/components/message-attachments/MessageAttachment.tsx
@@ -1,21 +1,29 @@
 import { Attachment, IconButton } from '@edifice.io/react';
-import { IconDownload, IconFolderAdd } from '@edifice.io/react/icons';
+import {
+  IconDelete,
+  IconDownload,
+  IconFolderAdd,
+} from '@edifice.io/react/icons';
 import { useI18n } from '~/hooks';
-import { Attachment as AttachmentMetaData } from '~/models';
+import { useMessageAttachments } from '~/hooks/useMessageAttachments';
+import { Attachment as AttachmentMetaData, Message } from '~/models';
 import { baseUrl } from '~/services';
 
 export interface MessageAttachmentsProps {
   attachment: AttachmentMetaData;
-  messageId: string;
+  message: Message;
+  editMode?: boolean;
 }
 
 export function MessageAttachment({
   attachment,
-  messageId,
+  message,
+  editMode,
 }: MessageAttachmentsProps) {
   const { t } = useI18n();
+  const { detachFile } = useMessageAttachments(message);
 
-  const downloadUrl = `${baseUrl}/message/${messageId}/attachment/${attachment.id}`;
+  const downloadUrl = `${baseUrl}/message/${message.id}/attachment/${attachment.id}`;
 
   return (
     <Attachment
@@ -38,6 +46,16 @@ export function MessageAttachment({
               variant="ghost"
             />
           </a>
+          {editMode && (
+            <IconButton
+              title={t('remove.attachment')}
+              color="danger"
+              type="button"
+              icon={<IconDelete />}
+              variant="ghost"
+              onClick={() => detachFile(attachment.id)}
+            />
+          )}
         </>
       }
     />

--- a/conversation/frontend/src/components/message-attachments/index.test.tsx
+++ b/conversation/frontend/src/components/message-attachments/index.test.tsx
@@ -6,23 +6,13 @@ const message = mockFullMessage;
 
 describe('Message preview header component', () => {
   it('should render successfully', async () => {
-    const { baseElement } = render(
-      <MessageAttachments
-        messageId={message.id}
-        attachments={message.attachments}
-      />,
-    );
+    const { baseElement } = render(<MessageAttachments message={message} />);
 
     expect(baseElement).toBeTruthy();
   });
 
   it('should render multiple attachements successfully', async () => {
-    render(
-      <MessageAttachments
-        messageId={message.id}
-        attachments={message.attachments}
-      />,
-    );
+    render(<MessageAttachments message={message} editMode={true} />);
 
     const messageAttachmentsTitle = await screen.findByText('attachments');
     const messageAttachmentsCopyAll = await screen.findByTitle(
@@ -30,6 +20,9 @@ describe('Message preview header component', () => {
     );
     const messageAttachmentsDownloadAll = await screen.findByTitle(
       'download.all.attachment',
+    );
+    const messageAttachmentsRemoveAll = await screen.findByTitle(
+      'remove.all.attachment',
     );
     const messageAttachment1 = await screen.findByText(
       message.attachments[0].filename,
@@ -43,18 +36,23 @@ describe('Message preview header component', () => {
     const messageAttachmentActionDownload = await screen.queryAllByTitle(
       'download.attachment',
     );
+    const messageAttachmentActionRemove =
+      await screen.queryAllByTitle('remove.attachment');
 
     expect(messageAttachmentsTitle).toBeInTheDocument();
     expect(messageAttachmentsCopyAll).toBeInTheDocument();
     expect(messageAttachmentsDownloadAll).toBeInTheDocument();
+    expect(messageAttachmentsRemoveAll).toBeInTheDocument();
     expect(messageAttachment1).toBeInTheDocument();
     expect(messageAttachment2).toBeInTheDocument();
     expect(messageAttachmentActionMoveTo).toHaveLength(2);
     expect(messageAttachmentActionDownload).toHaveLength(2);
+    expect(messageAttachmentActionRemove).toHaveLength(2);
   });
 
   it('should not render attachements', async () => {
-    render(<MessageAttachments messageId={message.id} attachments={[]} />);
+    const messageWoAttachments = { ...message, attachments: [] };
+    render(<MessageAttachments message={messageWoAttachments} />);
 
     const messageAttachmentsTitle = await screen.queryByText('attachments');
     const messageAttachmentsCopyAll = await screen.queryByLabelText(

--- a/conversation/frontend/src/components/message-attachments/index.tsx
+++ b/conversation/frontend/src/components/message-attachments/index.tsx
@@ -2,35 +2,40 @@ import { Button, IconButton } from '@edifice.io/react';
 import { IconDownload, IconFolderAdd, IconPlus } from '@edifice.io/react/icons';
 import clsx from 'clsx';
 import { useI18n } from '~/hooks';
-import { Attachment as AttachmentMetaData } from '~/models';
+import { Message } from '~/models';
 import { MessageAttachment } from './MessageAttachment';
 import './index.css';
-import { ChangeEvent, useRef } from 'react';
+import { ChangeEvent, useMemo, useRef } from 'react';
 import { useMessageAttachments } from '~/hooks/useMessageAttachments';
 
 export interface MessageAttachmentsProps {
-  attachments: AttachmentMetaData[];
-  messageId: string;
+  message: Message;
   editMode?: boolean;
 }
 
 export function MessageAttachments({
-  attachments,
-  messageId,
+  message,
   editMode = false,
 }: MessageAttachmentsProps) {
   const { common_t, t } = useI18n();
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const { downloadAllUrl, attachFiles } = useMessageAttachments({
-    messageId,
-    attachments,
-    editMode,
-  });
+  const { downloadAllUrl, attachFiles } = useMessageAttachments(message);
+
+  // This memo is required because `message` is intended to change sometimes
+  const { attachments } = useMemo(
+    () => ({
+      attachments: message.attachments,
+    }),
+    [message],
+  );
 
   if (!attachments.length && !editMode) return null;
 
-  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) =>
+  const handleAttachClick = () => inputRef?.current?.click();
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
     attachFiles(event.target.files);
+  };
 
   const className = clsx(
     'bg-gray-300 rounded-2 px-12 py-8 message-attachments gap-8 d-flex flex-column',
@@ -71,7 +76,8 @@ export function MessageAttachments({
               <li key={attachment.id}>
                 <MessageAttachment
                   attachment={attachment}
-                  messageId={messageId}
+                  message={message}
+                  editMode={editMode}
                 />
               </li>
             ))}
@@ -84,7 +90,7 @@ export function MessageAttachments({
             color="secondary"
             variant="ghost"
             leftIcon={<IconPlus />}
-            onClick={() => inputRef?.current?.click()}
+            onClick={handleAttachClick}
           >
             {t('add.attachment')}
           </Button>

--- a/conversation/frontend/src/components/message-attachments/index.tsx
+++ b/conversation/frontend/src/components/message-attachments/index.tsx
@@ -1,5 +1,10 @@
 import { Button, IconButton } from '@edifice.io/react';
-import { IconDownload, IconFolderAdd, IconPlus } from '@edifice.io/react/icons';
+import {
+  IconDownload,
+  IconFolderAdd,
+  IconLoader,
+  IconPlus,
+} from '@edifice.io/react/icons';
 import clsx from 'clsx';
 import { useI18n } from '~/hooks';
 import { Message } from '~/models';
@@ -19,7 +24,7 @@ export function MessageAttachments({
 }: MessageAttachmentsProps) {
   const { common_t, t } = useI18n();
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const { attachments, downloadAllUrl, attachFiles } =
+  const { attachments, downloadAllUrl, attachFiles, isMutating } =
     useMessageAttachments(message);
 
   if (!attachments.length && !editMode) return null;
@@ -82,8 +87,9 @@ export function MessageAttachments({
           <Button
             color="secondary"
             variant="ghost"
-            leftIcon={<IconPlus />}
+            leftIcon={isMutating ? <IconLoader /> : <IconPlus />}
             onClick={handleAttachClick}
+            disabled={isMutating}
           >
             {t('add.attachment')}
           </Button>

--- a/conversation/frontend/src/components/message-attachments/index.tsx
+++ b/conversation/frontend/src/components/message-attachments/index.tsx
@@ -1,4 +1,4 @@
-import { Button, IconButton } from '@edifice.io/react';
+import { Button, Dropzone, DropzoneContext, IconButton, useDropzone } from '@edifice.io/react';
 import { IconDownload, IconFolderAdd, IconPlus } from '@edifice.io/react/icons';
 import clsx from 'clsx';
 import { useI18n } from '~/hooks';
@@ -6,6 +6,7 @@ import { Attachment as AttachmentMetaData } from '~/models';
 import { baseUrl } from '~/services';
 import { MessageAttachment } from './MessageAttachment';
 import './index.css';
+import { useMemo } from 'react';
 
 export interface MessageAttachmentsProps {
   attachments: AttachmentMetaData[];
@@ -19,8 +20,33 @@ export function MessageAttachments({
   editMode = false,
 }: MessageAttachmentsProps) {
   const { common_t, t } = useI18n();
-  const downloadUrl = `${baseUrl}/message/${messageId}/allAttachments`;
 
+
+  const {
+    inputRef,
+//    dragging,
+    files,
+    addFile,
+    deleteFile,
+    replaceFileAt,
+    handleDragLeave,
+    handleDragging,
+    handleDrop,
+    handleOnChange,
+  } = useDropzone();
+
+  const value = useMemo(
+    () => ({
+      inputRef,
+      files,
+      addFile,
+      deleteFile,
+      replaceFileAt,
+    }),
+    [addFile, deleteFile, replaceFileAt, files, inputRef],
+  );
+
+  const downloadUrl = `${baseUrl}/message/${messageId}/allAttachments`;
   const className = clsx(
     'bg-gray-300 rounded-2 px-12 py-8 message-attachments gap-8 d-flex flex-column',
     editMode && 'border message-attachments-edit mx-16',
@@ -70,9 +96,27 @@ export function MessageAttachments({
         </>
       )}
       {editMode && (
-        <Button color="secondary" variant="ghost" leftIcon={<IconPlus />}>
-          {t('add.attachment')}
-        </Button>
+        <DropzoneContext.Provider value={value}>
+          <div
+            onDragEnter={handleDragging}
+            onDragOver={handleDragging}
+            onDragLeave={handleDragLeave}
+            onDrop={handleDrop}
+          >
+            <Button color="secondary" variant="ghost" leftIcon={<IconPlus />} onClick={() => inputRef?.current?.click()}>
+              {t('add.attachment')}
+            </Button>
+            <input
+              ref={inputRef}
+              multiple={true}
+              type="file"
+              name="attachment-input"
+              id="attachment-input"
+              onChange={handleOnChange}
+              hidden
+            />
+          </div>
+        </DropzoneContext.Provider>
       )}
     </div>
   );

--- a/conversation/frontend/src/components/message-attachments/index.tsx
+++ b/conversation/frontend/src/components/message-attachments/index.tsx
@@ -5,7 +5,7 @@ import { useI18n } from '~/hooks';
 import { Message } from '~/models';
 import { MessageAttachment } from './MessageAttachment';
 import './index.css';
-import { ChangeEvent, useMemo, useRef } from 'react';
+import { ChangeEvent, useRef } from 'react';
 import { useMessageAttachments } from '~/hooks/useMessageAttachments';
 
 export interface MessageAttachmentsProps {
@@ -19,15 +19,8 @@ export function MessageAttachments({
 }: MessageAttachmentsProps) {
   const { common_t, t } = useI18n();
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const { downloadAllUrl, attachFiles } = useMessageAttachments(message);
-
-  // This memo is required because `message` is intended to change sometimes
-  const { attachments } = useMemo(
-    () => ({
-      attachments: message.attachments,
-    }),
-    [message],
-  );
+  const { attachments, downloadAllUrl, attachFiles } =
+    useMessageAttachments(message);
 
   if (!attachments.length && !editMode) return null;
 

--- a/conversation/frontend/src/components/message-attachments/index.tsx
+++ b/conversation/frontend/src/components/message-attachments/index.tsx
@@ -1,5 +1,6 @@
 import { Button, IconButton } from '@edifice.io/react';
 import {
+  IconDelete,
   IconDownload,
   IconFolderAdd,
   IconLoader,
@@ -24,7 +25,7 @@ export function MessageAttachments({
 }: MessageAttachmentsProps) {
   const { common_t, t } = useI18n();
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const { attachments, downloadAllUrl, attachFiles, isMutating } =
+  const { attachments, downloadAllUrl, attachFiles, detachFiles, isMutating } =
     useMessageAttachments(message);
 
   if (!attachments.length && !editMode) return null;
@@ -34,6 +35,8 @@ export function MessageAttachments({
   const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
     attachFiles(event.target.files);
   };
+
+  const handleDetachAllClick = () => detachFiles(attachments);
 
   const className = clsx(
     'bg-gray-300 rounded-2 px-12 py-8 message-attachments gap-8 d-flex flex-column',
@@ -66,6 +69,17 @@ export function MessageAttachments({
                     variant="ghost"
                   />
                 </a>
+                {editMode && (
+                  <IconButton
+                    title={t('remove.all.attachment')}
+                    color="danger"
+                    type="button"
+                    icon={<IconDelete />}
+                    variant="ghost"
+                    onClick={handleDetachAllClick}
+                    disabled={isMutating}
+                  />
+                )}
               </div>
             )}
           </div>

--- a/conversation/frontend/src/features/message-edit/index.tsx
+++ b/conversation/frontend/src/features/message-edit/index.tsx
@@ -12,7 +12,6 @@ import {
   useMessageUpdatedNeedToSave,
 } from '~/store';
 import { MessageHeaderEdit } from './MessageHeaderEdit';
-import { useNavigate } from 'react-router-dom';
 
 export interface MessageEditProps {
   message: Message;
@@ -28,7 +27,6 @@ export function MessageEdit({ message }: MessageEditProps) {
   const debounceTimeToSave = useRef(5000);
   const createOrUpdateDraft = useCreateOrUpdateDraft();
   const [contentKey, setContentKey] = useState(0);
-  const navigate = useNavigate();
 
   useEffect(() => {
     odeServices
@@ -66,9 +64,7 @@ export function MessageEdit({ message }: MessageEditProps) {
 
   useEffect(() => {
     if (messageUpdatedDebounced && messageUpdatedNeedSave) {
-      createOrUpdateDraft()?.then(({ id }) => {
-        if (id) navigate(`/draft/message/${id}`);
-      });
+      createOrUpdateDraft();
       setMessageUpdatedNeedToSave(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/conversation/frontend/src/features/message-edit/index.tsx
+++ b/conversation/frontend/src/features/message-edit/index.tsx
@@ -12,6 +12,7 @@ import {
   useMessageUpdatedNeedToSave,
 } from '~/store';
 import { MessageHeaderEdit } from './MessageHeaderEdit';
+import { useNavigate } from 'react-router-dom';
 
 export interface MessageEditProps {
   message: Message;
@@ -27,6 +28,7 @@ export function MessageEdit({ message }: MessageEditProps) {
   const debounceTimeToSave = useRef(5000);
   const createOrUpdateDraft = useCreateOrUpdateDraft();
   const [contentKey, setContentKey] = useState(0);
+  const navigate = useNavigate();
 
   useEffect(() => {
     odeServices
@@ -60,7 +62,9 @@ export function MessageEdit({ message }: MessageEditProps) {
 
   useEffect(() => {
     if (messageUpdatedDebounced && messageUpdatedNeedSave) {
-      createOrUpdateDraft();
+      createOrUpdateDraft()?.then(({ id }) => {
+        if (id) navigate(`/draft/message/${id}`);
+      });
       setMessageUpdatedNeedToSave(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/conversation/frontend/src/features/message-edit/index.tsx
+++ b/conversation/frontend/src/features/message-edit/index.tsx
@@ -44,6 +44,10 @@ export function MessageEdit({ message }: MessageEditProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(() => {
+    setMessageUpdated(message);
+  }, [message, setMessageUpdated]);
+
   const handleSubjectChange = (subject: string) => {
     setSubject(subject);
     setMessageUpdated({ ...message, subject });

--- a/conversation/frontend/src/hooks/useMessageAttachments.tsx
+++ b/conversation/frontend/src/hooks/useMessageAttachments.tsx
@@ -1,0 +1,27 @@
+import { MessageAttachmentsProps } from '~/components/message-attachments';
+import { baseUrl } from '~/services';
+import { useAttachFiles } from '~/services/queries/attachment';
+
+export function useMessageAttachments({ messageId }: MessageAttachmentsProps) {
+  const attachFileMutation = useAttachFiles();
+
+  const downloadAllUrl = `${baseUrl}/message/${messageId}/allAttachments`;
+
+  const attachFiles = (files: FileList | null) => {
+    const mutateVars: { draftId: string; files: File[] } = {
+      draftId: messageId,
+      files: [],
+    };
+    for (let i = 0; files && i < files.length; i++) {
+      const file = files.item(i);
+      if (file) mutateVars.files.push(file);
+    }
+
+    attachFileMutation.mutate(mutateVars);
+  };
+
+  return {
+    downloadAllUrl,
+    attachFiles,
+  };
+}

--- a/conversation/frontend/src/hooks/useMessageAttachments.tsx
+++ b/conversation/frontend/src/hooks/useMessageAttachments.tsx
@@ -1,27 +1,49 @@
-import { MessageAttachmentsProps } from '~/components/message-attachments';
-import { baseUrl } from '~/services';
-import { useAttachFiles } from '~/services/queries/attachment';
+import { useNavigate } from 'react-router-dom';
+import { Message } from '~/models';
+import { baseUrl, useCreateOrUpdateDraft } from '~/services';
+import { useAttachFiles, useRemoveFile } from '~/services/queries/attachment';
 
-export function useMessageAttachments({ messageId }: MessageAttachmentsProps) {
+export function useMessageAttachments({ id }: Message) {
   const attachFileMutation = useAttachFiles();
+  const detachFileMutation = useRemoveFile();
 
-  const downloadAllUrl = `${baseUrl}/message/${messageId}/allAttachments`;
+  // These hooks are required when attaching files to a new draft without any id.
+  const createOrUpdateDraft = useCreateOrUpdateDraft();
+  const navigate = useNavigate();
 
-  const attachFiles = (files: FileList | null) => {
+  const downloadAllUrl = `${baseUrl}/message/${id}/allAttachments`;
+
+  async function attachFiles(files: FileList | null) {
+    if (!id) {
+      // Save this new draft to get its id
+      const promise = createOrUpdateDraft();
+      if (promise) id = (await promise).id;
+    }
     const mutateVars: { draftId: string; files: File[] } = {
-      draftId: messageId,
+      draftId: id,
       files: [],
     };
     for (let i = 0; files && i < files.length; i++) {
       const file = files.item(i);
       if (file) mutateVars.files.push(file);
     }
+    attachFileMutation.mutateAsync(mutateVars, {
+      onSuccess() {
+        if (id) navigate(`/draft/message/${id}`);
+      },
+    });
+  }
 
-    attachFileMutation.mutate(mutateVars);
-  };
+  async function detachFile(attachmentId: string) {
+    return detachFileMutation.mutateAsync({
+      draftId: id,
+      attachmentId,
+    });
+  }
 
   return {
     downloadAllUrl,
     attachFiles,
+    detachFile,
   };
 }

--- a/conversation/frontend/src/hooks/useMessageAttachments.tsx
+++ b/conversation/frontend/src/hooks/useMessageAttachments.tsx
@@ -48,5 +48,6 @@ export function useMessageAttachments({ id, attachments }: Message) {
     downloadAllUrl,
     attachFiles,
     detachFile,
+    isMutating: attachFileMutation.isPending || detachFileMutation.isPending,
   };
 }

--- a/conversation/frontend/src/hooks/useMessageAttachments.tsx
+++ b/conversation/frontend/src/hooks/useMessageAttachments.tsx
@@ -2,20 +2,13 @@ import { useNavigate } from 'react-router-dom';
 import { Message } from '~/models';
 import { baseUrl, useCreateOrUpdateDraft } from '~/services';
 import { useAttachFiles, useRemoveFile } from '~/services/queries/attachment';
-import { useAppActions, useMessageUpdated } from '~/store';
 
-export function useMessageAttachments({
-  id,
-  attachments,
-  ...message
-}: Message) {
+export function useMessageAttachments({ id, attachments }: Message) {
   const attachFileMutation = useAttachFiles();
   const detachFileMutation = useRemoveFile();
 
   // These hooks are required when attaching files to a new draft without any id.
   const createOrUpdateDraft = useCreateOrUpdateDraft();
-  const { setMessageUpdated } = useAppActions();
-  const messageUpdated = useMessageUpdated();
   const navigate = useNavigate();
 
   const downloadAllUrl = `${baseUrl}/message/${id}/allAttachments`;
@@ -35,28 +28,9 @@ export function useMessageAttachments({
       if (file) mutateVars.files.push(file);
     }
     attachFileMutation.mutateAsync(mutateVars, {
-      onSuccess(data, { files }) {
+      onSuccess() {
         if (id) {
           navigate(`/draft/message/${id}`);
-        } else {
-          if (messageUpdated) {
-            //Optimistic update
-            const { attachments } = messageUpdated;
-            for (let j = 0; j < mutateVars.files.length; j++) {
-              if (j < data.length && data[j]) {
-                attachments.push({
-                  id: data[j].id,
-                  filename: mutateVars.files[j].name,
-                  name: mutateVars.files[j].name,
-                  size: mutateVars.files[j].size,
-                  charset: '',
-                  contentTransferEncoding: '',
-                  contentType: '',
-                });
-              }
-            }
-            setMessageUpdated({ ...messageUpdated });
-          }
         }
       },
     });

--- a/conversation/frontend/src/hooks/useMessageAttachments.tsx
+++ b/conversation/frontend/src/hooks/useMessageAttachments.tsx
@@ -1,15 +1,13 @@
-import { useNavigate } from 'react-router-dom';
 import { Attachment, Message } from '~/models';
 import { baseUrl, useCreateOrUpdateDraft } from '~/services';
-import { useAttachFiles, useRemoveFile } from '~/services/queries/attachment';
+import { useAttachFiles, useDetachFile } from '~/services/queries/attachment';
 
 export function useMessageAttachments({ id, attachments }: Message) {
   const attachFileMutation = useAttachFiles();
-  const detachFileMutation = useRemoveFile();
+  const detachFileMutation = useDetachFile();
 
-  // These hooks are required when attaching files to a new draft without any id.
+  // These hooks is required when attaching files to a blank new draft, without id.
   const createOrUpdateDraft = useCreateOrUpdateDraft();
-  const navigate = useNavigate();
 
   const downloadAllUrl = `${baseUrl}/message/${id}/allAttachments`;
 
@@ -27,13 +25,7 @@ export function useMessageAttachments({ id, attachments }: Message) {
       const file = files.item(i);
       if (file) mutateVars.files.push(file);
     }
-    attachFileMutation.mutateAsync(mutateVars, {
-      onSuccess() {
-        if (id) {
-          navigate(`/draft/message/${id}`);
-        }
-      },
-    });
+    attachFileMutation.mutateAsync(mutateVars);
   }
 
   function detachFile(attachmentId: string) {
@@ -44,9 +36,7 @@ export function useMessageAttachments({ id, attachments }: Message) {
   }
 
   function detachFiles(attachments: Attachment[]) {
-    return Promise.all(
-      attachments.map((attachment) => detachFile(attachment.id)),
-    );
+    return Promise.all(attachments.map(({ id }) => detachFile(id)));
   }
 
   return {

--- a/conversation/frontend/src/hooks/useMessageAttachments.tsx
+++ b/conversation/frontend/src/hooks/useMessageAttachments.tsx
@@ -2,13 +2,20 @@ import { useNavigate } from 'react-router-dom';
 import { Message } from '~/models';
 import { baseUrl, useCreateOrUpdateDraft } from '~/services';
 import { useAttachFiles, useRemoveFile } from '~/services/queries/attachment';
+import { useAppActions, useMessageUpdated } from '~/store';
 
-export function useMessageAttachments({ id }: Message) {
+export function useMessageAttachments({
+  id,
+  attachments,
+  ...message
+}: Message) {
   const attachFileMutation = useAttachFiles();
   const detachFileMutation = useRemoveFile();
 
   // These hooks are required when attaching files to a new draft without any id.
   const createOrUpdateDraft = useCreateOrUpdateDraft();
+  const { setMessageUpdated } = useAppActions();
+  const messageUpdated = useMessageUpdated();
   const navigate = useNavigate();
 
   const downloadAllUrl = `${baseUrl}/message/${id}/allAttachments`;
@@ -28,8 +35,29 @@ export function useMessageAttachments({ id }: Message) {
       if (file) mutateVars.files.push(file);
     }
     attachFileMutation.mutateAsync(mutateVars, {
-      onSuccess() {
-        if (id) navigate(`/draft/message/${id}`);
+      onSuccess(data, { files }) {
+        if (id) {
+          navigate(`/draft/message/${id}`);
+        } else {
+          if (messageUpdated) {
+            //Optimistic update
+            const { attachments } = messageUpdated;
+            for (let j = 0; j < mutateVars.files.length; j++) {
+              if (j < data.length && data[j]) {
+                attachments.push({
+                  id: data[j].id,
+                  filename: mutateVars.files[j].name,
+                  name: mutateVars.files[j].name,
+                  size: mutateVars.files[j].size,
+                  charset: '',
+                  contentTransferEncoding: '',
+                  contentType: '',
+                });
+              }
+            }
+            setMessageUpdated({ ...messageUpdated });
+          }
+        }
       },
     });
   }
@@ -42,6 +70,7 @@ export function useMessageAttachments({ id }: Message) {
   }
 
   return {
+    attachments,
     downloadAllUrl,
     attachFiles,
     detachFile,

--- a/conversation/frontend/src/hooks/useMessageAttachments.tsx
+++ b/conversation/frontend/src/hooks/useMessageAttachments.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import { Message } from '~/models';
+import { Attachment, Message } from '~/models';
 import { baseUrl, useCreateOrUpdateDraft } from '~/services';
 import { useAttachFiles, useRemoveFile } from '~/services/queries/attachment';
 
@@ -36,11 +36,17 @@ export function useMessageAttachments({ id, attachments }: Message) {
     });
   }
 
-  async function detachFile(attachmentId: string) {
+  function detachFile(attachmentId: string) {
     return detachFileMutation.mutateAsync({
       draftId: id,
       attachmentId,
     });
+  }
+
+  function detachFiles(attachments: Attachment[]) {
+    return Promise.all(
+      attachments.map((attachment) => detachFile(attachment.id)),
+    );
   }
 
   return {
@@ -48,6 +54,7 @@ export function useMessageAttachments({ id, attachments }: Message) {
     downloadAllUrl,
     attachFiles,
     detachFile,
+    detachFiles,
     isMutating: attachFileMutation.isPending || detachFileMutation.isPending,
   };
 }

--- a/conversation/frontend/src/services/api/attachmentService.test.ts
+++ b/conversation/frontend/src/services/api/attachmentService.test.ts
@@ -3,19 +3,47 @@ import { baseUrl, attachmentService } from '.';
 import { odeServices } from 'edifice-ts-client';
 
 describe('Conversation Attachment Mutation Methods', () => {
-  test('makes a POST request to attach a file or blob to a message', async () => {
+  test('makes a POST request to attach a file or blob to a draft message', async () => {
     const messageId = 'f43d3783';
-    const uploadedFile = new File(["Le sage ne dit pas ce qu'il sait, le sot ne sait pas ce qu'il dit."], "Koan.txt", {
-      type: "text/plain",
-    });
+    const uploadedFile = new File(
+      ["Le sage ne dit pas ce qu'il sait, le sot ne sait pas ce qu'il dit."],
+      'Koan.txt',
+      {
+        type: 'text/plain',
+      },
+    );
+    const formData = new FormData();
+    formData.append('file', uploadedFile);
 
-    const postFileMock = vi.spyOn(odeServices.http(), 'postFile').mockResolvedValue(undefined);
+    const postFileMock = vi
+      .spyOn(odeServices.http(), 'postFile')
+      .mockResolvedValue(undefined);
 
     const response = await attachmentService.attach(messageId, uploadedFile);
 
-    expect(postFileMock).toHaveBeenCalledWith(`${baseUrl}/message/${messageId}/attachment`, uploadedFile);
+    expect(postFileMock).toHaveBeenCalledWith(
+      `${baseUrl}/message/${messageId}/attachment`,
+      formData,
+    );
     expect(response).toBeUndefined();
 
     postFileMock.mockRestore();
+  });
+
+  test('makes a DELETE request to detach an attachment from a draft message', async () => {
+    const messageId = 'f43d3783';
+    const attachmentId = 'ababab';
+
+    const deleteFileMock = vi
+      .spyOn(odeServices.http(), 'delete')
+      .mockResolvedValue(undefined);
+
+    await attachmentService.detach(messageId, attachmentId);
+
+    expect(deleteFileMock).toHaveBeenCalledWith(
+      `${baseUrl}/message/${messageId}/attachment/${attachmentId}`,
+    );
+
+    deleteFileMock.mockRestore();
   });
 });

--- a/conversation/frontend/src/services/api/attachmentService.test.ts
+++ b/conversation/frontend/src/services/api/attachmentService.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest';
+import { baseUrl, attachmentService } from '.';
+import { odeServices } from 'edifice-ts-client';
+
+describe('Conversation Attachment Mutation Methods', () => {
+  test('makes a POST request to attach a file or blob to a message', async () => {
+    const messageId = 'f43d3783';
+    const uploadedFile = new File(["Le sage ne dit pas ce qu'il sait, le sot ne sait pas ce qu'il dit."], "Koan.txt", {
+      type: "text/plain",
+    });
+
+    const postFileMock = vi.spyOn(odeServices.http(), 'postFile').mockResolvedValue(undefined);
+
+    const response = await attachmentService.attach(messageId, uploadedFile);
+
+    expect(postFileMock).toHaveBeenCalledWith(`${baseUrl}/message/${messageId}/attachment`, uploadedFile);
+    expect(response).toBeUndefined();
+
+    postFileMock.mockRestore();
+  });
+});

--- a/conversation/frontend/src/services/api/attachmentService.ts
+++ b/conversation/frontend/src/services/api/attachmentService.ts
@@ -7,11 +7,18 @@ import { odeServices } from 'edifice-ts-client';
  * @returns A service to interact with folders.
  */
 export const createAttachmentService = (baseURL: string) => ({
+  attach(messageId: string, payload: File | Blob) {
+    const formData = new FormData();
+    formData.append('file', payload);
+    return odeServices.http().postFile<{
+      id: string;
+    }>(`${baseURL}/message/${messageId}/attachment`, formData);
+  },
 
-    attach(messageId: string, payload: File | Blob) {
-        return odeServices
-            .http()
-            .postFile<{ id: string }>(`${baseURL}/message/${messageId}/attachment`, payload);
-    },
-
+  detach(messageId: string, attachmentId: string) {
+    return odeServices.http().delete<{
+      fileId: string;
+      fileSize: number;
+    }>(`${baseURL}/message/${messageId}/attachment/${attachmentId}`);
+  },
 });

--- a/conversation/frontend/src/services/api/attachmentService.ts
+++ b/conversation/frontend/src/services/api/attachmentService.ts
@@ -1,0 +1,17 @@
+import { odeServices } from 'edifice-ts-client';
+
+/**
+ * Creates a message attachment service with the specified base URL.
+ *
+ * @param baseURL The base URL for the folder service API.
+ * @returns A service to interact with folders.
+ */
+export const createAttachmentService = (baseURL: string) => ({
+
+    attach(messageId: string, payload: File | Blob) {
+        return odeServices
+            .http()
+            .postFile<{ id: string }>(`${baseURL}/message/${messageId}/attachment`, payload);
+    },
+
+});

--- a/conversation/frontend/src/services/api/attachmentService.ts
+++ b/conversation/frontend/src/services/api/attachmentService.ts
@@ -7,7 +7,12 @@ import { odeServices } from 'edifice-ts-client';
  * @returns A service to interact with folders.
  */
 export const createAttachmentService = (baseURL: string) => ({
-  attach(messageId: string, payload: File | Blob) {
+  attach(
+    messageId: string,
+    payload: File | Blob,
+  ): Promise<{
+    id: string;
+  }> {
     const formData = new FormData();
     formData.append('file', payload);
     return odeServices.http().postFile<{
@@ -15,7 +20,13 @@ export const createAttachmentService = (baseURL: string) => ({
     }>(`${baseURL}/message/${messageId}/attachment`, formData);
   },
 
-  detach(messageId: string, attachmentId: string) {
+  detach(
+    messageId: string,
+    attachmentId: string,
+  ): Promise<{
+    fileId: string;
+    fileSize: number;
+  }> {
     return odeServices.http().delete<{
       fileId: string;
       fileSize: number;

--- a/conversation/frontend/src/services/api/index.ts
+++ b/conversation/frontend/src/services/api/index.ts
@@ -1,6 +1,8 @@
 import { createFolderService } from './folderService';
 import { createMessageService } from './messageService';
+import { createAttachmentService } from './attachmentService';
 
 export const baseUrl = '/conversation';
 export const folderService = createFolderService(baseUrl);
 export const messageService = createMessageService(baseUrl);
+export const attachmentService = createAttachmentService(baseUrl);

--- a/conversation/frontend/src/services/api/messageService.test.ts
+++ b/conversation/frontend/src/services/api/messageService.test.ts
@@ -50,7 +50,7 @@ describe('Conversation Message Mutation Methods', () => {
       body: 'New content',
     });
 
-    expect(response).toBe('');
+    expect(response).toBeUndefined();
   });
 
   test('makes a POST request to send a draft message', async () => {

--- a/conversation/frontend/src/services/api/messageService.ts
+++ b/conversation/frontend/src/services/api/messageService.ts
@@ -138,6 +138,6 @@ export const createMessageService = (baseURL: string) => ({
       cci?: string[];
     },
   ) {
-    return odeServices.http().put(`${baseURL}/draft/${draftId}`, payload);
+    return putThenVoid(`${baseURL}/draft/${draftId}`, payload);
   },
 });

--- a/conversation/frontend/src/services/queries/attachment.ts
+++ b/conversation/frontend/src/services/queries/attachment.ts
@@ -29,3 +29,33 @@ export const useAttachFiles = () => {
     },
   });
 };
+
+/**
+ * Hook to remove a File from a draft message.
+ * @returns Mutation result for removing the File.
+ */
+export const useRemoveFile = () => {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  return useMutation({
+    mutationFn: ({
+      draftId,
+      attachmentId,
+    }: {
+      draftId: string;
+      attachmentId: string;
+    }) => attachmentService.detach(draftId, attachmentId),
+    onSuccess(_ids, { draftId }) {
+      queryClient.invalidateQueries({
+        queryKey: messageQueryOptions.getById(draftId).queryKey,
+      });
+    },
+    onError(error, { draftId }) {
+      queryClient.invalidateQueries({
+        queryKey: messageQueryOptions.getById(draftId).queryKey,
+      });
+      toast.error(error.message);
+    },
+  });
+};

--- a/conversation/frontend/src/services/queries/attachment.ts
+++ b/conversation/frontend/src/services/queries/attachment.ts
@@ -31,10 +31,10 @@ export const useAttachFiles = () => {
 };
 
 /**
- * Hook to remove a File from a draft message.
+ * Hook to remove an attachment from a draft message.
  * @returns Mutation result for removing the File.
  */
-export const useRemoveFile = () => {
+export const useDetachFile = () => {
   const queryClient = useQueryClient();
   const toast = useToast();
 

--- a/conversation/frontend/src/services/queries/message.ts
+++ b/conversation/frontend/src/services/queries/message.ts
@@ -314,6 +314,11 @@ export const useMoveMessage = () => {
   });
 };
 
+/**
+ * Hook that generates a function to create a new, or update an existing, draft message.
+ * When the draft message is created, the function will return its id.
+ * @returns
+ */
 export const useCreateOrUpdateDraft = () => {
   const updateDraft = useUpdateDraft();
   const createDraft = useCreateDraft();
@@ -340,18 +345,12 @@ export const useCreateOrUpdateDraft = () => {
     };
 
     if (messageUpdated.id && messageUpdated.state === 'DRAFT') {
-      return updateDraft.mutate({
+      updateDraft.mutateAsync({
         draftId: messageUpdated.id,
         payload,
       });
     } else {
-      return createDraft.mutate(
-        { payload },
-        {
-          onSuccess: ({ id }) =>
-            window.history.replaceState(null, '', `/draft/message/${id}`),
-        },
-      );
+      return createDraft.mutateAsync({ payload });
     }
   };
 };

--- a/conversation/frontend/src/services/queries/message.ts
+++ b/conversation/frontend/src/services/queries/message.ts
@@ -11,10 +11,11 @@ import { useParams, useSearchParams } from 'react-router-dom';
 import { Message, MessageBase, MessageMetadata } from '~/models';
 import { useAppActions, useMessageUpdated } from '~/store';
 import {
+  baseUrl,
   folderQueryOptions,
   messageService,
   useUpdateFolderBadgeCountLocal,
-} from '..';
+} from '~/services';
 const appCodeName = 'conversation';
 /**
  * Message Query Options Factory.
@@ -316,8 +317,8 @@ export const useMoveMessage = () => {
 
 /**
  * Hook that generates a function to create a new, or update an existing, draft message.
- * When the draft message is created, the function will return its id.
- * @returns
+ * When the draft message is created, the function will return a Promise of its id.
+ * @returns undefined, or a Promise of the id af a newly created draft
  */
 export const useCreateOrUpdateDraft = () => {
   const updateDraft = useUpdateDraft();
@@ -350,7 +351,17 @@ export const useCreateOrUpdateDraft = () => {
         payload,
       });
     } else {
-      return createDraft.mutateAsync({ payload });
+      return createDraft.mutateAsync(
+        { payload },
+        {
+          onSuccess: ({ id }) =>
+            window.history.replaceState(
+              null,
+              '',
+              `${baseUrl}/draft/message/${id}`,
+            ),
+        },
+      );
     }
   };
 };


### PR DESCRIPTION
# Description

Ajout ou suppression de pièces jointes dans un message en brouillon.

J'ai modifié le hook useCreateOrUpdateDraft, et ai eu un conflit lors de l'ouverture de cette PR.
=> bien vérifier si la navigation vous parait correcte.

## Fixes

[WB-3925](https://edifice-community.atlassian.net/browse/WB-3925)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [X] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

* Test que l'URL adéquate est appelée par le service d'ajout de PJs. 

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley:

[WB-3925]: https://edifice-community.atlassian.net/browse/WB-3925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ