### PR TITLE
Feat: #pedago-2770, get display names from broker

### DIFF
--- a/broker-parent/broker-api/src/main/java/org/entcore/broker/api/dto/directory/GetUserDisplayNamesRequestDTO.java
+++ b/broker-parent/broker-api/src/main/java/org/entcore/broker/api/dto/directory/GetUserDisplayNamesRequestDTO.java
@@ -1,0 +1,34 @@
+package org.entcore.broker.api.dto.directory;
+
+import java.util.List;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+/**
+ * DTO for requesting user display names by their ENT IDs.
+ */
+public class GetUserDisplayNamesRequestDTO {
+    private final List<String> userIds;
+
+    @JsonCreator
+    public GetUserDisplayNamesRequestDTO(@JsonProperty("userIds") List<String> userIds) {
+        this.userIds = userIds;
+    }
+
+    public List<String> getUserIds() {
+        return userIds;
+    }
+
+    /**
+     * Validates that the request contains the necessary data.
+     * @return true if the request is valid, false otherwise
+     */
+    public boolean isValid() {
+        return userIds != null && !userIds.isEmpty();
+    }
+
+    public String toString() {
+        return "GetUserDisplayNamesRequestDTO{" +
+                "userIds=" + userIds +
+                '}';
+    }
+}

--- a/broker-parent/broker-api/src/main/java/org/entcore/broker/api/dto/directory/GetUserDisplayNamesResponseDTO.java
+++ b/broker-parent/broker-api/src/main/java/org/entcore/broker/api/dto/directory/GetUserDisplayNamesResponseDTO.java
@@ -1,0 +1,27 @@
+package org.entcore.broker.api.dto.directory;
+
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * DTO for responding with user display names mapped to their ENT IDs.
+ */
+public class GetUserDisplayNamesResponseDTO {
+    private final Map<String, String> userDisplayNames;
+
+    @JsonCreator
+    public GetUserDisplayNamesResponseDTO(@JsonProperty("userDisplayNames") Map<String, String> userDisplayNames) {
+        this.userDisplayNames = userDisplayNames;
+    }
+
+    public Map<String, String> getUserDisplayNames() {
+        return userDisplayNames;
+    }
+
+    public String toString() {
+        return "GetUserDisplayNamesResponseDTO{" +
+                "userDisplayNames=" + userDisplayNames +
+                '}';
+    }
+}

--- a/broker-parent/broker-client/ts/package.json
+++ b/broker-parent/broker-client/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edifice.io/edifice-ent-client",
-  "version": "1.0.1-develop.20250512172231",
+  "version": "1.0.1-develop.20250522172231",
   "description": "Clients to interact with ENT service",
   "scripts": {
     "dev": "vite",

--- a/broker-parent/broker-client/ts/src/nats/ent-nats-service.client.ts
+++ b/broker-parent/broker-client/ts/src/nats/ent-nats-service.client.ts
@@ -9,6 +9,7 @@ import { DeleteGroupRequestDTO } from './ent-nats-service.types';
 import { AddGroupMemberRequestDTO } from './ent-nats-service.types';
 import { RemoveGroupMemberRequestDTO } from './ent-nats-service.types';
 import { FindGroupByExternalIdRequestDTO } from './ent-nats-service.types';
+import { GetUserDisplayNamesRequestDTO } from './ent-nats-service.types';
 import { AppRegistrationRequestDTO } from './ent-nats-service.types';
 import { FetchTranslationsRequestDTO } from './ent-nats-service.types';
 import { RegisterTranslationFilesRequestDTO } from './ent-nats-service.types';
@@ -21,6 +22,7 @@ import { DeleteGroupResponseDTO } from './ent-nats-service.types';
 import { AddGroupMemberResponseDTO } from './ent-nats-service.types';
 import { RemoveGroupMemberResponseDTO } from './ent-nats-service.types';
 import { FindGroupByExternalIdResponseDTO } from './ent-nats-service.types';
+import { GetUserDisplayNamesResponseDTO } from './ent-nats-service.types';
 import { AppRegistrationResponseDTO } from './ent-nats-service.types';
 import { FetchTranslationsResponseDTO } from './ent-nats-service.types';
 import { RegisterTranslationFilesResponseDTO } from './ent-nats-service.types';
@@ -124,6 +126,16 @@ export class EntNatsServiceClient {
       throw new Error('No reply received');
     }
     return JSON.parse(reply) as FindGroupByExternalIdResponseDTO;
+  }
+        
+  
+  async directoryUsersGetDisplaynames(event: GetUserDisplayNamesRequestDTO): Promise<GetUserDisplayNamesResponseDTO> {
+    const eventAddress = this.getSubject(`directory.users.get.displaynames`);
+    const reply = await firstValueFrom(this.natsClient.send(eventAddress, event));
+    if(!reply) {
+      throw new Error('No reply received');
+    }
+    return JSON.parse(reply) as GetUserDisplayNamesResponseDTO;
   }
         
   

--- a/broker-parent/broker-client/ts/src/nats/ent-nats-service.types.ts
+++ b/broker-parent/broker-client/ts/src/nats/ent-nats-service.types.ts
@@ -162,9 +162,20 @@ export interface GroupDTO {
   name?: string;
 }
 
+export interface GetUserDisplayNamesRequestDTO {
+  userIds?: string[];
+}
+
+
+export interface GetUserDisplayNamesResponseDTO {
+  userDisplayNames?: {
+    [k: string]: string;
+  };
+}
+
 export interface AppRegistrationRequestDTO {
   application?: AppRegistrationDTO;
-  actions?: SecuredAction[];
+  actions?: SecuredActionDTO[];
 }
 export interface AppRegistrationDTO {
   name?: string;
@@ -178,7 +189,7 @@ export interface AppRegistrationDTO {
     [k: string]: {};
   };
 }
-export interface SecuredAction {
+export interface SecuredActionDTO {
   name?: string;
   displayName?: string;
   type?: string;
@@ -192,7 +203,7 @@ export interface AppRegistrationResponseDTO {
 
 export interface AppRegistrationRequestDTO {
   application?: AppRegistrationDTO;
-  actions?: SecuredAction[];
+  actions?: SecuredActionDTO[];
 }
 export interface AppRegistrationDTO {
   name?: string;
@@ -206,7 +217,7 @@ export interface AppRegistrationDTO {
     [k: string]: {};
   };
 }
-export interface SecuredAction {
+export interface SecuredActionDTO {
   name?: string;
   displayName?: string;
   type?: string;

--- a/broker-parent/broker-client/ts/src/nats/index.ts
+++ b/broker-parent/broker-client/ts/src/nats/index.ts
@@ -18,6 +18,8 @@ export type { RemoveGroupMemberRequestDTO } from './ent-nats-service.types';
 export type { RemoveGroupMemberResponseDTO } from './ent-nats-service.types';
 export type { FindGroupByExternalIdRequestDTO } from './ent-nats-service.types';
 export type { FindGroupByExternalIdResponseDTO } from './ent-nats-service.types';
+export type { GetUserDisplayNamesRequestDTO } from './ent-nats-service.types';
+export type { GetUserDisplayNamesResponseDTO } from './ent-nats-service.types';
 export type { AppRegistrationRequestDTO } from './ent-nats-service.types';
 export type { AppRegistrationResponseDTO } from './ent-nats-service.types';
 export type { FetchTranslationsRequestDTO } from './ent-nats-service.types';

--- a/broker-parent/broker-proxy/src/main/java/org/entcore/broker/proxy/DirectoryBrokerListener.java
+++ b/broker-parent/broker-proxy/src/main/java/org/entcore/broker/proxy/DirectoryBrokerListener.java
@@ -54,4 +54,12 @@ public interface DirectoryBrokerListener {
    */
   @BrokerListener(subject = "directory.group.find.byexternalid", proxy = true)
   Future<FindGroupByExternalIdResponseDTO> findGroupByExternalId(FindGroupByExternalIdRequestDTO request);
+
+  /**
+   * This method retrieves display names for multiple users by their ENT IDs.
+   * @param request The request object containing the list of user IDs to look up.
+   * @return A response object containing a map of user IDs to their display names.
+   */
+  @BrokerListener(subject = "directory.users.get.displaynames", proxy = true)
+  Future<GetUserDisplayNamesResponseDTO> getUserDisplayNames(GetUserDisplayNamesRequestDTO request);
 }

--- a/directory/src/main/java/org/entcore/directory/Directory.java
+++ b/directory/src/main/java/org/entcore/directory/Directory.java
@@ -67,7 +67,6 @@ public class Directory extends BaseServer {
 	public void start(final Promise<Void> startPromise) throws Exception {
 		final EventBus eb = getEventBus(vertx);
 		super.start(startPromise);
-		BrokerProxyUtils.addBrokerProxy(new DirectoryBrokerListenerImpl(vertx), vertx);
 		MongoDbConf.getInstance().setCollection(SLOTPROFILE_COLLECTION);
 		setDefaultResourceFilter(new DirectoryResourcesProvider());
 
@@ -210,7 +209,7 @@ public class Directory extends BaseServer {
 			addController(remoteUserController);
 		}
 		// add the directory broker listener
-		BrokerProxyUtils.addBrokerProxy(new DirectoryBrokerListenerImpl(vertx), vertx);
+		BrokerProxyUtils.addBrokerProxy(new DirectoryBrokerListenerImpl(vertx, userService), vertx);
 
 	}
 


### PR DESCRIPTION
# Description

Ce fix ajoute la possibilité de récupérer les display name depuis le broker

## Fixes

#pedago-2770

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [X] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results
Les tests sont dans community

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley: