### PR TITLE
fix(common): #WB-3639, do not remove existing shares from users and groups that a share updater cannot see

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   maven:
     image: maven:3.8.6-jdk-8
+    user: "$DEFAULT_DOCKER_USER"
     working_dir: /usr/src/maven
     volumes:
       - ./:/usr/src/maven


### PR DESCRIPTION
# Description

Faire en sorte de bien prendre en compte les partages existants mais sur lesquels l'utilisateur n'a pas de visiblité lors de la mise à jour des droits de partage.

## Fixes

WB-3639

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [x] tests
- [ ] timeline
- [ ] workspace

## Tests

Mise à jour du test d'inté `testSharesViaProfileGroupInDifferentSchools` qui correspond au cas problématique pour y ajouter la vérification que les partages existants persistent bien.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: