### PR TITLE
fix(directory,common,communication): #WB-4022, exclude non-visible users from sharebookmarks

### DIFF
--- a/common/src/main/java/org/entcore/common/user/UserUtils.java
+++ b/common/src/main/java/org/entcore/common/user/UserUtils.java
@@ -603,6 +603,22 @@ public class UserUtils {
 		findUsers(eb, request, m, handler);
 	}
 
+	public static Future<JsonArray> areVisible(EventBus eb, String userId, JsonArray checkIds) {
+		final Promise<JsonArray> promise = Promise.promise();
+		JsonObject query = new JsonObject()
+				.put("action", "areVisible")
+				.put("userId", userId)
+				.put("checkIds", checkIds);
+		eb.request(COMMUNICATION_USERS, query, (final AsyncResult<Message<JsonArray>> ar) -> {
+			if (ar.succeeded()) {
+				promise.complete(ar.result().body());
+			} else {
+				promise.fail(ar.cause());
+			}
+		});
+		return promise.future();
+	};
+
 	public static void getSession(EventBus eb, final HttpServerRequest request,
 								  final Handler<JsonObject> handler) {
 		getSession(eb, request, false, handler);

--- a/common/src/main/java/org/entcore/common/user/UserUtils.java
+++ b/common/src/main/java/org/entcore/common/user/UserUtils.java
@@ -188,21 +188,32 @@ public class UserUtils {
 		return m;
 	}
 
+	/* On error, handler will receive an empty JsonArray (legacy behavior) */
 	public static void findVisibles(EventBus eb, String userId, String customReturn,
 		JsonObject additionnalParams, boolean itSelf, boolean myGroup, boolean profile,
 		final Handler<JsonArray> handler) {
 		findVisibles(eb, userId, customReturn, additionnalParams, itSelf, myGroup, profile, null, handler);
 	}
 
+	/* On error, handler will receive an empty JsonArray (legacy behavior) */
 	public static void findVisibles(EventBus eb, String userId, String customReturn,
 		JsonObject additionnalParams, boolean itSelf, boolean myGroup, boolean profile,
 		final String acceptLanguage, final Handler<JsonArray> handler) {
 		findVisibles(eb, userId, customReturn, additionnalParams, itSelf, myGroup, profile, acceptLanguage, null, handler);
 	}
 
+	/* On error, handler will receive an empty JsonArray (legacy behavior) */
 	public static void findVisibles(EventBus eb, String userId, String customReturn,
 			JsonObject additionnalParams, boolean itSelf, boolean myGroup, boolean profile,
 			final String acceptLanguage, String preFilter, final Handler<JsonArray> handler) {
+		findVisibles(eb, userId, customReturn, additionnalParams, itSelf, myGroup, profile, acceptLanguage, preFilter, null, false)
+		.onSuccess( results -> handler.handle(results) )
+		.onFailure( throwable -> handler.handle(new fr.wseduc.webutils.collections.JsonArray()) );
+	}
+
+	public static Future<JsonArray> findVisibles(EventBus eb, String userId, String customReturn,
+			JsonObject additionnalParams, boolean itSelf, boolean myGroup, boolean profile,
+			final String acceptLanguage, String preFilter, String userProfile, boolean reverseUnion) {
 		JsonObject m = new JsonObject()
 				.put("itself", itSelf)
 				.put("mygroup", myGroup)
@@ -217,6 +228,10 @@ public class UserUtils {
 		if (additionnalParams != null) {
 			m.put("additionnalParams", additionnalParams);
 		}
+		if (userProfile != null) {
+			m.put("userProfile", userProfile);
+		}
+		m.put("reverseUnion", reverseUnion);
 		m.put("userId", userId);
 		LocalMap<Object, Object> serverConfig = vertx.sharedData().getLocalMap("server");
 		final int timeout;
@@ -225,8 +240,9 @@ public class UserUtils {
 		} else {
 			timeout = DEFAULT_VISIBLES_TIMEOUT;
 		}
-		eb.request(COMMUNICATION_USERS, m, new DeliveryOptions().setSendTimeout(timeout), new Handler<AsyncResult<Message<JsonArray>>>() {
 
+		Promise<JsonArray> promise = Promise.promise();
+		eb.request(COMMUNICATION_USERS, m, new DeliveryOptions().setSendTimeout(timeout), new Handler<AsyncResult<Message<JsonArray>>>() {
 			@Override
 			public void handle(AsyncResult<Message<JsonArray>> res) {
 				if (res.succeeded()) {
@@ -235,13 +251,14 @@ public class UserUtils {
 					if (acceptLanguage != null) {
 						translateGroupsNames(r, acceptLanguage);
 					}
-					handler.handle(r);
+					promise.complete(r);
 				} else {
 					log.error("An error occurred while fetching visible users for user " + userId, res.cause());
-					handler.handle(new fr.wseduc.webutils.collections.JsonArray());
+					promise.fail(res.cause());
 				}
 			}
 		});
+		return promise.future();
 	}
 
 	public static void translateGroupsNames(JsonArray groups, String acceptLanguage) {
@@ -603,20 +620,30 @@ public class UserUtils {
 		findUsers(eb, request, m, handler);
 	}
 
-	public static Future<JsonArray> areVisible(EventBus eb, String userId, JsonArray checkIds) {
-		final Promise<JsonArray> promise = Promise.promise();
-		JsonObject query = new JsonObject()
-				.put("action", "areVisible")
-				.put("userId", userId)
-				.put("checkIds", checkIds);
-		eb.request(COMMUNICATION_USERS, query, (final AsyncResult<Message<JsonArray>> ar) -> {
-			if (ar.succeeded()) {
-				promise.complete(ar.result().body());
-			} else {
-				promise.fail(ar.cause());
-			}
-		});
-		return promise.future();
+	/**
+	 * Check if a user can communicate with some other (visible) users or groups.
+	 * @param userId  id of the sender
+	 * @param checkIds	ids of the users or groups to check
+	 * @return JsonArray of JsonObjects:
+	 * {
+	 *   id: recipient ID which the sender can communicate with
+	 * }
+	 */
+	public static Future<JsonArray> filterVisibles(EventBus eb, String userId, JsonArray checkIds) {
+		return  (userId == null || checkIds == null || checkIds.isEmpty())
+		  ? Future.succeededFuture(new JsonArray())
+		  : findVisibles(eb, 
+				userId, 
+				" MATCH (visibles) RETURN DISTINCT visibles.id as id ",
+				new JsonObject().put("checkIds", checkIds),
+				false, 
+				true, 
+				false,
+				null, 
+				"AND (m.id IN {checkIds}) ",
+				null,
+				true
+			);
 	};
 
 	public static void getSession(EventBus eb, final HttpServerRequest request,

--- a/communication/src/main/java/org/entcore/communication/controllers/CommunicationController.java
+++ b/communication/src/main/java/org/entcore/communication/controllers/CommunicationController.java
@@ -357,6 +357,15 @@ public class CommunicationController extends BaseController {
 				JsonObject pa = message.body().getJsonObject("additionnalParams");
 				communicationService.visibleManualGroups(userId, cr, pa, responseHandler);
 				break;
+			case "areVisible":
+				final JsonArray checkIds = message.body().getJsonArray("checkIds");
+				communicationService.areVisible(userId, checkIds)
+					.onSuccess( message::reply )
+					.onFailure( throwable -> {
+						log.warn(throwable.getMessage());
+						message.reply(new JsonArray());
+					});
+				break;
 			default:
 				message.reply(new JsonArray());
 				break;

--- a/communication/src/main/java/org/entcore/communication/controllers/CommunicationController.java
+++ b/communication/src/main/java/org/entcore/communication/controllers/CommunicationController.java
@@ -340,8 +340,10 @@ public class CommunicationController extends BaseController {
 				boolean myGroup = communicationService instanceof DefaultCommunicationService ? true :
 						message.body().getBoolean("mygroup", false);
 				boolean profile = message.body().getBoolean("profile", true);
+				String userProfile = message.body().getString("userProfile", null);
+				boolean reverseUnion = message.body().getBoolean("reverseUnion", false);
 				communicationService.visibleUsers(userId, schoolId, expectedTypes, itSelf, myGroup,
-						profile, preFilter, customReturn, ap, responseHandler);
+						profile, preFilter, customReturn, ap, userProfile, reverseUnion, responseHandler);
 				break;
 			case "usersCanSeeMe":
 				communicationService.usersCanSeeMe(userId, responseHandler);
@@ -356,15 +358,6 @@ public class CommunicationController extends BaseController {
 				String cr = message.body().getString("customReturn");
 				JsonObject pa = message.body().getJsonObject("additionnalParams");
 				communicationService.visibleManualGroups(userId, cr, pa, responseHandler);
-				break;
-			case "areVisible":
-				final JsonArray checkIds = message.body().getJsonArray("checkIds");
-				communicationService.areVisible(userId, checkIds)
-					.onSuccess( message::reply )
-					.onFailure( throwable -> {
-						log.warn(throwable.getMessage());
-						message.reply(new JsonArray());
-					});
 				break;
 			default:
 				message.reply(new JsonArray());

--- a/communication/src/main/java/org/entcore/communication/services/CommunicationService.java
+++ b/communication/src/main/java/org/entcore/communication/services/CommunicationService.java
@@ -179,16 +179,5 @@ public interface CommunicationService {
 	 */
 	Future<JsonArray> searchVisibles(UserInfos user, String search, String language);
 
-	/**
-	 * Check if a sender (user) can communicate with some other (visible) recipients.
-	 * @param senderId  id of the sender
-	 * @param checkIds	ids of the recipients to check
-	 * @return JsonArray of JsonObjects:
-	 * {
-	 *   id: recipient ID which the sender can communicate with
-	 * }
-	 */
-	Future<JsonArray> areVisible(String senderId, JsonArray checkIds);
-
 }
 

--- a/communication/src/main/java/org/entcore/communication/services/CommunicationService.java
+++ b/communication/src/main/java/org/entcore/communication/services/CommunicationService.java
@@ -179,5 +179,16 @@ public interface CommunicationService {
 	 */
 	Future<JsonArray> searchVisibles(UserInfos user, String search, String language);
 
+	/**
+	 * Check if a sender (user) can communicate with some other (visible) recipients.
+	 * @param senderId  id of the sender
+	 * @param checkIds	ids of the recipients to check
+	 * @return JsonArray of JsonObjects:
+	 * {
+	 *   id: recipient ID which the sender can communicate with
+	 * }
+	 */
+	Future<JsonArray> areVisible(String senderId, JsonArray checkIds);
+
 }
 

--- a/communication/src/main/java/org/entcore/communication/services/impl/DefaultCommunicationService.java
+++ b/communication/src/main/java/org/entcore/communication/services/impl/DefaultCommunicationService.java
@@ -1180,39 +1180,6 @@ public class DefaultCommunicationService implements CommunicationService {
 
 	}
 
-	@Override
-	public Future<JsonArray> areVisible(String senderId, JsonArray checkIds) {
-		if(senderId == null || checkIds == null || checkIds.isEmpty()) {
-			return Future.succeededFuture(new JsonArray());
-		} else {
-			Promise<Either<String, JsonArray>> getVisiblePromise = Promise.promise();
-			visibleUsers(
-				senderId,
-				null,
-				null,
-				false,
-				true,
-				false,
-				" AND m.id IN {checkIds} ",
-				" MATCH (visibles) RETURN DISTINCT visibles.id as id ",
-				new JsonObject().put("checkIds", checkIds),
-				null,
-				true,
-				getVisiblePromise::complete
-			);
-			return getVisiblePromise.future()
-				.map((Either<String, JsonArray> either) -> {
-					if (either.isLeft()) {
-						String cause = either.left().getValue();
-						log.error(cause);
-						throw new RuntimeException(cause);
-					}
-					return either.right().getValue();
-				});
-		}
-	}
-
-
 	/**
 	 * Return the list of users, with filtering on the structures, profiles and search
 	 * */

--- a/communication/src/main/java/org/entcore/communication/services/impl/DefaultCommunicationService.java
+++ b/communication/src/main/java/org/entcore/communication/services/impl/DefaultCommunicationService.java
@@ -1203,9 +1203,11 @@ public class DefaultCommunicationService implements CommunicationService {
 			return getVisiblePromise.future()
 				.map((Either<String, JsonArray> either) -> {
 					if (either.isLeft()) {
-						log.error(either.left().getValue());
+						String cause = either.left().getValue();
+						log.error(cause);
+						throw new RuntimeException(cause);
 					}
-					return either.isLeft() ? new JsonArray() : either.right().getValue();
+					return either.right().getValue();
 				});
 		}
 	}

--- a/directory/src/main/java/org/entcore/directory/Directory.java
+++ b/directory/src/main/java/org/entcore/directory/Directory.java
@@ -192,7 +192,7 @@ public class Directory extends BaseServer {
 		addController(timetableController);
 
         ShareBookmarkController shareBookmarkController = new ShareBookmarkController();
-        shareBookmarkController.setShareBookmarkService(new DefaultShareBookmarkService());
+        shareBookmarkController.setShareBookmarkService(new DefaultShareBookmarkService(eb));
         addController(shareBookmarkController);
 
         SlotProfileController slotProfileController = new SlotProfileController(SLOTPROFILE_COLLECTION);

--- a/directory/src/main/java/org/entcore/directory/controllers/ShareBookmarkController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/ShareBookmarkController.java
@@ -110,7 +110,7 @@ public class ShareBookmarkController extends BaseController {
 
 							// Check bookmarked members' visibility
 							final Set<String> membersMapIds = membersMap.keySet();
-							UserUtils.areVisible(
+							UserUtils.filterVisibles(
 								eb, 
 								user.getUserId(),
 								new JsonArray( membersMapIds.stream().collect(Collectors.toList()) )

--- a/directory/src/main/java/org/entcore/directory/controllers/ShareBookmarkController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/ShareBookmarkController.java
@@ -30,12 +30,20 @@ import fr.wseduc.webutils.http.BaseController;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+
 import org.entcore.common.http.filter.AdminFilter;
 import org.entcore.common.http.filter.ResourceFilter;
 import org.entcore.common.user.UserUtils;
 import org.entcore.directory.services.ShareBookmarkService;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import static fr.wseduc.webutils.request.RequestUtils.bodyToJson;
+
 import static org.entcore.common.http.response.DefaultResponseHandler.*;
 
 public class ShareBookmarkController extends BaseController {
@@ -77,25 +85,62 @@ public class ShareBookmarkController extends BaseController {
 					shareBookmarkService.list(user.getUserId(), arrayResponseHandler(request));
 				} else {
 					shareBookmarkService.get(user.getUserId(), id, r -> {
-						if (r.isRight()) {
-							final JsonObject res = r.right().getValue();
-							JsonArray members = res.getJsonArray("members");
-							if (members == null || members.isEmpty()) {
-								shareBookmarkService.delete(user.getUserId(), id, dres -> {
-									if (dres.isLeft()) {
-										log.error("Error deleting sharebookmark " + id + " : " + dres.left().getValue());
-									}
-								});
-								notFound(request, "empty.sharebookmark");
-								return;
-							}
-							res.mergeIn(UserUtils.translateAndGroupVisible(
-									members, I18n.acceptLanguage(request), true)
-							);
-							res.remove("members");
-							renderJson(request, res);
-						} else {
+						if (r.isLeft()) {
 							leftToResponse(request, r.left());
+							return;
+						}
+
+						final JsonObject res = r.right().getValue();
+						final JsonArray members = res.getJsonArray("members");
+
+						if (members == null || members.isEmpty()) {
+							// Clean empty Bookmark
+							shareBookmarkService.delete(user.getUserId(), id, dres -> {
+								if (dres.isLeft()) {
+									log.error("Error deleting sharebookmark " + id + " : " + dres.left().getValue());
+								}
+							});
+							notFound(request, "empty.sharebookmark");
+						} else {
+							// Map members by their ID
+							Map<String, JsonObject> membersMap = new HashMap(members.size());
+							members.stream()
+								.map(JsonObject.class::cast)
+								.forEach(member -> membersMap.put(member.getString("id"), member));
+
+							// Check bookmarked members' visibility
+							final Set<String> membersMapIds = membersMap.keySet();
+							UserUtils.areVisible(
+								eb, 
+								user.getUserId(),
+								new JsonArray( membersMapIds.stream().collect(Collectors.toList()) )
+							)
+							.onSuccess( visibleInfos -> {
+								List<String> visibleIds = visibleInfos.stream()
+									.map(JsonObject.class::cast)
+									.map(jo -> jo.getString("id"))
+									.collect(Collectors.toList());
+								// Keep only visible users, in the *membersMap*
+								membersMapIds.retainAll(visibleIds);
+								// Update members array
+								members.clear();
+								membersMap.values().stream().forEach( member -> members.add(member) );
+							})
+							.onComplete( ar -> {
+								if (members.isEmpty()) {
+									// Clean empty Bookmark
+									shareBookmarkService.delete(user.getUserId(), id, dres -> {
+										if (dres.isLeft()) {
+											log.error("Error deleting sharebookmark " + id + " : " + dres.left().getValue());
+										}
+									});
+									notFound(request, "empty.sharebookmark");
+								} else {
+									res.mergeIn(UserUtils.translateAndGroupVisible(members, I18n.acceptLanguage(request), true));
+									res.remove("members");
+									renderJson(request, res);
+								}
+							});
 						}
 					});
 				}

--- a/directory/src/main/java/org/entcore/directory/services/ShareBookmarkService.java
+++ b/directory/src/main/java/org/entcore/directory/services/ShareBookmarkService.java
@@ -32,7 +32,7 @@ public interface ShareBookmarkService {
 
 	void delete(String userId, String id, Handler<Either<String, JsonObject>> handler);
 
-	void get(String userId, String id, Handler<Either<String, JsonObject>> handler);
+	void get(String userId, String id, boolean onlyVisibles, Handler<Either<String, JsonObject>> handler);
 
 	void list(String userId, Handler<Either<String, JsonArray>> handler);
 


### PR DESCRIPTION
# Description

Si les règles de communication ont été modifiées, et qu'un groupe ou un utilisateur dans mes favoris de partage n'est plus visible,
alors la requête `GET /directory/sharebookmark/:bookmarkId` ne doit plus retourner ces users ou groupes non-visibles.

## Fixes

[WB-4022](https://edifice-community.atlassian.net/browse/WB-4022)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [X] common
- [X] communication
- [ ] conversation
- [X] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley:

[WB-4022]: https://edifice-community.atlassian.net/browse/WB-4022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ