### PR TITLE
feat(conversation): #WB-3999, reroute '#write-mail'-like URLs

### DIFF
--- a/conversation/frontend/src/features/message-edit/components/MessageEditHeader.tsx
+++ b/conversation/frontend/src/features/message-edit/components/MessageEditHeader.tsx
@@ -21,52 +21,54 @@ export function MessageEditHeader({ message }: MessageHeaderProps) {
   );
 
   return (
-    <div className="d-flex flex-fill flex-column overflow-hidden">
-      <div className="d-flex align-items-center justify-content-between gap-12 border-bottom pe-16">
-        <RecipientListEdit
-          head={<span className="me-4">{t('at')} :</span>}
-          recipients={to}
-          recipientType="to"
-        />
-        <div className="d-flex align-items-center">
-          <Button
-            onClick={() => setShowCC((prev) => !prev)}
-            variant="ghost"
-            size="sm"
-            color="secondary"
-            hidden={showCC}
-          >
-            {t('button.cc')}
-          </Button>
-          <Button
-            onClick={() => setShowCCI((prev) => !prev)}
-            variant="ghost"
-            size="sm"
-            color="secondary"
-            hidden={showCCI}
-          >
-            {t('button.cci')}
-          </Button>
+    <>
+      <div className="d-flex flex-fill flex-column overflow-hidden">
+        <div className="d-flex align-items-center justify-content-between gap-12 border-bottom pe-16">
+          <RecipientListEdit
+            head={<span className="me-4">{t('at')} :</span>}
+            recipients={to}
+            recipientType="to"
+          />
+          <div className="d-flex align-items-center">
+            <Button
+              onClick={() => setShowCC((prev) => !prev)}
+              variant="ghost"
+              size="sm"
+              color="secondary"
+              hidden={showCC}
+            >
+              {t('button.cc')}
+            </Button>
+            <Button
+              onClick={() => setShowCCI((prev) => !prev)}
+              variant="ghost"
+              size="sm"
+              color="secondary"
+              hidden={showCCI}
+            >
+              {t('button.cci')}
+            </Button>
+          </div>
         </div>
+        {showCC && (
+          <div className="border-bottom">
+            <RecipientListEdit
+              head={<span className="me-4">{t('cc')} :</span>}
+              recipients={cc}
+              recipientType="cc"
+            />
+          </div>
+        )}
+        {showCCI && (
+          <div className="border-bottom">
+            <RecipientListEdit
+              head={<span className="me-4">{t('cci')} :</span>}
+              recipients={cci || { groups: [], users: [] }}
+              recipientType="cci"
+            />
+          </div>
+        )}
       </div>
-      {showCC && (
-        <div className="border-bottom">
-          <RecipientListEdit
-            head={<span className="me-4">{t('cc')} :</span>}
-            recipients={cc}
-            recipientType="cc"
-          />
-        </div>
-      )}
-      {showCCI && (
-        <div className="border-bottom">
-          <RecipientListEdit
-            head={<span className="me-4">{t('cci')} :</span>}
-            recipients={cci || { groups: [], users: [] }}
-            recipientType="cci"
-          />
-        </div>
-      )}
-    </div>
+    </>
   );
 }

--- a/conversation/frontend/src/features/message-edit/components/MessageEditHeader.tsx
+++ b/conversation/frontend/src/features/message-edit/components/MessageEditHeader.tsx
@@ -21,54 +21,52 @@ export function MessageEditHeader({ message }: MessageHeaderProps) {
   );
 
   return (
-    <>
-      <div className="d-flex flex-fill flex-column overflow-hidden">
-        <div className="d-flex align-items-center justify-content-between gap-12 border-bottom pe-16">
-          <RecipientListEdit
-            head={<span className="me-4">{t('at')} :</span>}
-            recipients={to}
-            recipientType="to"
-          />
-          <div className="d-flex align-items-center">
-            <Button
-              onClick={() => setShowCC((prev) => !prev)}
-              variant="ghost"
-              size="sm"
-              color="secondary"
-              hidden={showCC}
-            >
-              {t('button.cc')}
-            </Button>
-            <Button
-              onClick={() => setShowCCI((prev) => !prev)}
-              variant="ghost"
-              size="sm"
-              color="secondary"
-              hidden={showCCI}
-            >
-              {t('button.cci')}
-            </Button>
-          </div>
+    <div className="d-flex flex-fill flex-column overflow-hidden">
+      <div className="d-flex align-items-center justify-content-between gap-12 border-bottom pe-16">
+        <RecipientListEdit
+          head={<span className="me-4">{t('at')} :</span>}
+          recipients={to}
+          recipientType="to"
+        />
+        <div className="d-flex align-items-center">
+          <Button
+            onClick={() => setShowCC((prev) => !prev)}
+            variant="ghost"
+            size="sm"
+            color="secondary"
+            hidden={showCC}
+          >
+            {t('button.cc')}
+          </Button>
+          <Button
+            onClick={() => setShowCCI((prev) => !prev)}
+            variant="ghost"
+            size="sm"
+            color="secondary"
+            hidden={showCCI}
+          >
+            {t('button.cci')}
+          </Button>
         </div>
-        {showCC && (
-          <div className="border-bottom">
-            <RecipientListEdit
-              head={<span className="me-4">{t('cc')} :</span>}
-              recipients={cc}
-              recipientType="cc"
-            />
-          </div>
-        )}
-        {showCCI && (
-          <div className="border-bottom">
-            <RecipientListEdit
-              head={<span className="me-4">{t('cci')} :</span>}
-              recipients={cci || { groups: [], users: [] }}
-              recipientType="cci"
-            />
-          </div>
-        )}
       </div>
-    </>
+      {showCC && (
+        <div className="border-bottom">
+          <RecipientListEdit
+            head={<span className="me-4">{t('cc')} :</span>}
+            recipients={cc}
+            recipientType="cc"
+          />
+        </div>
+      )}
+      {showCCI && (
+        <div className="border-bottom">
+          <RecipientListEdit
+            head={<span className="me-4">{t('cci')} :</span>}
+            recipients={cci || { groups: [], users: [] }}
+            recipientType="cci"
+          />
+        </div>
+      )}
+    </div>
   );
 }

--- a/conversation/frontend/src/hooks/index.ts
+++ b/conversation/frontend/src/hooks/index.ts
@@ -3,3 +3,5 @@ export * from './useSelectedFolder';
 export * from './useRecall';
 export * from './useRights';
 export * from './useUsedSpace';
+export * from './useMessageReplyOrTransfer';
+export * from './useAdditionalRecipients';

--- a/conversation/frontend/src/hooks/useAdditionalRecipients.ts
+++ b/conversation/frontend/src/hooks/useAdditionalRecipients.ts
@@ -1,0 +1,58 @@
+import { RecipientType } from '~/features/message-edit/components/RecipientListEdit';
+import { Message, Recipients } from '~/models';
+import { useBookmarkById, useSearchVisible } from '~/services/queries/user';
+
+export function useAdditionalRecipients(
+  recipientType: RecipientType,
+  userIds?: string[],
+  groupIds?: string[],
+  bookmarkIds?: string[],
+) {
+  const { getVisibleUserById, getVisibleGroupById } = useSearchVisible();
+  const { getBookmarkById } = useBookmarkById();
+
+  const allUsersPromise = Promise.allSettled(
+    userIds?.map((userId) => getVisibleUserById(userId)) ?? [],
+  );
+  const allGroupsPromise = Promise.allSettled(
+    groupIds?.map((groupId) => getVisibleGroupById(groupId)) ?? [],
+  );
+  const allBookmarksPromise = Promise.allSettled(
+    bookmarkIds?.map((bookmarkId) => getBookmarkById(bookmarkId)) ?? [],
+  );
+
+  async function addRecipientsById(message: Message): Promise<Message> {
+    const allUsersSettled = await allUsersPromise;
+    const allGroupsSettled = await allGroupsPromise;
+    const allBookmarksSettled = await allBookmarksPromise;
+    const recipients: Recipients = {
+      users: [],
+      groups: [],
+      ...message[recipientType],
+    };
+
+    allUsersSettled
+      .filter((promise) => promise.status === 'fulfilled')
+      .map((success) => success.value)
+      .forEach((user) => recipients.users.push(user));
+
+    allGroupsSettled
+      .filter((promise) => promise.status === 'fulfilled')
+      .map((success) => success.value)
+      .forEach((group) => recipients.groups.push(group));
+
+    allBookmarksSettled
+      .filter((promise) => promise.status === 'fulfilled')
+      .map((success) => success.value)
+      .forEach((bookmark) => {
+        recipients.users.push(...bookmark.users);
+        recipients.groups.push(...bookmark.groups);
+      });
+
+    return { ...message };
+  }
+
+  return {
+    addRecipientsById,
+  };
+}

--- a/conversation/frontend/src/routes/pages/Message.tsx
+++ b/conversation/frontend/src/routes/pages/Message.tsx
@@ -78,7 +78,7 @@ export function Component() {
   useEffect(() => {
     // Update the current key to trigger a re-render
     setCurrentKey((prev) => prev + 1);
-  }, [messageId]);
+  }, [message]);
 
   if (!message) {
     return null;

--- a/conversation/frontend/src/routes/pages/Message.tsx
+++ b/conversation/frontend/src/routes/pages/Message.tsx
@@ -34,21 +34,10 @@ export function Component() {
   const { folderId } = useSelectedFolder();
   const [currentKey, setCurrentKey] = useState(0);
 
-  // Get IDs of users and groups/favorites to add as recipients.
-  const toUsers = searchParams.getAll('user');
-  const toGroups = searchParams.getAll('group');
-  const toFavorites = searchParams.getAll('favorite');
-  const { addRecipientsById } = useAdditionalRecipients(
-    'to',
-    toUsers,
-    toGroups,
-    toFavorites,
-  );
-
   const replyMessageId = searchParams.get('reply');
   const replyAllMessageId = searchParams.get('replyall');
   const transferMessageId = searchParams.get('transfer');
-  const { message: baseMessage } = useMessageReplyOrTransfer({
+  const { message: templateMessage } = useMessageReplyOrTransfer({
     messageId:
       messageId ||
       replyMessageId ||
@@ -63,6 +52,23 @@ export function Component() {
           ? 'transfer'
           : undefined,
   });
+  const [message, setMessage] = useState(templateMessage);
+
+  // Get IDs of users and groups/favorites to add as recipients.
+  const toUsers = searchParams.getAll('user');
+  const toGroups = searchParams.getAll('group');
+  const toFavorites = searchParams.getAll('favorite');
+  const { addRecipientsToMessage } = useAdditionalRecipients(
+    'to',
+    toUsers,
+    toGroups,
+    toFavorites,
+  );
+  useEffect(() => {
+    if (templateMessage) {
+      setMessage(addRecipientsToMessage(templateMessage));
+    }
+  }, [templateMessage, addRecipientsToMessage]);
 
   useEffect(() => {
     // Scroll to the top of the page
@@ -74,11 +80,9 @@ export function Component() {
     setCurrentKey((prev) => prev + 1);
   }, [messageId]);
 
-  if (!baseMessage) {
+  if (!message) {
     return null;
   }
-
-  const message = addRecipientsById(baseMessage);
 
   return (
     <Fragment key={currentKey}>

--- a/conversation/frontend/src/routes/pages/Message.tsx
+++ b/conversation/frontend/src/routes/pages/Message.tsx
@@ -66,7 +66,10 @@ export function Component() {
   );
   useEffect(() => {
     if (templateMessage) {
-      setMessage(addRecipientsToMessage(templateMessage));
+      setMessage((msg) => ({
+        ...msg,
+        ...addRecipientsToMessage(templateMessage),
+      }));
     }
   }, [templateMessage, addRecipientsToMessage]);
 

--- a/conversation/frontend/src/routes/redirections/index.tsx
+++ b/conversation/frontend/src/routes/redirections/index.tsx
@@ -62,9 +62,30 @@ export const manageRedirections = async () => {
       return;
     }
 
-    const isEditMessage = matchPath('/write-mail/:mailId', hashLocation);
-    if (isEditMessage?.params.mailId) {
-      redirectTo(asSubPath('draft', 'message', isEditMessage.params.mailId));
+    const isWriteToRecipient = matchPath(
+      '/write-mail/:recipientId/:recipientType',
+      hashLocation,
+    );
+    if (
+      isWriteToRecipient?.params.recipientId &&
+      isWriteToRecipient.params.recipientType
+    ) {
+      // eslint-disable-next-line prefer-const
+      let { recipientId, recipientType } = isWriteToRecipient.params;
+      recipientType = recipientType.toLowerCase();
+      if (['user', 'group', 'favorite'].includes(recipientType)) {
+        redirectTo(
+          `${asSubPath('draft', 'create')}?${recipientType}=${recipientId}`,
+        );
+        return;
+      }
+    }
+
+    const isWriteToUser = matchPath('/write-mail/:userId', hashLocation);
+    if (isWriteToUser?.params.userId) {
+      redirectTo(
+        `${asSubPath('draft', 'create')}?user=${isWriteToUser.params.userId}`,
+      );
       return;
     }
 

--- a/conversation/frontend/src/services/api/userService.ts
+++ b/conversation/frontend/src/services/api/userService.ts
@@ -1,7 +1,8 @@
 import { BookmarkWithDetails, odeServices } from '@edifice.io/client';
 import { Visible } from '~/models/visible';
 
-export type VisibleData = { id: string; displayName: string };
+type VisibleData = { id: string; displayName: string };
+export type VisibleGroupData = VisibleData & { nbUsers: number };
 export type VisibleUserData = VisibleData & { profile: string };
 
 /**
@@ -23,11 +24,11 @@ export type VisibleUserData = VisibleData & { profile: string };
 export const createUserService = () => {
   // Locally define a function with multiple signatures and return types.
   function getVisibleById(id: string, type: 'User'): Promise<VisibleUserData>;
-  function getVisibleById(id: string, type: 'Group'): Promise<VisibleData>;
+  function getVisibleById(id: string, type: 'Group'): Promise<VisibleGroupData>;
   function getVisibleById(
     id: string,
     type: 'User' | 'Group',
-  ): Promise<VisibleData | VisibleUserData> {
+  ): Promise<VisibleGroupData | VisibleUserData> {
     switch (type) {
       case 'User':
         return odeServices
@@ -51,9 +52,10 @@ export const createUserService = () => {
             name: string;
             nbUsers: number;
           }>(`/directory/group/${id}`)
-          .then(({ id, ...result }) => ({
+          .then(({ id, nbUsers, ...result }) => ({
             id,
             displayName: result.name,
+            nbUsers,
           }));
     }
   }

--- a/conversation/frontend/src/services/api/userService.ts
+++ b/conversation/frontend/src/services/api/userService.ts
@@ -1,8 +1,8 @@
 import { BookmarkWithDetails, odeServices } from '@edifice.io/client';
 import { Visible } from '~/models/visible';
 
-type VisibleData = { id: string; displayName: string };
-type VisibleUserData = VisibleData & { profile: string };
+export type VisibleData = { id: string; displayName: string };
+export type VisibleUserData = VisibleData & { profile: string };
 
 /**
  * User service to manage user/group/bookmark.

--- a/conversation/frontend/src/services/queries/user.ts
+++ b/conversation/frontend/src/services/queries/user.ts
@@ -11,8 +11,41 @@ export const userQueryOptions = {
    */
   searchVisible(search: string) {
     return queryOptions({
-      queryKey: [...userQueryOptions.base, search] as const,
+      queryKey: [...userQueryOptions.base, 'search', { search }] as const,
       queryFn: () => userService.searchVisible(search),
+    });
+  },
+
+  /**
+   * Get visible information about a user
+   * @param id ID of the user
+   * @returns The query options for the get visible by ID
+   */
+  getVisibleUserById(id: string) {
+    return queryOptions({
+      queryKey: [
+        ...userQueryOptions.base,
+        'get',
+        { id, type: 'User' },
+      ] as const,
+      queryFn: () => userService.getVisibleById(id, 'User'),
+    });
+  },
+
+  /**
+   * Get visible information about a group
+   * @param id ID of the group
+   * @param type Type of ID
+   * @returns The query options for the get visible by ID
+   */
+  getVisibleGroupById(id: string) {
+    return queryOptions({
+      queryKey: [
+        ...userQueryOptions.base,
+        'get',
+        { id, type: 'Group' },
+      ] as const,
+      queryFn: () => userService.getVisibleById(id, 'Group'),
     });
   },
 
@@ -47,11 +80,22 @@ export const userQueryOptions = {
  */
 export const useSearchVisible = () => {
   const queryClient = useQueryClient();
+
   const searchVisible = (search: string) => {
     return queryClient.ensureQueryData(userQueryOptions.searchVisible(search));
   };
 
-  return { searchVisible };
+  const getVisibleUserById = (id: string) => {
+    return queryClient.ensureQueryData(userQueryOptions.getVisibleUserById(id));
+  };
+
+  const getVisibleGroupById = (id: string) => {
+    return queryClient.ensureQueryData(
+      userQueryOptions.getVisibleGroupById(id),
+    );
+  };
+
+  return { searchVisible, getVisibleUserById, getVisibleGroupById };
 };
 
 /**


### PR DESCRIPTION
# Description

* Prend en compte les raccourcis de création d'un nouveau message (`#write-mail/....`)
* Ajoute des User / Group / Bookmark en destinataire, à l'aide de query-params
  L'URL attendue est de la forme `conversation/draft/create?user=userId&group=groupId1&favorite=favoriteId1`
 Les query params multiples sont pris en compte.

* Supprime les destinataires en doublon

## Fixes

[WB-3999](https://edifice-community.atlassian.net/browse/WB-3999)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [X] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley:

[WB-3999]: https://edifice-community.atlassian.net/browse/WB-3999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ