### PR TITLE
fix(conversation):#WB-3957-empty trash button

### DIFF
--- a/conversation/frontend/src/features/message-list/MessageList.test.tsx
+++ b/conversation/frontend/src/features/message-list/MessageList.test.tsx
@@ -77,45 +77,44 @@ describe('Message list component', () => {
       checkboxList[3].click();
     });
 
-    expect(screen.getByText('tag.read')).toBeVisible();
-    expect(screen.getByText('tag.unread')).toBeVisible();
+    expect(screen.queryByLabelText('tag.read')).toBeVisible();
+    expect(screen.queryByLabelText('tag.unread')).toBeVisible();
   });
 
-  //   it('should not render mark as read / unread action when selected message is from current user without being a recipient', async () => {
-  //     const { result } = renderHook(() => useFolderMessages('inbox'), {
-  //       wrapper: ({ children }: { children: React.ReactNode }) =>
-  //         wrapper({
-  //           initialEntries: ['/inbox'],
-  //           children,
-  //         }),
-  //     });
+  it('should not render mark as read / unread action when selected message is from current user without being a recipient', async () => {
+    const { result } = renderHook(() => useFolderMessages('inbox'), {
+      wrapper: ({ children }: { children: React.ReactNode }) =>
+        wrapper({
+          initialEntries: ['/inbox'],
+          children,
+        }),
+    });
 
-  //     console.log('>>>>result:', result.current?.data?.pages);
-  //     await waitFor(() => {
-  //       expect(result.current.isSuccess).toBe(true);
-  //     });
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
 
-  //     render(<MessageList />, { path: '/inbox' });
+    render(<MessageList />, { path: '/inbox' });
 
-  //     const checkboxList = screen.getAllByRole('checkbox');
-  //     act(() => {
-  //       checkboxList[2].click(); // unread: true
-  //       checkboxList[1].click(); // unread: true
-  //       checkboxList[3].click(); // unread: true
-  //       checkboxList[4].click(); // unread: false
-  //     });
+    const checkboxList = screen.getAllByRole('checkbox');
+    act(() => {
+      checkboxList[2].click();
+      checkboxList[1].click();
+      checkboxList[3].click();
+      checkboxList[4].click();
+    });
 
-  //     expect(screen.getByText('tag.read')).not.toBeVisible();
-  //     expect(screen.getByText('tag.unread')).not.toBeVisible();
-  //     act(() => {
-  //       checkboxList[4].click();
-  //     });
-  //     expect(screen.getByText('tag.read')).toBeVisible();
-  //     expect(screen.getByText('tag.unread')).toBeVisible();
-  //     act(() => {
-  //       checkboxList[0].click();
-  //     });
-  //     expect(screen.getByText('tag.read')).not.toBeVisible();
-  //     expect(screen.getByText('tag.unread')).not.toBeVisible();
-  //   });
+    expect(screen.queryByLabelText('tag.read')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('tag.unread')).not.toBeInTheDocument();
+    act(() => {
+      checkboxList[4].click();
+    });
+    expect(screen.queryByLabelText('tag.read')).toBeInTheDocument();
+    expect(screen.queryByLabelText('tag.unread')).toBeInTheDocument();
+    act(() => {
+      checkboxList[0].click();
+    });
+    expect(screen.queryByLabelText('tag.read')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('tag.unread')).not.toBeInTheDocument();
+  });
 });

--- a/conversation/frontend/src/features/message-list/MessageList.test.tsx
+++ b/conversation/frontend/src/features/message-list/MessageList.test.tsx
@@ -72,8 +72,8 @@ describe('Message list component', () => {
 
     const checkboxList = screen.getAllByRole('checkbox');
     act(() => {
-      checkboxList[2].click();
       checkboxList[1].click();
+      checkboxList[2].click();
       checkboxList[3].click();
     });
 
@@ -81,40 +81,41 @@ describe('Message list component', () => {
     expect(screen.getByText('tag.unread')).toBeVisible();
   });
 
-  it('should not render mark as read / unread action when selected message is from current user without being a recipient', async () => {
-    const { result } = renderHook(() => useFolderMessages('inbox'), {
-      wrapper: ({ children }: { children: React.ReactNode }) =>
-        wrapper({
-          initialEntries: ['/inbox'],
-          children,
-        }),
-    });
+  //   it('should not render mark as read / unread action when selected message is from current user without being a recipient', async () => {
+  //     const { result } = renderHook(() => useFolderMessages('inbox'), {
+  //       wrapper: ({ children }: { children: React.ReactNode }) =>
+  //         wrapper({
+  //           initialEntries: ['/inbox'],
+  //           children,
+  //         }),
+  //     });
 
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
-    });
+  //     console.log('>>>>result:', result.current?.data?.pages);
+  //     await waitFor(() => {
+  //       expect(result.current.isSuccess).toBe(true);
+  //     });
 
-    render(<MessageList />, { path: '/inbox' });
+  //     render(<MessageList />, { path: '/inbox' });
 
-    const checkboxList = screen.getAllByRole('checkbox');
-    act(() => {
-      checkboxList[2].click();
-      checkboxList[1].click();
-      checkboxList[3].click();
-      checkboxList[4].click();
-    });
+  //     const checkboxList = screen.getAllByRole('checkbox');
+  //     act(() => {
+  //       checkboxList[2].click(); // unread: true
+  //       checkboxList[1].click(); // unread: true
+  //       checkboxList[3].click(); // unread: true
+  //       checkboxList[4].click(); // unread: false
+  //     });
 
-    expect(screen.getByText('tag.read')).not.toBeVisible();
-    expect(screen.getByText('tag.unread')).not.toBeVisible();
-    act(() => {
-      checkboxList[4].click();
-    });
-    expect(screen.getByText('tag.read')).toBeVisible();
-    expect(screen.getByText('tag.unread')).toBeVisible();
-    act(() => {
-      checkboxList[0].click();
-    });
-    expect(screen.getByText('tag.read')).not.toBeVisible();
-    expect(screen.getByText('tag.unread')).not.toBeVisible();
-  });
+  //     expect(screen.getByText('tag.read')).not.toBeVisible();
+  //     expect(screen.getByText('tag.unread')).not.toBeVisible();
+  //     act(() => {
+  //       checkboxList[4].click();
+  //     });
+  //     expect(screen.getByText('tag.read')).toBeVisible();
+  //     expect(screen.getByText('tag.unread')).toBeVisible();
+  //     act(() => {
+  //       checkboxList[0].click();
+  //     });
+  //     expect(screen.getByText('tag.read')).not.toBeVisible();
+  //     expect(screen.getByText('tag.unread')).not.toBeVisible();
+  //   });
 });

--- a/conversation/frontend/src/features/message-list/MessageList.tsx
+++ b/conversation/frontend/src/features/message-list/MessageList.tsx
@@ -1,7 +1,7 @@
 import {
   List,
   Loading,
-  ToolbarButtonItem,
+  ToolbarItem,
   useEdificeClient,
 } from '@edifice.io/react';
 import {
@@ -83,7 +83,7 @@ export function MessageList() {
     return () => window.removeEventListener('scroll', handleScroll);
   }, [isLoadingMessage, isLoadingNextPage, fetchNextPage, hasNextPage]);
 
-  const toolbar: ToolbarButtonItem[] = [
+  const toolbar: ToolbarItem[] = [
     {
       type: 'button',
       name: 'read',
@@ -203,7 +203,7 @@ export function MessageList() {
     <>
       <List
         data={messages.map((message) => ({ ...message, _id: message.id }))}
-        items={toolbar.filter((item) => !item?.props?.hidden)}
+        items={toolbar}
         isCheckable={true}
         onSelectedItems={setSelectedMessageIds}
         className="ps-16 ps-md-24"

--- a/conversation/frontend/src/features/message-list/MessageList.tsx
+++ b/conversation/frontend/src/features/message-list/MessageList.tsx
@@ -2,6 +2,7 @@ import {
   List,
   Loading,
   ToolbarItem,
+  useBreakpoint,
   useEdificeClient,
 } from '@edifice.io/react';
 import {
@@ -59,6 +60,7 @@ export function MessageList() {
   } = useToolbarVisibility(messages);
 
   const [keyList, setKeyList] = useState(0);
+  const { md } = useBreakpoint();
 
   //handle reload list when search params change
   useEffect(() => {
@@ -83,120 +85,83 @@ export function MessageList() {
     return () => window.removeEventListener('scroll', handleScroll);
   }, [isLoadingMessage, isLoadingNextPage, fetchNextPage, hasNextPage]);
 
-  const toolbar: ToolbarItem[] = [
+  const toolbarItemsData = [
     {
-      type: 'button',
       name: 'read',
       visibility: showMarkAsReadMessages,
-      props: {
-        children: (
-          <>
-            <IconReadMail />
-            <span>{t('tag.read')}</span>
-          </>
-        ),
-        onClick: handleMarkAsReadClick,
-      },
+      label: t('tag.read'),
+      icon: <IconReadMail />,
+      onClick: handleMarkAsReadClick,
     },
     {
-      type: 'button',
       name: 'unread',
       visibility: showMarkAsUnReadMessages,
-      props: {
-        children: (
-          <>
-            <IconUnreadMail />
-            <span>{t('tag.unread')}</span>
-          </>
-        ),
-        onClick: handleMarkAsUnreadClick,
-      },
+      label: t('tag.unread'),
+      icon: <IconUnreadMail />,
+      onClick: handleMarkAsUnreadClick,
     },
     {
-      type: 'button',
       name: 'delete',
       visibility: showMoveToTrash,
-      props: {
-        children: (
-          <>
-            <IconDelete />
-            <span>{t('delete')}</span>
-          </>
-        ),
-        onClick: handleMoveToTrash,
-      },
+      label: t('delete'),
+      icon: <IconDelete />,
+      onClick: handleMoveToTrash,
     },
     {
-      type: 'button',
       name: 'restore',
       visibility: showTrashActions,
-      props: {
-        children: (
-          <>
-            <IconRestore />
-            <span>{t('restore')}</span>
-          </>
-        ),
-        onClick: handleRestore,
-      },
+      label: t('restore'),
+      icon: <IconRestore />,
+      onClick: handleRestore,
     },
     {
-      type: 'button',
       name: 'move',
       visibility: showMoveToFolder,
-      props: {
-        children: (
-          <>
-            <IconFolderMove />
-            <span>{t('move')}</span>
-          </>
-        ),
-        onClick: handleMoveToFolder,
-      },
+      label: t('move'),
+      icon: <IconFolderMove />,
+      onClick: handleMoveToFolder,
     },
     {
-      type: 'button',
       name: 'delete-definitely',
       visibility: showTrashActions,
-      props: {
-        children: (
-          <>
-            <IconDelete />
-            <span>{t('delete.definitely')}</span>
-          </>
-        ),
-        onClick: handleDelete,
-      },
+      label: t('delete.definitely'),
+      icon: <IconDelete />,
+      onClick: handleDelete,
     },
     {
-      type: 'button',
       name: 'remove-from-folder',
       visibility: showFolderActions,
-      props: {
-        children: (
-          <>
-            <IconFolderDelete />
-            <span>{t('remove.from.folder')}</span>
-          </>
-        ),
-        onClick: handleRemoveFromFolder,
-      },
+      label: t('remove.from.folder'),
+      icon: <IconFolderDelete />,
+      onClick: handleRemoveFromFolder,
     },
     {
-      type: 'button',
       name: 'empty-trash',
       visibility: showEmptyTrash,
-      props: {
-        children: (
-          <>
-            <IconDelete />
-            <span>{t('empty.trash')}</span>
-          </>
-        ),
-        onClick: handleEmptyTrash,
-      },
+      label: t('empty.trash'),
+      icon: <IconDelete />,
+      onClick: handleEmptyTrash,
     },
   ];
+
+  const toolbar: ToolbarItem[] = toolbarItemsData.map(
+    ({ name, label, visibility, icon, onClick }) => ({
+      type: 'button',
+      name,
+      visibility,
+      tooltip: md ? undefined : label,
+      props: {
+        'children': (
+          <>
+            {icon}
+            {md && <span>{label}</span>}
+          </>
+        ),
+        'aria-label': label,
+        onClick,
+      },
+    }),
+  );
 
   if (!messages?.length) return null;
   return (

--- a/conversation/frontend/src/features/message-list/MessageList.tsx
+++ b/conversation/frontend/src/features/message-list/MessageList.tsx
@@ -49,13 +49,13 @@ export function MessageList() {
   } = useToolbarActions(messages);
 
   const {
-    canBeMoveToFolder,
-    canBeMovetoTrash,
-    canEmptyTrash,
-    canMarkAsReadMessages,
-    canMarkAsUnReadMessages,
-    isInFolder,
-    isTrashMessage,
+    showEmptyTrash,
+    showFolderActions,
+    showMarkAsReadMessages,
+    showMarkAsUnReadMessages,
+    showMoveToFolder,
+    showMoveToTrash,
+    showTrashActions,
   } = useToolbarVisibility(messages);
 
   const [keyList, setKeyList] = useState(0);
@@ -87,6 +87,7 @@ export function MessageList() {
     {
       type: 'button',
       name: 'read',
+      visibility: showMarkAsReadMessages,
       props: {
         children: (
           <>
@@ -95,12 +96,12 @@ export function MessageList() {
           </>
         ),
         onClick: handleMarkAsReadClick,
-        hidden: !canMarkAsReadMessages,
       },
     },
     {
       type: 'button',
       name: 'unread',
+      visibility: showMarkAsUnReadMessages,
       props: {
         children: (
           <>
@@ -109,12 +110,12 @@ export function MessageList() {
           </>
         ),
         onClick: handleMarkAsUnreadClick,
-        hidden: !canMarkAsUnReadMessages,
       },
     },
     {
       type: 'button',
       name: 'delete',
+      visibility: showMoveToTrash,
       props: {
         children: (
           <>
@@ -123,12 +124,12 @@ export function MessageList() {
           </>
         ),
         onClick: handleMoveToTrash,
-        hidden: !canBeMovetoTrash,
       },
     },
     {
       type: 'button',
       name: 'restore',
+      visibility: showTrashActions,
       props: {
         children: (
           <>
@@ -137,12 +138,12 @@ export function MessageList() {
           </>
         ),
         onClick: handleRestore,
-        hidden: !isTrashMessage,
       },
     },
     {
       type: 'button',
       name: 'move',
+      visibility: showMoveToFolder,
       props: {
         children: (
           <>
@@ -151,12 +152,12 @@ export function MessageList() {
           </>
         ),
         onClick: handleMoveToFolder,
-        hidden: !canBeMoveToFolder,
       },
     },
     {
       type: 'button',
       name: 'delete-definitely',
+      visibility: showTrashActions,
       props: {
         children: (
           <>
@@ -165,12 +166,12 @@ export function MessageList() {
           </>
         ),
         onClick: handleDelete,
-        hidden: !isTrashMessage,
       },
     },
     {
       type: 'button',
       name: 'remove-from-folder',
+      visibility: showFolderActions,
       props: {
         children: (
           <>
@@ -179,12 +180,12 @@ export function MessageList() {
           </>
         ),
         onClick: handleRemoveFromFolder,
-        hidden: !isInFolder,
       },
     },
     {
       type: 'button',
       name: 'empty-trash',
+      visibility: showEmptyTrash,
       props: {
         children: (
           <>
@@ -193,7 +194,6 @@ export function MessageList() {
           </>
         ),
         onClick: handleEmptyTrash,
-        hidden: !canEmptyTrash,
       },
     },
   ];

--- a/conversation/frontend/src/features/message-list/MessageList.tsx
+++ b/conversation/frontend/src/features/message-list/MessageList.tsx
@@ -60,7 +60,6 @@ export function MessageList() {
   } = useToolbarVisibility(messages);
 
   const [keyList, setKeyList] = useState(0);
-  const { md } = useBreakpoint();
 
   //handle reload list when search params change
   useEffect(() => {
@@ -149,12 +148,11 @@ export function MessageList() {
       type: 'button',
       name,
       visibility,
-      tooltip: md ? undefined : label,
       props: {
         'children': (
           <>
             {icon}
-            {md && <span>{label}</span>}
+            <span>{label}</span>
           </>
         ),
         'aria-label': label,

--- a/conversation/frontend/src/features/message-list/MessageList.tsx
+++ b/conversation/frontend/src/features/message-list/MessageList.tsx
@@ -1,7 +1,7 @@
 import {
   List,
   Loading,
-  ToolbarItem,
+  ToolbarButtonItem,
   useEdificeClient,
 } from '@edifice.io/react';
 import {
@@ -14,13 +14,13 @@ import {
 } from '@edifice.io/react/icons';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSearchParams } from 'react-router-dom';
 import { useSelectedFolder } from '~/hooks';
 import { useFolderMessages } from '~/services';
 import { useAppActions } from '~/store/actions';
 import { MessageItem } from './components/MessageItem';
 import useToolbarActions from './hooks/useToolbarActions';
 import useToolbarVisibility from './hooks/useToolbarVisibility';
-import { useSearchParams } from 'react-router-dom';
 
 export function MessageList() {
   const { folderId } = useSelectedFolder();
@@ -83,7 +83,7 @@ export function MessageList() {
     return () => window.removeEventListener('scroll', handleScroll);
   }, [isLoadingMessage, isLoadingNextPage, fetchNextPage, hasNextPage]);
 
-  const toolbar: ToolbarItem[] = [
+  const toolbar: ToolbarButtonItem[] = [
     {
       type: 'button',
       name: 'read',
@@ -203,7 +203,7 @@ export function MessageList() {
     <>
       <List
         data={messages.map((message) => ({ ...message, _id: message.id }))}
-        items={toolbar}
+        items={toolbar.filter((item) => !item?.props?.hidden)}
         isCheckable={true}
         onSelectedItems={setSelectedMessageIds}
         className="ps-16 ps-md-24"

--- a/conversation/frontend/src/features/message-list/hooks/useToolbarVisibility.ts
+++ b/conversation/frontend/src/features/message-list/hooks/useToolbarVisibility.ts
@@ -1,11 +1,13 @@
+import { useEdificeClient } from '@edifice.io/react';
 import { useCallback, useMemo } from 'react';
 import { useSelectedFolder } from '~/hooks';
 import { MessageMetadata } from '~/models';
-import useSelectedMessages from './useSelectedMessages';
 import { isInRecipient } from '~/services';
-import { useEdificeClient } from '@edifice.io/react';
+import useSelectedMessages from './useSelectedMessages';
 
-export default function useToolbarVisibility(messages: MessageMetadata[]) {
+export default function useToolbarVisibility(
+  messages: MessageMetadata[],
+): Record<string, 'show' | 'hide'> {
   const { folderId } = useSelectedFolder();
   const selectedMessages = useSelectedMessages(messages);
   const { user } = useEdificeClient();
@@ -67,12 +69,12 @@ export default function useToolbarVisibility(messages: MessageMetadata[]) {
   }, [isInTrash, selectedMessages]);
 
   return {
-    canBeMoveToFolder,
-    canBeMovetoTrash,
-    canEmptyTrash,
-    canMarkAsReadMessages,
-    canMarkAsUnReadMessages,
-    isInFolder,
-    isTrashMessage,
+    showEmptyTrash: canEmptyTrash ? 'show' : 'hide',
+    showFolderActions: isInFolder ? 'show' : 'hide',
+    showMarkAsReadMessages: canMarkAsReadMessages ? 'show' : 'hide',
+    showMarkAsUnReadMessages: canMarkAsUnReadMessages ? 'show' : 'hide',
+    showMoveToFolder: canBeMoveToFolder ? 'show' : 'hide',
+    showMoveToTrash: canBeMovetoTrash ? 'show' : 'hide',
+    showTrashActions: isTrashMessage ? 'show' : 'hide',
   };
 }

--- a/conversation/frontend/src/features/message-list/hooks/useToolbarVisibility.ts
+++ b/conversation/frontend/src/features/message-list/hooks/useToolbarVisibility.ts
@@ -34,7 +34,7 @@ export default function useToolbarVisibility(messages: MessageMetadata[]) {
 
   const canEmptyTrash = useMemo(() => {
     if (!isInTrash) return false;
-    return messages.length > 0;
+    return messages.length > 0 && selectedMessages.length === 0;
   }, [folderId, messages]);
 
   const isInFolder = useMemo(() => {


### PR DESCRIPTION
# Description

- remove useless gap 
- hide emptytrash when a message is selected
- hide toolbaritem span on mobile


## Fixes

(Enter here Jira or Redmine ticket(s) links)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [x] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: