### PR TITLE
Feat/coco 4198

### DIFF
--- a/conversation/backend/src/main/java/org/entcore/conversation/Conversation.java
+++ b/conversation/backend/src/main/java/org/entcore/conversation/Conversation.java
@@ -48,6 +48,8 @@ public class Conversation extends BaseServer {
 	public final static int DEFAULT_FOLDER_DEPTH = 3;
 	/** Default delay in minutes after which a message can not be recalled. */
 	public final static int DEFAULT_RECALL_DELAY = 60;
+	/** Default strategy for getting visible contacts. */
+	public final static String DEFAULT_GET_VISIBLE_STRATEGY = "all-at-once"; /* other expected value is "filtered" */
 
 	@Override
 	public void start(final Promise<Void> startPromise) throws Exception {

--- a/conversation/backend/src/main/java/org/entcore/conversation/controllers/ConversationController.java
+++ b/conversation/backend/src/main/java/org/entcore/conversation/controllers/ConversationController.java
@@ -1182,13 +1182,14 @@ public class ConversationController extends BaseController {
 		});
 	}
 
-	//Get max folder depth
+	//Get max folder depth and other parameters
 	@Get("max-depth")
 	@SecuredAction(value="conversation.max.depth", type=ActionType.AUTHENTICATED)
 	public void getMaxDepth(final HttpServerRequest request){
 		renderJson(request, new JsonObject()
 			.put("max-depth", Config.getConf().getInteger("max-folder-depth", Conversation.DEFAULT_FOLDER_DEPTH))
 			.put("recall-delay-minutes", Config.getConf().getInteger("recall-delay-minutes", Conversation.DEFAULT_RECALL_DELAY))
+			.put("get-visible-strategy", Config.getConf().getString("get-visible-strategy", Conversation.DEFAULT_GET_VISIBLE_STRATEGY))
 		);
 	}
 

--- a/conversation/frontend/src/config/Config.ts
+++ b/conversation/frontend/src/config/Config.ts
@@ -1,4 +1,5 @@
 export interface Config {
   maxDepth: number;
   recallDelayMinutes: number;
+  getVisibleStrategy: 'all-at-once' | 'filtered';
 }

--- a/conversation/frontend/src/mocks/index.ts
+++ b/conversation/frontend/src/mocks/index.ts
@@ -3,9 +3,11 @@ import { Folder, Message, MessageMetadata, User } from '~/models';
 export const mockConfiguration: {
   'max-depth': number;
   'recall-delay-minutes': number;
+  'get-visible-strategy': 'all-at-once' | 'filtered';
 } = {
   'max-depth': 2,
   'recall-delay-minutes': 60,
+  'get-visible-strategy': 'all-at-once',
 };
 
 export const mockCurrentUserPreview: User = {

--- a/conversation/frontend/src/services/api/configService.test.ts
+++ b/conversation/frontend/src/services/api/configService.test.ts
@@ -8,6 +8,7 @@ describe('Conversation Configuration GET Methods', () => {
     expect(response).toBeDefined();
     expect(response).toHaveProperty('max-depth');
     expect(response).toHaveProperty('recall-delay-minutes');
+    expect(response).toHaveProperty('get-visible-strategy');
     expect(response).toStrictEqual(mockConfiguration);
   });
 

--- a/conversation/frontend/src/services/api/configService.ts
+++ b/conversation/frontend/src/services/api/configService.ts
@@ -17,6 +17,7 @@ export const createConfigService = (baseURL: string) => ({
     return odeServices.http().get<{
       'max-depth': number;
       'recall-delay-minutes': number;
+      'get-visible-strategy': 'all-at-once' | 'filtered';
     }>(`${baseURL}/max-depth`);
   },
 

--- a/conversation/frontend/src/services/api/userService.ts
+++ b/conversation/frontend/src/services/api/userService.ts
@@ -66,12 +66,15 @@ export const createUserService = () => {
      * @param search search string
      * @returns a list of Visible objects
      */
-    searchVisible(search: string) {
-      return odeServices
-        .http()
-        .get<Visible[]>(`/communication/visible/search`, {
-          queryParams: { query: search },
-        });
+    searchVisible(search?: string) {
+      return odeServices.http().get<Visible[]>(
+        `/communication/visible/search`,
+        typeof search === 'string'
+          ? {
+              queryParams: { query: search },
+            }
+          : undefined,
+      );
     },
 
     /**

--- a/conversation/frontend/src/services/queries/config.ts
+++ b/conversation/frontend/src/services/queries/config.ts
@@ -6,6 +6,7 @@ import {
 } from '@tanstack/react-query';
 import { configService } from '..';
 import { SignaturePreferences } from '~/models/signature';
+import { Config } from '~/config';
 
 /**
  * Provides query options for config-related operations.
@@ -23,7 +24,7 @@ export const configQueryOptions = {
   getGlobalConfig() {
     return queryOptions({
       queryKey: [...configQueryOptions.base, 'global'] as const,
-      queryFn: async () => {
+      queryFn: async (): Promise<Config> => {
         const data = await configService.getGlobalConfig();
         return {
           maxDepth: data['max-depth'] ?? 2,

--- a/conversation/frontend/src/services/queries/config.ts
+++ b/conversation/frontend/src/services/queries/config.ts
@@ -28,6 +28,7 @@ export const configQueryOptions = {
         return {
           maxDepth: data['max-depth'] ?? 2,
           recallDelayMinutes: data['recall-delay-minutes'] ?? 60,
+          getVisibleStrategy: data['get-visible-strategy'] ?? 'all-at-once',
         };
       },
       staleTime: Infinity,

--- a/conversation/frontend/src/services/queries/user.ts
+++ b/conversation/frontend/src/services/queries/user.ts
@@ -1,18 +1,28 @@
+import { odeServices } from '@edifice.io/client';
+import { useIsAdml } from '@edifice.io/react';
 import { queryOptions, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Config } from '~/config';
+import { Visible } from '~/models/visible';
 import { userService } from '~/services';
+import { useConfig } from '~/store';
 
 export const userQueryOptions = {
   base: ['user'] as const,
 
   /**
-   * Get the list of visible users
+   * Get a filtered list of visible users. Filtering is done by the *backend*.
    * @param search The search string to filter the users
    * @returns The query options for the search visible users
    */
-  searchVisible(search: string) {
+  searchVisible(search?: string) {
     return queryOptions({
-      queryKey: [...userQueryOptions.base, 'search', { search }] as const,
+      queryKey: [
+        ...userQueryOptions.base,
+        'search',
+        search ? { search } : undefined,
+      ] as const,
       queryFn: () => userService.searchVisible(search),
+      staleTime: Infinity, // This data will never change during user's session.
     });
   },
 
@@ -29,6 +39,7 @@ export const userQueryOptions = {
         { id, type: 'User' },
       ] as const,
       queryFn: () => userService.getVisibleById(id, 'User'),
+      staleTime: Infinity, // This data will never change during user's session.
     });
   },
 
@@ -46,6 +57,7 @@ export const userQueryOptions = {
         { id, type: 'Group' },
       ] as const,
       queryFn: () => userService.getVisibleById(id, 'Group'),
+      staleTime: Infinity, // This data will never change during user's session.
     });
   },
 
@@ -57,6 +69,7 @@ export const userQueryOptions = {
     return queryOptions({
       queryKey: [...userQueryOptions.base, 'bookmarks'] as const,
       queryFn: () => userService.getBookmarks(),
+      staleTime: Infinity, // This data will never change during user's session.
     });
   },
 
@@ -69,9 +82,52 @@ export const userQueryOptions = {
     return queryOptions({
       queryKey: [...userQueryOptions.base, 'bookmark', id] as const,
       queryFn: () => userService.getBookMarkById(id),
+      staleTime: Infinity, // This data will never change during user's session.
     });
   },
 };
+
+/** Apply filtering rules during visible searches. */
+function applySearchRules(
+  isAdml: boolean,
+  getVisibleStrategy: Config['getVisibleStrategy'],
+  search: string,
+) {
+  // Do not search unless at least 3 characters are typed in.
+  if (!search || search.length < 3) {
+    return { triggerSearch: false };
+  }
+
+  const backendFiltering = 'all-at-once' !== getVisibleStrategy || isAdml;
+  const startText = backendFiltering ? search.substring(0, 3) : undefined;
+  const frontendFiltering = !backendFiltering || search.length > 3;
+  function computeFrontendFilter() {
+    const removeAccents = odeServices.idiom().removeAccents;
+    const searchTerm = removeAccents(search).toLowerCase();
+    return !frontendFiltering
+      ? undefined
+      : (user: Visible) => {
+          let testDisplayName = '',
+            testNameReversed = '';
+          if (user.displayName) {
+            testDisplayName = removeAccents(user.displayName).toLowerCase();
+            const split = testDisplayName.split(' ');
+            testNameReversed =
+              split.length > 1 ? split[1] + ' ' + split[0] : testDisplayName;
+          }
+          return (
+            testDisplayName.indexOf(searchTerm) !== -1 ||
+            testNameReversed.indexOf(searchTerm) !== -1
+          );
+        };
+  }
+
+  return {
+    triggerSearch: true,
+    backendFilter: startText,
+    frontendFilter: computeFrontendFilter(),
+  };
+}
 
 /**
  * Hook to get the list of visible users
@@ -80,9 +136,26 @@ export const userQueryOptions = {
  */
 export const useSearchVisible = () => {
   const queryClient = useQueryClient();
+  const { getVisibleStrategy } = useConfig();
+  const { isAdml } = useIsAdml();
 
-  const searchVisible = (search: string) => {
-    return queryClient.ensureQueryData(userQueryOptions.searchVisible(search));
+  const searchVisible = async (search: string) => {
+    const { triggerSearch, backendFilter, frontendFilter } = applySearchRules(
+      isAdml,
+      getVisibleStrategy,
+      search,
+    );
+
+    if (triggerSearch) {
+      const startVisible = await queryClient.ensureQueryData(
+        userQueryOptions.searchVisible(backendFilter),
+      );
+      return frontendFilter
+        ? startVisible.filter(frontendFilter)
+        : startVisible;
+    } else {
+      return Promise.resolve([]);
+    }
   };
 
   const getVisibleUserById = (id: string) => {


### PR DESCRIPTION
# Description

* ajout d'un feature flag
* adaptation front pour suivre la stratégie de requêtage des visibles comme indiqué par le feature flag
  `all-at-once` : le frontend récupère la liste de tous les contacts visibles, et fait le tri.
  `filtered`: le tri est fait côté backend.
Pour les profils ADML, la stratégie `filtered` est appliquée par défaut. Un minimum de 3 caractères est requis.

## Fixes

https://edifice-community.atlassian.net/browse/COCO-4198

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: