### PR TITLE
fix(communication): #WB-3801, add visible groups while filtering by name

### DIFF
--- a/communication/src/main/java/org/entcore/communication/services/impl/DefaultCommunicationService.java
+++ b/communication/src/main/java/org/entcore/communication/services/impl/DefaultCommunicationService.java
@@ -46,7 +46,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -1814,7 +1813,7 @@ public class DefaultCommunicationService implements CommunicationService {
 							shareBookmarks,
 							visible,
 							language,
-							StringUtils.isEmpty(search) ? Optional.empty() : Optional.of(search)
+							StringUtils.isEmpty(search) ? null : search
 						)
 					);
 				}

--- a/communication/src/main/java/org/entcore/communication/services/impl/DefaultCommunicationService.java
+++ b/communication/src/main/java/org/entcore/communication/services/impl/DefaultCommunicationService.java
@@ -46,6 +46,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -1812,7 +1813,8 @@ public class DefaultCommunicationService implements CommunicationService {
 							user.getType(),
 							shareBookmarks,
 							visible,
-							language
+							language,
+							StringUtils.isEmpty(search) ? Optional.empty() : Optional.of(search)
 						)
 					);
 				}

--- a/communication/src/main/java/org/entcore/communication/services/impl/DefaultCommunicationService.java
+++ b/communication/src/main/java/org/entcore/communication/services/impl/DefaultCommunicationService.java
@@ -1635,7 +1635,7 @@ public class DefaultCommunicationService implements CommunicationService {
 		JsonObject params = new JsonObject();
 
 		if (!StringUtils.isEmpty(search)) {
-			preFilter = "AND m.displayNameSearchField CONTAINS {search} ";
+			preFilter = "AND (m:Group OR m.displayNameSearchField CONTAINS {search}) ";
 			String sanitizedSearch = StringValidation.sanitize(search);
 			params.put("search", sanitizedSearch);
 		}
@@ -1747,7 +1747,7 @@ public class DefaultCommunicationService implements CommunicationService {
 		JsonObject params = new JsonObject();
 
 		if (!StringUtils.isEmpty(search)) {
-			preFilter = "AND m.displayNameSearchField CONTAINS {search} ";
+			preFilter = "AND (m:Group OR m.displayNameSearchField CONTAINS {search}) ";
 			String sanitizedSearch = StringValidation.sanitize(search);
 			params.put("search", sanitizedSearch);
 		}
@@ -1856,7 +1856,7 @@ public class DefaultCommunicationService implements CommunicationService {
 		JsonObject params = new JsonObject();
 
 		if (!StringUtils.isEmpty(search)) {
-			preFilter = "AND m.displayNameSearchField CONTAINS {search} ";
+			preFilter = "AND (m:Group OR m.displayNameSearchField CONTAINS {search}) ";
 			String sanitizedSearch = StringValidation.sanitize(search);
 			params.put("search", sanitizedSearch);
 		}


### PR DESCRIPTION
# Description

Cette PR vise à corriger une régression dans la messagerie,  issue de l'utilisation de la nouvelle API de recherche des visibles :
* on n’a pas la liste de diffusion lorsqu’on la recherche en destinataire 
* ni la recherche pas discipline ou fonction ou groupe de profil qui fonctionne,
alors qu’en prod, ça marche.

L'idée est de ré-inclure les groupes dans la requête Neo4j, comme fait dans l'API d'origine.
Or, il faudrait aussi les filtrer par nom, mais certains groupes ont une clé de trad à la place d'un nom en BDD.
On est donc obligé de récupérer les traductions de noms des groupes, avant de pouvoir filtrer dessus.

Comme l'API n'accepte pas la pagination des résultats, l'implémentation proposée fonctionne partiellement : 
il reste que l'ordre de tri des résultats est un peu aléatoire... c'est la vie.

## Fixes

[WB-3801](https://edifice-community.atlassian.net/browse/WB-3801)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [X] common
- [X] communication
- [X] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley:

[WB-3801]: https://edifice-community.atlassian.net/browse/WB-3801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ