### PR TITLE
fix(conversation)-WB-4093 fix message-attachements

### DIFF
--- a/conversation/frontend/src/components/MessageAttachments/MessageAttachments.tsx
+++ b/conversation/frontend/src/components/MessageAttachments/MessageAttachments.tsx
@@ -3,8 +3,6 @@ import {
   IconDelete,
   IconDownload,
   IconFolderAdd,
-  IconLoader,
-  IconPlus,
 } from '@edifice.io/react/icons';
 import clsx from 'clsx';
 import { ChangeEvent, useRef, useState } from 'react';
@@ -34,7 +32,8 @@ export function MessageAttachments({
     useState<Attachment[] | undefined>(undefined);
   const attachments = messageUpdated?.attachments || message.attachments || [];
 
-  if (!editMode && !attachments) return null;
+  if ((!editMode && !attachments.length) || message.state === 'RECALL')
+    return null;
 
   const handleAttachClick = () => inputRef?.current?.click();
 
@@ -46,106 +45,104 @@ export function MessageAttachments({
 
   const className = clsx(
     'bg-gray-200 rounded-2 px-12 py-8 message-attachments align-self-start gap-8 d-flex flex-column',
-    editMode && 'border message-attachments-edit mx-16',
+    { 'border message-attachments-edit mx-16': editMode },
   );
 
   const handleWantAddToWorkspace = (attachments: Attachment[]) => {
     setAttachmentsToAddToWorkspace(attachments);
   };
   return (
-    message.state !== 'RECALL' && (
-      <div
-        className={className}
-        style={{ maxWidth: '-webkit-fill-available' }}
-        data-drag-handle
-      >
-        {!!attachments.length && (
-          <>
-            <div className="d-flex align-items-center justify-content-between border-bottom">
-              <span className="caption fw-bold my-8">
-                {common_t('attachments')}
-              </span>
-              {attachments.length > 1 && (
-                <div>
+    <div
+      className={className}
+      style={{ maxWidth: '-webkit-fill-available' }}
+      data-drag-handle
+    >
+      {!!attachments.length && (
+        <>
+          <div className="d-flex align-items-center justify-content-between border-bottom">
+            <span className="caption fw-bold my-8">
+              {common_t('attachments')}
+            </span>
+            {attachments.length > 1 && (
+              <div>
+                <IconButton
+                  title={common_t('conversation.copy.all.toworkspace')}
+                  color="tertiary"
+                  type="button"
+                  icon={<IconFolderAdd />}
+                  onClick={() => handleWantAddToWorkspace(attachments)}
+                  variant="ghost"
+                />
+                <a href={downloadAllUrl} download>
                   <IconButton
-                    title={common_t('conversation.copy.all.toworkspace')}
+                    title={common_t('download.all.attachment')}
                     color="tertiary"
                     type="button"
-                    icon={<IconFolderAdd />}
-                    onClick={() => handleWantAddToWorkspace(attachments)}
+                    icon={<IconDownload />}
                     variant="ghost"
                   />
-                  <a href={downloadAllUrl} download>
-                    <IconButton
-                      title={common_t('download.all.attachment')}
-                      color="tertiary"
-                      type="button"
-                      icon={<IconDownload />}
-                      variant="ghost"
-                    />
-                  </a>
-                  {editMode && (
-                    <IconButton
-                      title={t('remove.all.attachment')}
-                      color="danger"
-                      type="button"
-                      icon={<IconDelete />}
-                      variant="ghost"
-                      onClick={handleDetachAllClick}
-                      disabled={isMutating}
-                    />
-                  )}
-                </div>
-              )}
-            </div>
-            <ul className="d-flex gap-8 flex-column list-unstyled m-0">
-              {attachments.map((attachment) => (
-                <li key={attachment.id} className="mw-100">
-                  <MessageAttachment
-                    attachment={attachment}
-                    message={message}
-                    editMode={editMode}
-                    onWantAddToWorkspace={(attachment) =>
-                      handleWantAddToWorkspace([attachment])
-                    }
+                </a>
+                {editMode && (
+                  <IconButton
+                    title={t('remove.all.attachment')}
+                    color="danger"
+                    type="button"
+                    icon={<IconDelete />}
+                    variant="ghost"
+                    onClick={handleDetachAllClick}
+                    disabled={isMutating}
                   />
-                </li>
-              ))}
-            </ul>
-          </>
-        )}
-        {editMode && (
-          <>
-            <Button
-              color="secondary"
-              variant="ghost"
-              leftIcon={isMutating ? <IconLoader /> : <IconPlus />}
-              onClick={handleAttachClick}
-              disabled={isMutating}
-              className="align-self-start"
-            >
-              {t('add.attachment')}
-            </Button>
-            <input
-              ref={inputRef}
-              multiple={true}
-              type="file"
-              name="attachment-input"
-              id="attachment-input"
-              onChange={handleFileChange}
-              hidden
-            />
-          </>
-        )}
-        {!!attachmentsToAddToWorkspace && (
-          <AddMessageAttachmentToWorkspaceModal
-            message={message}
-            isOpen
-            onModalClose={() => setAttachmentsToAddToWorkspace(undefined)}
-            attachments={attachmentsToAddToWorkspace}
+                )}
+              </div>
+            )}
+          </div>
+          <ul className="d-flex gap-8 flex-column list-unstyled m-0">
+            {attachments.map((attachment) => (
+              <li key={attachment.id} className="mw-100">
+                <MessageAttachment
+                  attachment={attachment}
+                  message={message}
+                  editMode={editMode}
+                  onWantAddToWorkspace={(attachment) =>
+                    handleWantAddToWorkspace([attachment])
+                  }
+                />
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+      {editMode && (
+        <>
+          <Button
+            color="secondary"
+            variant="ghost"
+            isLoading={isMutating}
+            onClick={handleAttachClick}
+            disabled={isMutating}
+            className="align-self-start"
+          >
+            {t('add.attachment')}
+          </Button>
+          <input
+            ref={inputRef}
+            multiple={true}
+            type="file"
+            name="attachment-input"
+            id="attachment-input"
+            onChange={handleFileChange}
+            hidden
           />
-        )}
-      </div>
-    )
+        </>
+      )}
+      {!!attachmentsToAddToWorkspace && (
+        <AddMessageAttachmentToWorkspaceModal
+          message={message}
+          isOpen
+          onModalClose={() => setAttachmentsToAddToWorkspace(undefined)}
+          attachments={attachmentsToAddToWorkspace}
+        />
+      )}
+    </div>
   );
 }

--- a/conversation/frontend/src/services/queries/message.ts
+++ b/conversation/frontend/src/services/queries/message.ts
@@ -87,6 +87,7 @@ export const useMessage = (messageId: string) => {
   const { folderId } = useSelectedFolder();
   const { updateFolderMessagesQueryData } = useFolderUtils();
   const { currentLanguage, user, userProfile } = useEdificeClient();
+  const { setMessageUpdated } = useAppActions();
 
   if (result.isSuccess && result.data) {
     let message: Message = result.data;
@@ -118,6 +119,7 @@ export const useMessage = (messageId: string) => {
         },
       };
     }
+    setMessageUpdated(message);
   }
   return result;
 };


### PR DESCRIPTION
# Description

[Ticket](https://edifice-community.atlassian.net/jira/software/c/projects/WB/boards/234?assignee=712020%3Aa351bfd8-8169-43e4-821c-48991f7e3d43&selectedIssue=WB-4093)
- On ne doit pas avoir le bloc de PJ visible sur un message sans PJ
- ne pas afficher une piece jointe ajoutée sur un nouveau message precedent
- animer le loader lors de l’ajout d’une piece jointe

## Fixes

(Enter here Jira or Redmine ticket(s) links)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [x] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: