### PR TITLE
fix(conversation): #WB-3441, feedback from free tests

### DIFF
--- a/conversation/frontend/src/components/SignatureEditor/components/SignatureEditor.tsx
+++ b/conversation/frontend/src/components/SignatureEditor/components/SignatureEditor.tsx
@@ -91,8 +91,6 @@ export const SignatureEditor = forwardRef(
 
     if (editor === null) return null;
 
-    const borderClass = 'border rounded-3';
-    const contentClass = 'py-12 px-16';
     const counterClass = clsx(
       'small p-2 text-end',
       length > maxLength ? 'text-danger' : 'text-gray-700',
@@ -100,9 +98,9 @@ export const SignatureEditor = forwardRef(
 
     return (
       <>
-        <div className={borderClass}>
+        <div className={'border rounded-3'}>
           <SignatureEditorToolbar editorId={id} editor={editor} />
-          <EditorContent id={id} editor={editor} className={contentClass} />
+          <EditorContent id={id} editor={editor} className={'py-12 px-16'} />
         </div>
         <p className={counterClass}>
           <i>{`${length} / ${maxLength}`}</i>

--- a/conversation/frontend/src/components/SignatureEditor/components/SignatureEditorToolbar/SignatureEditorToolbar.tsx
+++ b/conversation/frontend/src/components/SignatureEditor/components/SignatureEditorToolbar/SignatureEditorToolbar.tsx
@@ -30,7 +30,6 @@ export const SignatureEditorToolbar = ({ editorId, editor }: Props) => {
           'aria-label': common_t('tiptap.toolbar.bold'),
           'className': editor?.isActive('bold') ? 'is-selected' : '',
           'onClick': () => editor?.chain().focus().toggleBold().run(),
-          'disabled': editor?.isActive('heading'),
         },
         name: 'bold',
         visibility: showIf(hasMark('bold', editor)),
@@ -62,7 +61,8 @@ export const SignatureEditorToolbar = ({ editorId, editor }: Props) => {
         tooltip: common_t('tiptap.toolbar.removeFormat'),
       },
     ];
-  }, [common_t, editor]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editor.state]);
 
   return (
     <div className="sticky-top z-1 editor-toolbar rounded-3">

--- a/conversation/frontend/src/features/modals/SignatureModal.tsx
+++ b/conversation/frontend/src/features/modals/SignatureModal.tsx
@@ -1,4 +1,4 @@
-import { Button, Checkbox, Loading, Modal } from '@edifice.io/react';
+import { Button, Loading, Modal, Switch } from '@edifice.io/react';
 import { useI18n } from '~/hooks';
 import { useSignatureHandlers } from './hooks';
 import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
@@ -60,7 +60,7 @@ export function SignatureModal() {
 
       <Modal.Body>
         <Suspense fallback={<Loading isLoading={preferencesQuery.isPending} />}>
-          <Checkbox
+          <Switch
             label={t('signature.modal.toggle.label')}
             checked={useSignature}
             onChange={handleToggleChange}

--- a/conversation/frontend/src/features/modals/SignatureModal.tsx
+++ b/conversation/frontend/src/features/modals/SignatureModal.tsx
@@ -22,18 +22,19 @@ export function SignatureModal() {
   const [useSignature, setUseSignature] = useState(
     preferencesQuery.data?.useSignature ?? false,
   );
+  const [isLengthValid, setIsLengthValid] = useState(true);
 
   useEffect(() => {
     if (typeof preferencesQuery.data?.useSignature !== 'undefined')
       setUseSignature(preferencesQuery.data.useSignature);
   }, [preferencesQuery.data]);
 
-  const lockSaveButton = preferencesQuery.isPending || isSaving;
-  const lockEditor = lockSaveButton || !useSignature;
-
   function handleToggleChange() {
     setUseSignature((previousState) => !previousState);
   }
+
+  const lockSaveButton =
+    !isLengthValid || preferencesQuery.isPending || isSaving;
 
   const handleSaveClick = useCallback(() => {
     async function handleSave() {
@@ -72,8 +73,9 @@ export function SignatureModal() {
           <SignatureEditor
             ref={editor}
             content={preferencesQuery.data?.signature ?? ''}
-            mode={lockEditor ? 'read' : 'edit'}
+            mode={'edit'}
             placeholder={t('signature.modal.editor.placeholder')}
+            onLengthChange={setIsLengthValid}
           />
         </Suspense>
       </Modal.Body>


### PR DESCRIPTION
# Description

Derniers ajustements demandés : 

* Si la signature n’est pas activé, on doit pouvoir modifier la signature quand même 

* Quand j'écris du texte et que j’atteins le quota maximum de caractères disponible >
** le compteur de caractère qui doit devenir rouge pour indiquer l’erreur
** le bouton d’enregistrement doit être disable

* Quand je copie colle du texte et que j’atteins le quota maximum de caractères autorisé
** le texte copié est collé dans son entièreté
** le quota de la signature affiche le nombre de caractères utilisés / 800 caractères en rouge
** Le bouton de sauvegarde est disable

* Quand on clique sur gras ou italique, on doit avoir un surlignage sur ces icônes pour avertir le user que le mode graisse ou italique est activé

## Fixes

[WB-3441](https://edifice-community.atlassian.net/browse/WB-3441)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [X] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley:

[WB-3441]: https://edifice-community.atlassian.net/browse/WB-3441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ