### PR TITLE
fix(common): #WB-3639, do not remove existing shares from users and groups that a share updater cannot see

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,3 +28,18 @@ services:
       - ../recette:/home/node/recette # TODO : rendre générique pour appliquer à tous les springboards
     environment:
       - NG_CLI_ANALYTICS=false
+
+  k6:
+    image: grafana/k6:master
+    volumes:
+      - ./tests/src/test/js:/home/k6/src
+      - ./tests/src/test/resources/data:/home/k6/data
+    environment:
+      ROOT_URL: http://172.17.0.1:8090
+      DATA_ROOT_PATH: /home/k6/data
+      DURATION: 61s
+      VUS: 100
+      ADMC_LOGIN: tom.mate
+      ADMC_PASSWORD: password
+      DEFAULT_PASSWORD: password
+      RECREATE_STRUCTURES: false # Set to 'true' if you want to run the tests on brand new structures


### PR DESCRIPTION
# Description

Faire en sorte de bien prendre en compte les partages existants mais sur lesquels l'utilisateur n'a pas de visiblité lors de la mise à jour des droits de partage.

## Fixes

WB-3639

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [x] tests
- [ ] timeline
- [ ] workspace

## Tests

Mise à jour du test d'inté `testSharesViaProfileGroupInDifferentSchools` qui correspond au cas problématique pour y ajouter la vérification que les partages existants persistent bien.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: