### PR TITLE
feat(conversation): #WB-4163, hide unwanted data from RECALL messages

### DIFF
--- a/conversation/frontend/src/components/MessageActionDropdown/hooks/useMessageActionDropdown.tsx
+++ b/conversation/frontend/src/components/MessageActionDropdown/hooks/useMessageActionDropdown.tsx
@@ -59,6 +59,8 @@ export function useMessageActionDropdown({
   const { user } = useEdificeClient();
   const { success } = useToast();
 
+  const isFromMe = message.from.id === user?.userId;
+
   // Hidden condition's
   const isInFolder = useMemo(() => {
     if (folderId && ['trash', 'inbox', 'outbox'].includes(folderId)) return;
@@ -66,8 +68,11 @@ export function useMessageActionDropdown({
   }, [folderId]);
 
   const canTransfer = useMemo(() => {
-    return message.state !== 'DRAFT' && message.trashed !== true;
-  }, [message.state, message.trashed]);
+    return (
+      (message.state === 'SENT' || (message.state === 'RECALL' && isFromMe)) &&
+      message.trashed !== true
+    );
+  }, [isFromMe, message.state, message.trashed]);
 
   const canReply = useMemo(() => {
     return message.state === 'SENT' && message.trashed !== true;


### PR DESCRIPTION
# Description

* Modifier l'objet du message uniquement pour le/les destinataire.s en "Ce message a été rappelé";
Le backend nettoie le sujet du message, et les front devront mettre la traduction adéquate (pourrait être différente entre web et mobile) 
* Si le message a été envoyé à plusieurs personnes, le destinataire ne doit voir plus que lui dans les destinataires et pas les autres;
* Supprimer les pièces jointes pour les destinataires uniquement.

Par effet de bord, cela masquera les PJs côté front pour les destinataires de messages rappelés
+ petit fix sur les actions visibles dans ce cas-là (pour revue par @damienromito :pray: )

## Fixes

[COCO-4163](https://edifice-community.atlassian.net/browse/WB-4163)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [X] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

dumb manual test

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley:

[COCO-4163]: https://edifice-community.atlassian.net/browse/COCO-4163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ