### PR TITLE
fix(conversation)-WB-4015 user folders modals

### DIFF
--- a/conversation/frontend/src/features/menu/components/DesktopMenu.tsx
+++ b/conversation/frontend/src/features/menu/components/DesktopMenu.tsx
@@ -77,41 +77,6 @@ export function DesktopMenu() {
     navigate((isUserFolder ? '/folder/' : '/') + folderId);
   };
 
-  // Render a user's folder, to be used in a Tree or SortableTree
-  function renderUserFolder({ node }: { node: TreeItem }) {
-    const [dropdownOpened, setDropdownOpened] = useState(false);
-    const handleDropdownOpened = (visible: boolean) => {
-      setDropdownOpened(visible);
-    };
-
-    return (
-      <div
-        className={clsx(
-          'folder-item my-n8 py-2 w-100 d-flex justify-content-between align-content-center align-items-center',
-          { 'dropdown-opened': dropdownOpened },
-        )}
-      >
-        <div
-          className="overflow-x-hidden text-no-wrap text-truncate"
-          title={node.name}
-        >
-          {node.name}
-        </div>
-        <div className="d-flex align-items-center text-dark fw-normal justify-content-center">
-          <div className="unread-badge">
-            {renderBadge(node.folder.nbUnread)}
-          </div>
-          <div className="actions-button">
-            <FolderActionDropdown
-              folder={node.folder}
-              onDropdownOpened={handleDropdownOpened}
-            />
-          </div>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <Menu label={t('generic.folders')}>
       <Menu.Item>
@@ -155,7 +120,7 @@ export function DesktopMenu() {
           <Tree
             nodes={userFolders}
             onTreeItemClick={(folderId) => navigateTo(folderId, true)}
-            renderNode={renderUserFolder}
+            renderNode={UserFolderItem}
             selectedNodeId={selectedUserFolderId}
           />
           <Button
@@ -181,5 +146,38 @@ export function DesktopMenu() {
         </div>
       </Menu.Item>
     </Menu>
+  );
+}
+
+function UserFolderItem({ node }: { node: TreeItem }) {
+  const { renderBadge } = useMenuData();
+  const [dropdownOpened, setDropdownOpened] = useState(false);
+  const handleDropdownOpened = (visible: boolean) => {
+    setDropdownOpened(visible);
+  };
+
+  return (
+    <div
+      className={clsx(
+        'folder-item my-n8 py-2 w-100 d-flex justify-content-between align-content-center align-items-center',
+        { 'dropdown-opened': dropdownOpened },
+      )}
+    >
+      <div
+        className="overflow-x-hidden text-no-wrap text-truncate"
+        title={node.name}
+      >
+        {node.name}
+      </div>
+      <div className="d-flex align-items-center text-dark fw-normal justify-content-center">
+        <div className="unread-badge">{renderBadge(node.folder.nbUnread)}</div>
+        <div className="actions-button">
+          <FolderActionDropdown
+            folder={node.folder}
+            onDropdownOpened={handleDropdownOpened}
+          />
+        </div>
+      </div>
+    </div>
   );
 }

--- a/conversation/frontend/src/features/menu/components/DesktopMenu.tsx
+++ b/conversation/frontend/src/features/menu/components/DesktopMenu.tsx
@@ -43,9 +43,7 @@ export function DesktopMenu() {
     selectedSystemFolderId,
     selectedUserFolderId,
   } = useMenuData();
-
   const { usage, quota } = useUsedSpace();
-
   const { handleCreate: handleNewFolderClick } = useFolderHandlers();
 
   const userFolders = useMemo(() => {

--- a/conversation/frontend/src/features/menu/components/MobileMenu.tsx
+++ b/conversation/frontend/src/features/menu/components/MobileMenu.tsx
@@ -30,32 +30,30 @@ function buildMenuItemsWithSelection(
 ) {
   const items: FolderItem[] = [];
   let selectedItem: FolderItem | undefined;
-  folders
-    .sort((a, b) => (a.name < b.name ? -1 : a.name == b.name ? 0 : 1))
-    .forEach((folder) => {
-      // Build an item representing this folder
-      const name = `${prefix ? prefix : ''}${folder.name}`;
-      const item = { name, folder };
-      items.push(item);
+  folders.forEach((folder) => {
+    // Build an item representing this folder
+    const name = `${prefix ? prefix : ''}${folder.name}`;
+    const item = { name, folder };
+    items.push(item);
 
-      // Is this the selected folder ?
-      if (selectedFolderId === folder.id) {
-        selectedItem = item;
-      }
+    // Is this the selected folder ?
+    if (selectedFolderId === folder.id) {
+      selectedItem = item;
+    }
 
-      // Recursively build items for subFolders
-      if (folder.subFolders) {
-        const subs = buildMenuItemsWithSelection(
-          selectedFolderId,
-          folder.subFolders,
-          `${name} / `,
-        );
-        items.push(...subs.menuItems);
-        if (subs.selectedItem) {
-          selectedItem = subs.selectedItem;
-        }
+    // Recursively build items for subFolders
+    if (folder.subFolders) {
+      const subs = buildMenuItemsWithSelection(
+        selectedFolderId,
+        folder.subFolders,
+        `${name} / `,
+      );
+      items.push(...subs.menuItems);
+      if (subs.selectedItem) {
+        selectedItem = subs.selectedItem;
       }
-    });
+    }
+  });
   return { menuItems: items, selectedItem };
 }
 

--- a/conversation/frontend/src/features/menu/components/MobileMenu.tsx
+++ b/conversation/frontend/src/features/menu/components/MobileMenu.tsx
@@ -129,9 +129,7 @@ export function MobileMenu() {
   function renderFolderItem(item: FolderItem, isUserFolder = false) {
     return (
       <div className="w-100 d-flex justify-content-between align-content-center align-items-center">
-        <div className="overflow-x-hidden text-no-wrap text-truncate">
-          {t(item.name)}
-        </div>
+        <div>{t(item.name)}</div>
         {isUserFolder ? (
           <div className="d-flex align-items-center gap-4">
             {renderBadge(item.folder.nbUnread)}

--- a/conversation/frontend/src/features/menu/components/MobileMenu.tsx
+++ b/conversation/frontend/src/features/menu/components/MobileMenu.tsx
@@ -10,11 +10,12 @@ import {
 import { t } from 'i18next';
 import { ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { FolderActionDropdown } from '~/components';
+import { useI18n } from '~/hooks';
 import { Folder, SystemFolder } from '~/models';
 import { useFoldersTree } from '~/services';
 import { useFolderHandlers } from '../hooks/useFolderHandlers';
 import { useMenuData } from '../hooks/useMenuData';
-import { FolderActionDropdown } from '~/components';
 
 type FolderItem = { name: string; folder: Folder };
 
@@ -85,6 +86,8 @@ function asFolderItem(
 export function MobileMenu() {
   const navigate = useNavigate();
   const foldersTreeQuery = useFoldersTree();
+  const { t } = useI18n();
+
   const {
     counters,
     renderBadge,
@@ -127,7 +130,7 @@ export function MobileMenu() {
     return (
       <div className="w-100 d-flex justify-content-between align-content-center align-items-center">
         <div className="overflow-x-hidden text-no-wrap text-truncate">
-          {item.name}
+          {t(item.name)}
         </div>
         {isUserFolder ? (
           <div className="d-flex align-items-center gap-4">
@@ -147,7 +150,9 @@ export function MobileMenu() {
 
   return (
     <Dropdown block>
-      <Dropdown.Trigger label={selectedItem?.name || selectedUserFolderId} />
+      <Dropdown.Trigger
+        label={(selectedItem && t(selectedItem.name)) || selectedUserFolderId}
+      />
       <Dropdown.Menu>
         {systemFolderItems.map((item) => (
           <Dropdown.Item

--- a/conversation/frontend/src/features/menu/components/MobileMenu.tsx
+++ b/conversation/frontend/src/features/menu/components/MobileMenu.tsx
@@ -48,7 +48,7 @@ function buildMenuItemsWithSelection(
         const subs = buildMenuItemsWithSelection(
           selectedFolderId,
           folder.subFolders,
-          `${name}/`,
+          `${name} / `,
         );
         items.push(...subs.menuItems);
         if (subs.selectedItem) {

--- a/conversation/frontend/src/features/modals/CreateFolderModal.tsx
+++ b/conversation/frontend/src/features/modals/CreateFolderModal.tsx
@@ -7,6 +7,7 @@ import {
   Modal,
   Switch,
 } from '@edifice.io/react';
+import { IconFolder } from '@edifice.io/react/icons';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useI18n } from '~/hooks';
 import { Folder } from '~/models';
@@ -14,27 +15,24 @@ import { buildTree, searchFolder } from '~/services';
 import { useAppActions } from '~/store';
 import { useFolderActions } from './hooks';
 
-type FolderItem = { name: string; folder: Folder; canHaveChildren?: boolean };
+/**
+ * Custom typing of a TreeItem exposing a user folder
+ * @param name The name of the folder
+ * @param folder The folder
+ * @returns FolderItem[]
+ */
+type FolderItem = { name: string; folder: Folder };
 
 function flatFolders(folders: Folder[], prefix?: string) {
-  const SUB_FOLDER_INDICATOR = '•\u00A0\u00A0\u00A0\u00A0\u00A0';
   const items: FolderItem[] = [];
   folders.forEach((folder) => {
     const name = `${prefix || ''}${folder.name}`;
-    const item: FolderItem = {
-      name,
-      folder,
-      //Not more than 3 levels of folders
-      canHaveChildren:
-        prefix !== `${SUB_FOLDER_INDICATOR}${SUB_FOLDER_INDICATOR}`,
-    };
+    const item: FolderItem = { name, folder };
     items.push(item);
-
-    if (folder.subFolders) {
-      const subItems = flatFolders(
-        folder.subFolders,
-        `${prefix || ''}${SUB_FOLDER_INDICATOR}`,
-      );
+    const isOnSecondFolderLevel = !!prefix;
+    if (folder.subFolders && !isOnSecondFolderLevel) {
+      const parentFolderIndicator = `${name || ''} / `;
+      const subItems = flatFolders(folder.subFolders, parentFolderIndicator);
       items.push(...subItems);
     }
   });
@@ -117,7 +115,7 @@ export function CreateFolderModal() {
           {t('folder.new.title')}
         </Modal.Header>
 
-        <Modal.Body>
+        <Modal.Body className={'d-flex flex-column gap-24'}>
           <FormControl id="modalFolderNew" isRequired={true}>
             <Label>{t('folder.new.name.label')}</Label>
             <Input
@@ -131,15 +129,12 @@ export function CreateFolderModal() {
             />
           </FormControl>
           {userFolders.length > 0 && (
-            <>
-              <div className="mt-24"></div>
-
+            <div className="d-flex flex-column gap-8">
               <Switch
                 checked={checked}
                 label={t('folder.new.subfolder.label')}
                 onChange={handleSubfolderCheckChange}
               />
-              <div className="mt-8"></div>
               <Dropdown block>
                 <Dropdown.Trigger
                   disabled={!checked}
@@ -150,14 +145,14 @@ export function CreateFolderModal() {
                     <Dropdown.Item
                       key={item.name + index}
                       onClick={() => handleItemClick(item)}
-                      disabled={!item.canHaveChildren}
+                      icon={<IconFolder />}
                     >
                       {item.name}
                     </Dropdown.Item>
                   ))}
                 </Dropdown.Menu>
               </Dropdown>
-            </>
+            </div>
           )}
         </Modal.Body>
 

--- a/conversation/frontend/src/features/modals/CreateFolderModal.tsx
+++ b/conversation/frontend/src/features/modals/CreateFolderModal.tsx
@@ -6,15 +6,13 @@ import {
   Label,
   Modal,
   Switch,
-  Tree,
-  TreeItem,
 } from '@edifice.io/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useI18n } from '~/hooks';
+import { Folder } from '~/models';
 import { buildTree, searchFolder } from '~/services';
 import { useAppActions } from '~/store';
 import { useFolderActions } from './hooks';
-import { Folder } from '~/models';
 
 type FolderItem = { name: string; folder: Folder };
 

--- a/conversation/frontend/src/features/modals/CreateFolderModal.tsx
+++ b/conversation/frontend/src/features/modals/CreateFolderModal.tsx
@@ -1,18 +1,18 @@
-import { useAppActions } from '~/store';
 import {
   Button,
-  Checkbox,
   Dropdown,
   FormControl,
   Input,
   Label,
   Modal,
+  Switch,
   Tree,
   TreeItem,
 } from '@edifice.io/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useI18n } from '~/hooks';
 import { buildTree, searchFolder } from '~/services';
+import { useAppActions } from '~/store';
 import { useFolderActions } from './hooks';
 
 export function CreateFolderModal() {
@@ -23,21 +23,28 @@ export function CreateFolderModal() {
   const [subFolderId, setSubfolderId] = useState<string | undefined>(undefined);
   const refInputName = useRef<HTMLInputElement>(null);
   const refDropdownTrigger = useRef<HTMLButtonElement>(null);
+  const [newFolderName, setNewFolderName] = useState('');
 
   useEffect(() => {
     if (isActionPending === false) setOpenedModal(undefined);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isActionPending]);
 
-  const handleCreateClick = useCallback(() => {
-    const created = createFolder(
-      refInputName.current?.value,
-      checked ? subFolderId : undefined,
-    );
-    if (created === false) {
-      refInputName.current?.focus();
-    }
-  }, [checked, createFolder, subFolderId]);
+  const handleCreateClick = useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (!newFolderName) return;
+
+      const created = createFolder(
+        refInputName.current?.value,
+        checked ? subFolderId : undefined,
+      );
+      if (created === false) {
+        refInputName.current?.focus();
+      }
+    },
+    [checked, createFolder, subFolderId, newFolderName],
+  );
 
   const dropdownLabel = useMemo(() => {
     if (subFolderId && foldersTree) {
@@ -78,6 +85,10 @@ export function CreateFolderModal() {
     refDropdownTrigger.current?.click();
   };
 
+  const handleNameChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNewFolderName(e.target.value);
+  };
+
   return (
     <Modal
       size="sm"
@@ -85,72 +96,75 @@ export function CreateFolderModal() {
       isOpen={true}
       onModalClose={handleCloseFolderModal}
     >
-      <Modal.Header onModalClose={handleCloseFolderModal}>
-        {t('folder.new.title')}
-      </Modal.Header>
+      <form id="modalFolderNewForm" onSubmit={handleCreateClick}>
+        <Modal.Header onModalClose={handleCloseFolderModal}>
+          {t('folder.new.title')}
+        </Modal.Header>
 
-      <Modal.Body>
-        <FormControl id="modalFolderNewName" isRequired={true}>
-          <Label>{t('folder.new.name.label')}</Label>
-          <Input
-            ref={refInputName}
-            placeholder={t('folder.new.name.placeholder')}
-            size="md"
-            type="text"
-            maxLength={50}
-            autoComplete="off"
-          />
-        </FormControl>
-        {userFolders.length > 0 && (
-          <>
-            <div className="mt-24"></div>
-            <Checkbox
-              checked={checked}
-              label={t('folder.new.subfolder.label')}
-              onChange={handleSubfolderCheckChange}
+        <Modal.Body>
+          <FormControl id="modalFolderNew" isRequired={true}>
+            <Label>{t('folder.new.name.label')}</Label>
+            <Input
+              ref={refInputName}
+              placeholder={t('folder.new.name.placeholder')}
+              size="md"
+              type="text"
+              onChange={handleNameChanged}
+              maxLength={50}
+              autoComplete="off"
             />
-            <div className="mt-8"></div>
-            <Dropdown block>
-              <Dropdown.Trigger
-                ref={refDropdownTrigger}
-                disabled={!checked}
-                label={dropdownLabel}
-              ></Dropdown.Trigger>
-              <Dropdown.Menu>
-                <Tree
-                  nodes={userFolders}
-                  onTreeItemClick={handleTreeItemClick}
-                  renderNode={renderFolderTreeItem}
-                  selectedNodeId={subFolderId}
-                  shouldExpandAllNodes={true}
-                  showIcon={false}
-                />
-              </Dropdown.Menu>
-            </Dropdown>
-          </>
-        )}
-      </Modal.Body>
+          </FormControl>
+          {userFolders.length > 0 && (
+            <>
+              <div className="mt-24"></div>
 
-      <Modal.Footer>
-        <Button
-          type="button"
-          color="tertiary"
-          variant="ghost"
-          onClick={handleCloseFolderModal}
-        >
-          {common_t('cancel')}
-        </Button>
-        <Button
-          type="submit"
-          color="primary"
-          variant="filled"
-          onClick={handleCreateClick}
-          isLoading={isActionPending === true}
-          disabled={isActionPending === true}
-        >
-          {common_t('create')}
-        </Button>
-      </Modal.Footer>
+              <Switch
+                checked={checked}
+                label={t('folder.new.subfolder.label')}
+                onChange={handleSubfolderCheckChange}
+              />
+              <div className="mt-8"></div>
+              <Dropdown block>
+                <Dropdown.Trigger
+                  ref={refDropdownTrigger}
+                  disabled={!checked}
+                  label={dropdownLabel}
+                ></Dropdown.Trigger>
+                <Dropdown.Menu>
+                  <Tree
+                    nodes={userFolders}
+                    onTreeItemClick={handleTreeItemClick}
+                    renderNode={renderFolderTreeItem}
+                    selectedNodeId={subFolderId}
+                    shouldExpandAllNodes={true}
+                    showIcon={false}
+                  />
+                </Dropdown.Menu>
+              </Dropdown>
+            </>
+          )}
+        </Modal.Body>
+
+        <Modal.Footer>
+          <Button
+            type="button"
+            color="tertiary"
+            variant="ghost"
+            onClick={handleCloseFolderModal}
+          >
+            {common_t('cancel')}
+          </Button>
+          <Button
+            type="submit"
+            color="primary"
+            variant="filled"
+            isLoading={isActionPending === true}
+            disabled={isActionPending === true || !newFolderName}
+          >
+            {common_t('create')}
+          </Button>
+        </Modal.Footer>
+      </form>
     </Modal>
   );
 }

--- a/conversation/frontend/src/features/modals/CreateFolderModal.tsx
+++ b/conversation/frontend/src/features/modals/CreateFolderModal.tsx
@@ -17,7 +17,7 @@ import { useFolderActions } from './hooks';
 type FolderItem = { name: string; folder: Folder; canHaveChildren?: boolean };
 
 function flatFolders(folders: Folder[], prefix?: string) {
-  const SUB_FOLDER_INDICATOR = '>\u00A0\u00A0\u00A0\u00A0\u00A0';
+  const SUB_FOLDER_INDICATOR = '•\u00A0\u00A0\u00A0\u00A0\u00A0';
   const items: FolderItem[] = [];
   folders.forEach((folder) => {
     const name = `${prefix || ''}${folder.name}`;

--- a/conversation/frontend/src/features/modals/RenameFolderModal.tsx
+++ b/conversation/frontend/src/features/modals/RenameFolderModal.tsx
@@ -61,12 +61,12 @@ export function RenameFolderModal() {
       isOpen={true}
       onModalClose={handleCloseFolderModal}
     >
-      <Modal.Header onModalClose={handleCloseFolderModal}>
-        {t('folder.rename.title')}
-      </Modal.Header>
+      <form id="modalFolderNewNameForm" onSubmit={handleRenameClick}>
+        <Modal.Header onModalClose={handleCloseFolderModal}>
+          {t('folder.rename.title')}
+        </Modal.Header>
 
-      <Modal.Body>
-        <form id="modalFolderNewNameForm" onSubmit={handleRenameClick}>
+        <Modal.Body>
           <FormControl id="modalFolderNewName" isRequired={true}>
             <Label>{t('folder.rename.name.label')}</Label>
             <Input
@@ -80,28 +80,28 @@ export function RenameFolderModal() {
               data-testid="inputNewName"
             />
           </FormControl>
-        </form>
-      </Modal.Body>
+        </Modal.Body>
 
-      <Modal.Footer>
-        <Button
-          type="button"
-          color="tertiary"
-          variant="ghost"
-          onClick={handleCloseFolderModal}
-        >
-          {common_t('cancel')}
-        </Button>
-        <Button
-          type="submit"
-          color="primary"
-          variant="filled"
-          isLoading={isActionPending === true}
-          disabled={isActionPending === true || !newFolderName}
-        >
-          {common_t('save')}
-        </Button>
-      </Modal.Footer>
+        <Modal.Footer>
+          <Button
+            type="button"
+            color="tertiary"
+            variant="ghost"
+            onClick={handleCloseFolderModal}
+          >
+            {common_t('cancel')}
+          </Button>
+          <Button
+            type="submit"
+            color="primary"
+            variant="filled"
+            isLoading={isActionPending === true}
+            disabled={isActionPending === true || !newFolderName}
+          >
+            {common_t('save')}
+          </Button>
+        </Modal.Footer>
+      </form>
     </Modal>
   );
 }

--- a/conversation/frontend/src/routes/root/index.tsx
+++ b/conversation/frontend/src/routes/root/index.tsx
@@ -80,13 +80,17 @@ export function Component() {
       </AppHeader>
 
       <div className="d-md-flex">
-        <div className="d-block d-md-none px-0 py-12 border-bottom bg-white">
-          {!md && <MobileMenu />}
-        </div>
+        {!md && (
+          <div className="d-block d-md-none px-0 py-12 border-bottom bg-white">
+            <MobileMenu />
+          </div>
+        )}
 
-        <div className="desktop-menu d-none d-md-flex flex-column overflow-x-hidden p-16 ps-0 gap-16 border-end bg-white">
-          {md && <DesktopMenu />}
-        </div>
+        {md && (
+          <div className="desktop-menu d-none d-md-flex flex-column overflow-x-hidden p-16 ps-0 gap-16 border-end bg-white">
+            <DesktopMenu />
+          </div>
+        )}
 
         <div className="align-self-md-stretch flex-fill mx-n16 ms-md-0 overflow-hidden">
           <Outlet />


### PR DESCRIPTION
# Description

rename forlder modal : 
- submit with enter key
- disabled when not renamed

new folder modal : 
- limit to 3 sub folder levels
- flat folder tree in dopdown

MobileMenu : 
- multiline dropdown item to avoid overflow hidden

## Fixes

(Enter here Jira or Redmine ticket(s) links)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [x] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: