### PR TITLE
Feat/pedago configurable oauth2 expiration

### DIFF
--- a/admin/src/main/ts/package.json
+++ b/admin/src/main/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin-app",
-  "version": "6.4-SNAPSHOT",
+  "version": "6.4-%branch%.%generateVersion%",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --host 0.0.0.0",

--- a/auth/src/main/java/org/entcore/auth/Auth.java
+++ b/auth/src/main/java/org/entcore/auth/Auth.java
@@ -89,7 +89,7 @@ public class Auth extends BaseServer {
 				openIdConnectService, checkFederatedLogin, config.getInteger("maxRetry", 5), config.getLong("banDelay", 900000L),
 				config.getString("password-event-min-date"), config.getInteger("password-event-sync-default-value", 0),
 				config.getJsonArray("oauth2-pw-client-enable-saml2"), eventStore,
-				config.getBoolean("otp-disabled", false));
+				config.getBoolean("otp-disabled", false), config.getInteger("oauth2-token-expiration-time-seconds", 3600));
 
 		AuthController authController = new AuthController();
 		authController.setEventStore(eventStore);

--- a/auth/src/main/java/org/entcore/auth/oauth/OAuthDataHandler.java
+++ b/auth/src/main/java/org/entcore/auth/oauth/OAuthDataHandler.java
@@ -89,12 +89,13 @@ public class OAuthDataHandler extends DataHandler implements OpenIdDataHandler {
 	private final SamlHelper samlHelper;
 	private final JwtVerifier jwtVerifier;
 	private final boolean otpDisabled;
+	private final int tokenExpirationTimeSeconds;
 
 	public OAuthDataHandler(Request request, Neo4j neo, MongoDb mongo, RedisClient redisClient,
 			OpenIdConnectService openIdConnectService, boolean checkFederatedLogin,
 			int pwMaxRetry, long pwBanDelay, String passwordEventMinDate, int defaultSyncValue,
 			JsonArray clientPWSupportSaml2, EventStore eventStore, SamlHelper samlHelper, JwtVerifier jwtVerifier,
-			final boolean otpDisabled) {
+			final boolean otpDisabled, int tokenExpirationTimeSeconds) {
 		super(request);
 		this.neo = neo;
 		this.mongo = mongo;
@@ -110,6 +111,7 @@ public class OAuthDataHandler extends DataHandler implements OpenIdDataHandler {
 		this.clientPWSupportSaml2 = clientPWSupportSaml2;
 		this.samlHelper = samlHelper;
 		this.jwtVerifier = jwtVerifier;
+		this.tokenExpirationTimeSeconds = tokenExpirationTimeSeconds;
 	}
 
 	@Override
@@ -482,7 +484,7 @@ public class OAuthDataHandler extends DataHandler implements OpenIdDataHandler {
 										.put("authId", authInfo.getId())
 										.put("token", UUID.randomUUID().toString())
 										.put("createdOn", MongoDb.now())
-										.put("expiresIn", 3600);
+										.put("expiresIn", tokenExpirationTimeSeconds);
 								if (openIdConnectService != null && authInfo.getScope() != null
 										&& authInfo.getScope().contains("openid")) {
 									// "2.0".equals(RequestUtils.getAcceptVersion(getRequest().getHeader("Accept"))))
@@ -522,7 +524,7 @@ public class OAuthDataHandler extends DataHandler implements OpenIdDataHandler {
 												t.setAuthId(authInfo.getId());
 												t.setToken(token.getString("token"));
 								t.setCreatedOn(MongoDb.parseIsoDate(token.getJsonObject("createdOn")));
-												t.setExpiresIn(3600);
+												t.setExpiresIn(tokenExpirationTimeSeconds);
 												if (token.containsKey("id_token")) {
 													t.setIdToken(token.getString("id_token"));
 												}

--- a/auth/src/main/java/org/entcore/auth/oauth/OAuthDataHandlerFactory.java
+++ b/auth/src/main/java/org/entcore/auth/oauth/OAuthDataHandlerFactory.java
@@ -49,11 +49,12 @@ public class OAuthDataHandlerFactory implements DataHandlerFactory {
 	private final boolean otpDisabled;
 	private SamlHelper samlHelper;
 	private JwtVerifier jwtVerifier;
+	private final int tokenExpirationTimeSeconds;
 
 	public OAuthDataHandlerFactory(
 			OpenIdConnectService openIdConnectService, boolean cfl, int pwMaxRetry, long pwBanDelay,
 			String passwordEventMinDate, int defaultSyncValue, JsonArray clientPWSupportSaml2, EventStore eventStore,
-			final boolean otpDisabled) {
+			final boolean otpDisabled, int tokenExpirationTimeSeconds) {
 		this.otpDisabled = otpDisabled;
 		this.neo = Neo4j.getInstance();
 		this.mongo = MongoDb.getInstance();
@@ -66,19 +67,20 @@ public class OAuthDataHandlerFactory implements DataHandlerFactory {
 		this.passwordEventMinDate = passwordEventMinDate;
 		this.defaultSyncValue = defaultSyncValue;
 		this.clientPWSupportSaml2 = clientPWSupportSaml2;
+		this.tokenExpirationTimeSeconds = tokenExpirationTimeSeconds;
 	}
 
 	@Override
 	public DataHandler create(Request request) {
 		return new OAuthDataHandler(request, neo, mongo, redisClient, openIdConnectService, checkFederatedLogin,
 				pwMaxRetry, pwBanDelay, passwordEventMinDate, defaultSyncValue, clientPWSupportSaml2, eventStore, samlHelper,
-				jwtVerifier, otpDisabled);
+				jwtVerifier, otpDisabled, tokenExpirationTimeSeconds);
 	}
 
 	public DataHandler create(JsonRequestAdapter request) {
 		return new OAuthDataHandler(request, neo, mongo, redisClient, openIdConnectService, checkFederatedLogin,
 				pwMaxRetry, pwBanDelay, passwordEventMinDate, defaultSyncValue, clientPWSupportSaml2, eventStore,
-				samlHelper, jwtVerifier, otpDisabled);
+				samlHelper, jwtVerifier, otpDisabled, tokenExpirationTimeSeconds);
 	}
 
 	public void setSamlHelper(SamlHelper samlHelper) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ent-core",
-  "version": "6.4-SNAPSHOTdev.1",
+  "version": "6.4-develop-pedago.0",
   "description": "",
   "main": "gulpfile.js",
   "directories": {
@@ -27,7 +27,7 @@
     "angular-sanitize": "1.8.3",
     "axios": "0.15.3",
     "core-js": "^2.4.1",
-    "entcore": "dev",
+    "entcore": "develop-pedago",
     "entcore-generic-icons": "https://github.com/edificeio/generic-icons.git",
     "entcore-toolkit": "^1.0.1",
     "humane-js": "^3.2.2",
@@ -75,8 +75,8 @@
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
     "merge2": "^1.0.3",
-    "ode-ngjs-front": "dev",
-    "ode-ts-client": "dev",
+    "ode-ngjs-front": "develop-pedago",
+    "ode-ts-client": "develop-pedago",
     "sass-loader": "^13.0.2",
     "source-map-loader": "^0.1.5",
     "ts-loader": "^3.1.1",

--- a/pom.xml
+++ b/pom.xml
@@ -56,13 +56,13 @@
     </modules>
 
     <properties>
-        <revision>6.4-SNAPSHOT</revision>
+        <revision>6.4-develop-pedago-SNAPSHOT</revision>
         <junitVersion>4.13.2</junitVersion>
         <testContainerVersion>1.19.3</testContainerVersion>
         <modPostgresVersion>2.0-SNAPSHOT</modPostgresVersion>
-        <modMongoVersion>4.0-SNAPSHOT</modMongoVersion>
+        <modMongoVersion>4.0-develop-pedago-SNAPSHOT</modMongoVersion>
         <webUtilsVersion>3.1-SNAPSHOT</webUtilsVersion>
-        <mongodbHelperVersion>3.0-SNAPSHOT</mongodbHelperVersion>
+        <mongodbHelperVersion>3.0-develop-pedago-SNAPSHOT</mongodbHelperVersion>
         <jodaTimeVersion>2.9.4</jodaTimeVersion>
         <scramVersion>2.1</scramVersion>
         <micrometerPrometheusVersion>1.11.4</micrometerPrometheusVersion>


### PR DESCRIPTION
# Description

The 3600 second expiration time of a new oAuth2 token is now configurable with the key 'oauth2-token-expiration-time-seconds'. The value si 3600 by default to make no regression if the conf value is not present.

This commit is for debug purpose on clients that manages oAuth2 tokens.

## Fixes

- No ticket

## Type of change

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [x] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Without define a value in conf for 'oauth2-token-expiration-time-seconds', no changes are expected.
When this value is defined, the 'expiresIn' value in response for `POST /auth/oauth2/token` has to be equal to the configured value.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: