### PR TITLE
fix(conversation): #WB-3964, improved regex for the endpoint renderin…

### DIFF
--- a/conversation/backend/src/main/java/org/entcore/conversation/controllers/ConversationController.java
+++ b/conversation/backend/src/main/java/org/entcore/conversation/controllers/ConversationController.java
@@ -97,7 +97,7 @@ public class ConversationController extends BaseController {
 
 	private final static String QUOTA_BUS_ADDRESS = "org.entcore.workspace.quota";
 
-	private Storage storage;
+	private final Storage storage;
 	private int threshold;
 
 	private ConversationService conversationService;
@@ -139,13 +139,29 @@ public class ConversationController extends BaseController {
 		eventHelper.onAccess(request);
 	}
 
-	@Get(value = "(?:[/]?(?:conversation|inbox|outbox|draft|trash))?", regex = true)
+	/**
+	 * Main frontend rendering endpoint.
+	 * Secured by a dedicated access right named `org.entcore.conversation.controllers.ConversationController|view`
+	 * 
+	 * Example of valid URLs that should render the frontend HTML :
+	 * 	/conversation  (does not seem supported by the framework)
+	 *  /conversation/
+	 *  /conversation/inbox  (or outbox, draft or trash)
+	 *  /conversation/outbox/message/:messageId   (or inbox, draft or trash)
+	 *  /conversation/draft/create
+	 * @param request
+	 */
+	@Get(value = "(?:/?(?:conversation|(?:inbox|outbox|draft|trash){1}(?:/message/[^/\\\\s]+$)?)|draft/create$)?", regex = true)
 	@SecuredAction("conversation.view")
 	@Cache(value = "/conversation/count/INBOX", useQueryParams = true, scope = CacheScope.USER, operation = CacheOperation.INVALIDATE)
 	public void view(HttpServerRequest request) {
 		renderViewWeb(request);
 	}
 
+	/**
+	 * Another frontend rendering endpoint.
+	 * Secured by a dedicated resource filter.
+	 */
 	@Get("folder/:folderId")
 	@SecuredAction(value = "", type = ActionType.RESOURCE)
 	@ResourceFilter(SystemOrUserFolderFilter.class)
@@ -153,6 +169,10 @@ public class ConversationController extends BaseController {
 		renderViewWeb(request);
 	}
 
+	/**
+	 * Another frontend rendering endpoint.
+	 * Secured by a dedicated resource filter.
+	 */
 	@Get("folder/:folderId/message/:messageId")
 	@SecuredAction(value = "", type = ActionType.RESOURCE)
 	@ResourceFilter(SystemOrUserFolderFilter.class)


### PR DESCRIPTION
…g the app's HTML

# Description

The initial regex was not accepting some URLs like `/conversation/inbox/message/:messageId`  or `/conversation/draft/create` 

## Fixes

[WB-3964](https://edifice-community.atlassian.net/browse/WB-3964)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [X] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Local validation

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley: