### PR TITLE
feat(conversation): #WB-3776, new API allows listing of RECALLed messages

### DIFF
--- a/conversation/backend/src/main/java/org/entcore/conversation/service/ConversationService.java
+++ b/conversation/backend/src/main/java/org/entcore/conversation/service/ConversationService.java
@@ -21,6 +21,7 @@ package org.entcore.conversation.service;
 
 
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -94,8 +95,9 @@ public interface ConversationService {
 	 * @param page page number
 	 * @param page_size number of messages per page
 	 * @param searchWords optional text filter
+	 * @param states List messages having this state. Not applied when `folder` is either DRAFT or TRASH.
 	 */
-	void list(String folder, Boolean unread, UserInfos user, int page, int page_size, String searchWords, Handler<Either<String, JsonArray>> results);
+	void list(String folder, Boolean unread, UserInfos user, int page, int page_size, String searchWords, EnumSet<State> states, Handler<Either<String, JsonArray>> results);
 	/** Legacy */
 	void list(String folder, String restrain, Boolean unread, UserInfos user, int page, String searchWords, Handler<Either<String, JsonArray>> results);
 

--- a/conversation/backend/src/main/resources/i18n/fr.json
+++ b/conversation/backend/src/main/resources/i18n/fr.json
@@ -247,6 +247,7 @@
   "conversation.recall.ok": "Rappeler le message",
   "conversation.recall.mail": "Les destinataires ne pourront plus voir le contenu du message, mais ils verront que vous l'avez rappelé. Êtes-vous sûr de vouloir rappeler ce message ?",
   "conversation.recall.mail.subject": "Message rappelé",
+  "conversation.recall.mail.subject.details": "Ce message a été rappelé",
   "conversation.recall.mail.content": "L’expéditeur a rappelé ce message, son contenu n’est donc plus visible.",
   "conversation.success.recall.mail": "Message rappelé avec succès.",
   "conversation.error.recall.mail": "Le message n'a pas pu être rappelé.",

--- a/conversation/frontend/src/components/MessageBody.tsx
+++ b/conversation/frontend/src/components/MessageBody.tsx
@@ -1,4 +1,9 @@
-import { Alert, Button, EmptyScreen } from '@edifice.io/react';
+import {
+  Alert,
+  Button,
+  EmptyScreen,
+  useEdificeClient,
+} from '@edifice.io/react';
 import {
   ConversationHistoryNodeView,
   ConversationHistoryRenderer,
@@ -25,6 +30,7 @@ export function MessageBody({
   onMessageChange,
 }: MessageBodyProps) {
   const { t } = useI18n();
+  const { user } = useEdificeClient();
   const [content, setContent] = useState('');
   const extensions = [ConversationHistoryNodeView(ConversationHistoryRenderer)];
   const [isOriginalFormatOpen, setOriginalFormatOpen] = useState(false);
@@ -40,7 +46,7 @@ export function MessageBody({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return message.state === 'RECALL' ? (
+  return message.state === 'RECALL' && message.from.id !== user?.userId ? (
     <div className="d-flex flex-column gap-16 align-items-center justify-content-center">
       <EmptyScreen
         imageSrc={illuRecall}

--- a/conversation/frontend/src/features/message/message-header/index.tsx
+++ b/conversation/frontend/src/features/message/message-header/index.tsx
@@ -18,7 +18,11 @@ export function MessageHeader({ message }: MessageHeaderProps) {
     <header>
       {message && (
         <>
-          <h4>{subject}</h4>
+          <h4>
+            {message.state === 'RECALL'
+              ? t('conversation.recall.mail.subject.details')
+              : subject}
+          </h4>
           <div className="d-flex align-items-center mt-16 gap-12 small">
             <Avatar
               alt={t('author.avatar')}


### PR DESCRIPTION
# Description

Itération agile sur le rappel de messages : 
on souhaite désormais que les émetteurs puissent consulter les messages qu'ils ont rappelés, afin de pouvoir copier/coller le texte.
Cela nécessite de pouvoir retrouver ces messages dans les listes.
Coup de chance, on dispose d'une nouvelle API pour lister les messages, donc j'ai pu rajouter les messages _state=RECALL_ sans casser l'ancienne API, laquelle ne renvoie que les _state=SENT_.

Ajout aussi d'une trads pour les titres des messages rappelés, en vue détails.

## Fixes

WB-3776

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [X] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley: