### PR TITLE
fix(conversation): #COCO-4203 messages invalidations and query cache

### DIFF
--- a/conversation/frontend/src/components/MessageActionDropdown/hooks/useMessageActionDropdown.tsx
+++ b/conversation/frontend/src/components/MessageActionDropdown/hooks/useMessageActionDropdown.tsx
@@ -31,6 +31,7 @@ import {
   useTrashMessage,
 } from '~/services';
 import { useAppActions, useConfirmModalStore } from '~/store';
+import { useMessageActions } from '~/store/messageStore';
 
 export interface MessageActionDropdownProps {
   message: Message;
@@ -44,6 +45,7 @@ export function useMessageActionDropdown({
   actions,
 }: MessageActionDropdownProps) {
   const { t } = useI18n();
+  const { setMessageNeedToSave } = useMessageActions();
   const markAsUnreadQuery = useMarkUnread();
   const navigate = useNavigate();
   const { openModal } = useConfirmModalStore();
@@ -153,6 +155,7 @@ export function useMessageActionDropdown({
 
   const handleDraftSaveClick = async () => {
     await createOrUpdateDraft(true);
+    setMessageNeedToSave(false);
     navigate('/inbox');
   };
 

--- a/conversation/frontend/src/features/message-edit/MessageEdit.tsx
+++ b/conversation/frontend/src/features/message-edit/MessageEdit.tsx
@@ -12,7 +12,6 @@ import { MessageSaveDate } from './components/MessageSaveDate';
 import { useAutoSaveMessage } from './hooks/useAutoSaveMessage';
 
 export function MessageEdit({ message }: { message?: Message }) {
-  console.log('message:', message);
   const { t } = useI18n();
   const [subject, setSubject] = useState(message?.subject);
   const { setMessage, setMessageNeedToSave } = useMessageActions();

--- a/conversation/frontend/src/features/message-edit/MessageEdit.tsx
+++ b/conversation/frontend/src/features/message-edit/MessageEdit.tsx
@@ -1,24 +1,23 @@
-import { FormControl, Input, useDate, useDebounce } from '@edifice.io/react';
-import { useEffect, useRef, useState } from 'react';
+import { FormControl, Input } from '@edifice.io/react';
+import { useEffect, useState } from 'react';
 import { MessageActionDropdown } from '~/components/MessageActionDropdown/MessageActionDropdown';
 import { MessageBody } from '~/components/MessageBody';
 import { useI18n } from '~/hooks/useI18n';
 import { useMessageIdAndAction } from '~/hooks/useMessageIdAndAction';
 import { Message } from '~/models';
-import { useConversationConfig, useCreateOrUpdateDraft } from '~/services';
-import { useMessageActions, useMessageNeedToSave } from '~/store/messageStore';
+import { useCreateOrUpdateDraft } from '~/services';
+import { useMessageActions } from '~/store/messageStore';
 import { MessageEditHeader } from './components/MessageEditHeader';
+import { MessageSaveDate } from './components/MessageSaveDate';
+import { useAutoSaveMessage } from './hooks/useAutoSaveMessage';
 
 export function MessageEdit({ message }: { message?: Message }) {
+  console.log('message:', message);
   const { t } = useI18n();
   const [subject, setSubject] = useState(message?.subject);
-  const messageUpdatedNeedSave = useMessageNeedToSave();
   const { setMessage, setMessageNeedToSave } = useMessageActions();
-  const { fromNow } = useDate();
-  const debounceTimeToSave = useRef(3000);
   const createOrUpdateDraft = useCreateOrUpdateDraft();
-  const [dateKey, setDateKey] = useState(0);
-  const { data: publicConfig } = useConversationConfig();
+  useAutoSaveMessage();
   const { action } = useMessageIdAndAction();
   const isTransferAction = action === 'transfer';
 
@@ -34,11 +33,6 @@ export function MessageEdit({ message }: { message?: Message }) {
     setMessageNeedToSave(true);
   };
 
-  const messageUpdatedNeedSaveDebounced = useDebounce(
-    messageUpdatedNeedSave,
-    debounceTimeToSave.current,
-  );
-
   useEffect(() => {
     // Automatically create draft when this is a transfer action
     // so the attachments are transferred to the new message
@@ -46,26 +40,7 @@ export function MessageEdit({ message }: { message?: Message }) {
     if (message && !message.id && isTransferAction) {
       createOrUpdateDraft();
     }
-
-    const interval = setInterval(() => setDateKey((prev) => ++prev), 6000);
-
-    return () => clearInterval(interval);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  useEffect(() => {
-    if (publicConfig && publicConfig['debounce-time-to-auto-save']) {
-      debounceTimeToSave.current = publicConfig['debounce-time-to-auto-save'];
-    }
-  }, [publicConfig]);
-
-  useEffect(() => {
-    if (messageUpdatedNeedSaveDebounced) {
-      createOrUpdateDraft();
-      setMessageNeedToSave(false);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [messageUpdatedNeedSaveDebounced]);
 
   return (
     <>
@@ -98,11 +73,7 @@ export function MessageEdit({ message }: { message?: Message }) {
                 }}
                 className="gap-12"
               />
-              {message?.date && (
-                <div className="caption fst-italic" key={dateKey}>
-                  {t('message.saved') + ' ' + fromNow(message.date)}
-                </div>
-              )}
+              <MessageSaveDate />
             </div>
           </div>
         </div>

--- a/conversation/frontend/src/features/message-edit/components/MessageSaveDate.tsx
+++ b/conversation/frontend/src/features/message-edit/components/MessageSaveDate.tsx
@@ -10,7 +10,7 @@ export const MessageSaveDate = () => {
   const [dateKey, setDateKey] = useState(0);
 
   useEffect(() => {
-    const interval = setInterval(() => setDateKey((prev) => ++prev), 60000);
+    const interval = setInterval(() => setDateKey((prev) => ++prev), 10000);
     return () => clearInterval(interval);
   }, []);
 

--- a/conversation/frontend/src/features/message-edit/components/MessageSaveDate.tsx
+++ b/conversation/frontend/src/features/message-edit/components/MessageSaveDate.tsx
@@ -1,0 +1,26 @@
+import { useDate } from '@edifice.io/react';
+import { useEffect, useState } from 'react';
+import { useI18n } from '~/hooks/useI18n';
+import { useMessage } from '~/store/messageStore';
+
+export const MessageSaveDate = () => {
+  const { fromNow } = useDate();
+  const { t } = useI18n();
+  const message = useMessage();
+  const [dateKey, setDateKey] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => setDateKey((prev) => ++prev), 60000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    message?.date && (
+      <div className="caption fst-italic" key={dateKey}>
+        {t('message.saved') + ' ' + fromNow(message.date)}
+      </div>
+    )
+  );
+};
+
+export default MessageSaveDate;

--- a/conversation/frontend/src/features/message-edit/hooks/useAutoSaveMessage.tsx
+++ b/conversation/frontend/src/features/message-edit/hooks/useAutoSaveMessage.tsx
@@ -24,6 +24,7 @@ export const useAutoSaveMessage = () => {
 
   useEffect(() => {
     if (messageUpdatedNeedSaveDebounced && messageUpdatedNeedSave) {
+      console.log('Will Save:');
       createOrUpdateDraft();
       setMessageNeedToSave(false);
     }

--- a/conversation/frontend/src/features/message-edit/hooks/useAutoSaveMessage.tsx
+++ b/conversation/frontend/src/features/message-edit/hooks/useAutoSaveMessage.tsx
@@ -1,4 +1,4 @@
-import { useMessageActions } from '~/store/messageStore';
+import { useMessage, useMessageActions } from '~/store/messageStore';
 import { useDebounce } from '@edifice.io/react';
 import { useEffect, useRef } from 'react';
 import { useConversationConfig, useCreateOrUpdateDraft } from '~/services';
@@ -9,10 +9,10 @@ export const useAutoSaveMessage = () => {
   const messageUpdatedNeedSave = useMessageNeedToSave();
   const createOrUpdateDraft = useCreateOrUpdateDraft();
   const { setMessageNeedToSave } = useMessageActions();
-
+  const message = useMessage();
   const debounceTimeToSave = useRef(3000);
   const messageUpdatedNeedSaveDebounced = useDebounce(
-    messageUpdatedNeedSave,
+    message,
     debounceTimeToSave.current,
   );
 
@@ -23,7 +23,7 @@ export const useAutoSaveMessage = () => {
   }, [publicConfig]);
 
   useEffect(() => {
-    if (messageUpdatedNeedSaveDebounced) {
+    if (messageUpdatedNeedSaveDebounced && messageUpdatedNeedSave) {
       createOrUpdateDraft();
       setMessageNeedToSave(false);
     }

--- a/conversation/frontend/src/features/message-edit/hooks/useAutoSaveMessage.tsx
+++ b/conversation/frontend/src/features/message-edit/hooks/useAutoSaveMessage.tsx
@@ -1,0 +1,32 @@
+import { useMessageActions } from '~/store/messageStore';
+import { useDebounce } from '@edifice.io/react';
+import { useEffect, useRef } from 'react';
+import { useConversationConfig, useCreateOrUpdateDraft } from '~/services';
+import { useMessageNeedToSave } from '~/store/messageStore';
+
+export const useAutoSaveMessage = () => {
+  const { data: publicConfig } = useConversationConfig();
+  const messageUpdatedNeedSave = useMessageNeedToSave();
+  const createOrUpdateDraft = useCreateOrUpdateDraft();
+  const { setMessageNeedToSave } = useMessageActions();
+
+  const debounceTimeToSave = useRef(3000);
+  const messageUpdatedNeedSaveDebounced = useDebounce(
+    messageUpdatedNeedSave,
+    debounceTimeToSave.current,
+  );
+
+  useEffect(() => {
+    if (publicConfig && publicConfig['debounce-time-to-auto-save']) {
+      debounceTimeToSave.current = publicConfig['debounce-time-to-auto-save'];
+    }
+  }, [publicConfig]);
+
+  useEffect(() => {
+    if (messageUpdatedNeedSaveDebounced) {
+      createOrUpdateDraft();
+      setMessageNeedToSave(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [messageUpdatedNeedSaveDebounced]);
+};

--- a/conversation/frontend/src/features/message-edit/hooks/useAutoSaveMessage.tsx
+++ b/conversation/frontend/src/features/message-edit/hooks/useAutoSaveMessage.tsx
@@ -24,7 +24,6 @@ export const useAutoSaveMessage = () => {
 
   useEffect(() => {
     if (messageUpdatedNeedSaveDebounced && messageUpdatedNeedSave) {
-      console.log('Will Save:');
       createOrUpdateDraft();
       setMessageNeedToSave(false);
     }

--- a/conversation/frontend/src/features/message-list/components/MessageItem.tsx
+++ b/conversation/frontend/src/features/message-list/components/MessageItem.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useSelectedFolder } from '~/hooks/useSelectedFolder';
 import { MessageMetadata } from '~/models';
-import { useUpdateFolderBadgeCountLocal } from '~/services';
+import { useUpdateFolderBadgeCountQueryCache } from '~/services/queries/hooks/useUpdateFolderBadgeCountQueryCache';
 import { MessagePreview } from './MessagePreview/MessagePreview';
 
 interface MessageItemProps {
@@ -13,7 +13,8 @@ interface MessageItemProps {
 }
 export function MessageItem({ message, checked, checkbox }: MessageItemProps) {
   const navigate = useNavigate();
-  const { updateFolderBadgeCountLocal } = useUpdateFolderBadgeCountLocal();
+  const { updateFolderBadgeCountQueryCache } =
+    useUpdateFolderBadgeCountQueryCache();
   const [searchParams] = useSearchParams();
   const { folderId } = useSelectedFolder();
 
@@ -28,7 +29,7 @@ export function MessageItem({ message, checked, checkbox }: MessageItemProps) {
 
   const handleMessageClick = (message: MessageMetadata) => {
     if (message.unread && folderId !== 'draft') {
-      updateFolderBadgeCountLocal(folderId!, -1);
+      updateFolderBadgeCountQueryCache(folderId!, -1);
     }
     navigate({
       pathname: `message/${message.id}`,

--- a/conversation/frontend/src/routes/pages/Folder.tsx
+++ b/conversation/frontend/src/routes/pages/Folder.tsx
@@ -31,6 +31,7 @@ export function Component() {
   const { messages, isPending: isLoadingMessage } = useFolderMessages(
     folderId!,
   );
+
   return (
     <>
       {(!!messages.length ||

--- a/conversation/frontend/src/services/queries/attachment.ts
+++ b/conversation/frontend/src/services/queries/attachment.ts
@@ -13,7 +13,7 @@ export const useAttachFiles = () => {
   const queryClient = useQueryClient();
   const { setMessage } = useMessageActions();
   const message = useMessage();
-  const { updateFolderMessagesQueryData } = useFolderUtils();
+  const { updateFolderMessagesQueryCache } = useFolderUtils();
   const toast = useToast();
   const { t } = useI18n();
 
@@ -51,7 +51,7 @@ export const useAttachFiles = () => {
         },
       );
 
-      updateFolderMessagesQueryData(
+      updateFolderMessagesQueryCache(
         'draft',
         (oldMessage) =>
           oldMessage.id === draftId
@@ -76,7 +76,7 @@ export const useAttachFiles = () => {
 export const useDetachFile = () => {
   const queryClient = useQueryClient();
   const { setMessage } = useMessageActions();
-  const { updateFolderMessagesQueryData } = useFolderUtils();
+  const { updateFolderMessagesQueryCache } = useFolderUtils();
 
   return useMutation({
     mutationFn: ({
@@ -102,7 +102,7 @@ export const useDetachFile = () => {
           return updatedMessage;
         },
       );
-      updateFolderMessagesQueryData(
+      updateFolderMessagesQueryCache(
         'draft',
         (oldMessage) =>
           oldMessage.id === draftId

--- a/conversation/frontend/src/services/queries/folder.test.tsx
+++ b/conversation/frontend/src/services/queries/folder.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from '@testing-library/react';
-import { useFolderMessages } from './folder';
+import { PAGE_SIZE, useFolderMessages } from './folder';
 import { folderService } from '../api';
 import { wrapper } from '~/mocks/setup';
 
@@ -16,7 +16,7 @@ describe('Folder Queries', () => {
         search: undefined,
         unread: undefined,
         page: 0,
-        pageSize: 20,
+        pageSize: PAGE_SIZE,
       });
     });
   });
@@ -37,7 +37,7 @@ describe('Folder Queries', () => {
         search: 'searchValue',
         unread: true,
         page: 0,
-        pageSize: 20,
+        pageSize: PAGE_SIZE,
       });
     });
   });

--- a/conversation/frontend/src/services/queries/folder.ts
+++ b/conversation/frontend/src/services/queries/folder.ts
@@ -148,7 +148,7 @@ export const useFolderUtils = () => {
   );
 
   /** Update some messages metadata in the list of a folder's messages. */
-  function updateFolderMessagesQueryData(
+  function updateFolderMessagesQueryCache(
     folderId: string,
     updater: (oldMessage: MessageMetadata) => MessageMetadata,
     reOrder: boolean = false,
@@ -181,7 +181,7 @@ export const useFolderUtils = () => {
     );
   }
 
-  return { getFolderNameById, updateFolderMessagesQueryData };
+  return { getFolderNameById, updateFolderMessagesQueryCache };
 };
 
 /**
@@ -374,51 +374,4 @@ export const useTrashFolder = () => {
       });
     },
   });
-};
-
-export const useUpdateFolderBadgeCountLocal = () => {
-  const queryClient = useQueryClient();
-  const updateFolderBadgeCountLocal = (
-    folderId: string,
-    countDelta: number,
-  ) => {
-    if (folderId === 'inbox') {
-      // Update inbox count unread
-      queryClient.setQueryData(
-        ['folder', 'inbox', 'count', { unread: true }],
-        ({ count }: { count: number }) => {
-          return { count: count + countDelta };
-        },
-      );
-    } else if (folderId === 'draft') {
-      // Update draft count
-      queryClient.setQueryData(
-        ['folder', 'draft', 'count', null],
-        ({ count }: { count: number }) => {
-          return { count: count + countDelta };
-        },
-      );
-    } else if (!['inbox', 'trash', 'draft', 'outbox'].includes(folderId)) {
-      // Update custom folder count unread
-      queryClient.setQueryData(['folder', 'tree'], (folders: Folder[]) => {
-        // go trow the folder tree to find the folder to update
-        const result = searchFolder(folderId, folders);
-        if (!result?.parent) {
-          return folders.map((folder) => {
-            if (folder.id === folderId) {
-              return { ...folder, nbUnread: folder.nbUnread + countDelta };
-            }
-            return folder;
-          });
-        } else if (result?.folder) {
-          result.folder = {
-            ...result.folder,
-            nbUnread: result.folder.nbUnread + countDelta,
-          };
-          return [...folders];
-        }
-      });
-    }
-  };
-  return { updateFolderBadgeCountLocal };
 };

--- a/conversation/frontend/src/services/queries/folder.ts
+++ b/conversation/frontend/src/services/queries/folder.ts
@@ -13,6 +13,8 @@ import { Folder, MessageMetadata } from '~/models';
 import { useConfig } from '~/store';
 import { folderService, searchFolder } from '..';
 
+const PAGE_SIZE = 20;
+
 /**
  * Provides query options for folder-related operations.
  */
@@ -26,7 +28,13 @@ export const folderQueryOptions = {
     folderId: string,
     options: { search?: string; unread?: boolean },
   ) {
-    return [...folderQueryOptions.base, folderId, 'messages', options] as const;
+    return [
+      ...folderQueryOptions.base,
+      'messages',
+      folderId,
+      ,
+      options,
+    ] as const;
   },
 
   /**
@@ -63,8 +71,8 @@ export const folderQueryOptions = {
     return queryOptions({
       queryKey: [
         ...folderQueryOptions.base,
-        folderId,
         'count',
+        folderId,
         options,
       ] as const,
       queryFn: () => folderService.getCount(folderId, options?.unread),
@@ -90,15 +98,13 @@ export const folderQueryOptions = {
       unread?: boolean;
     },
   ) {
-    const pageSize = 20;
-
     return infiniteQueryOptions({
       queryKey: this.getMessagesQuerykey(folderId, options),
       queryFn: ({ pageParam = 0 }) => {
         return folderService.getMessages(folderId, {
           ...options,
           page: pageParam,
-          pageSize,
+          pageSize: PAGE_SIZE,
         });
       },
       staleTime: 5 * 60 * 1000, // 5 minutes

--- a/conversation/frontend/src/services/queries/folder.ts
+++ b/conversation/frontend/src/services/queries/folder.ts
@@ -13,7 +13,7 @@ import { Folder, MessageMetadata } from '~/models';
 import { useConfig } from '~/store';
 import { folderService, searchFolder } from '..';
 
-const PAGE_SIZE = 20;
+export const PAGE_SIZE = 2;
 
 /**
  * Provides query options for folder-related operations.
@@ -169,7 +169,7 @@ export const useFolderUtils = () => {
           const updatedMessages = allMessages.map(updater);
           updatedMessages.sort((a, b) => (b.date || 0) - (a.date || 0));
           const pages = [],
-            pageSize = oldData?.pages[0].length || 20;
+            pageSize = oldData?.pages[0].length || PAGE_SIZE;
           for (let i = 0; i < allMessages.length; i += pageSize) {
             pages.push(updatedMessages.slice(i, i + pageSize));
           }

--- a/conversation/frontend/src/services/queries/folder.ts
+++ b/conversation/frontend/src/services/queries/folder.ts
@@ -13,7 +13,7 @@ import { Folder, MessageMetadata } from '~/models';
 import { useConfig } from '~/store';
 import { folderService, searchFolder } from '..';
 
-export const PAGE_SIZE = 2;
+export const PAGE_SIZE = 20;
 
 /**
  * Provides query options for folder-related operations.

--- a/conversation/frontend/src/services/queries/hooks/useDeleteMessageFromQueryCache.ts
+++ b/conversation/frontend/src/services/queries/hooks/useDeleteMessageFromQueryCache.ts
@@ -1,0 +1,58 @@
+import { InfiniteData } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
+import { Message } from '~/models';
+import { folderQueryOptions } from '~/services';
+import { useUpdateFolderBadgeCountQueryCache } from './useUpdateFolderBadgeCountQueryCache';
+
+export const useDeleteMessagesFromQueryCache = () => {
+  const queryClient = useQueryClient();
+  const { updateFolderBadgeCountQueryCache } =
+    useUpdateFolderBadgeCountQueryCache();
+
+  const deleteMessagesFromQueryCache = (
+    folderId: string,
+    messageIds: string[],
+  ) => {
+    let unreadTrashedCount = 0;
+
+    // Update list message
+    queryClient.setQueriesData(
+      { queryKey: folderQueryOptions.getMessagesQuerykey(folderId, {}) },
+      // Remove deleted message from pages
+      (data: InfiniteData<Message[]>) => {
+        if (!['trash', 'draft', 'outbox'].includes(folderId!)) {
+          unreadTrashedCount = data.pages.reduce((count, page) => {
+            return (
+              count +
+              page.filter(
+                (message) => message.unread && messageIds.includes(message.id),
+              ).length
+            );
+          }, 0);
+        }
+
+        return {
+          ...data,
+          pages: data.pages.map((page: Message[]) =>
+            page.filter((message: Message) => !messageIds.includes(message.id)),
+          ),
+        };
+      },
+    );
+
+    // Update unread inbox count
+    // Update custom folder count
+    if (
+      !['trash', 'draft', 'outbox'].includes(folderId!) &&
+      unreadTrashedCount
+    ) {
+      updateFolderBadgeCountQueryCache(folderId!, -unreadTrashedCount);
+    }
+
+    // Update draft count if It's a draft message
+    if (folderId === 'draft') {
+      updateFolderBadgeCountQueryCache(folderId, -messageIds.length);
+    }
+  };
+  return { deleteMessagesFromQueryCache };
+};

--- a/conversation/frontend/src/services/queries/hooks/useDeleteMessageFromQueryCache.ts
+++ b/conversation/frontend/src/services/queries/hooks/useDeleteMessageFromQueryCache.ts
@@ -18,24 +18,31 @@ export const useDeleteMessagesFromQueryCache = () => {
     // Update list message
     queryClient.setQueriesData(
       { queryKey: folderQueryOptions.getMessagesQuerykey(folderId, {}) },
-      // Remove deleted message from pages
       (data: InfiniteData<Message[]>) => {
+        const countUnreadMessages = (
+          messages: Message[],
+          messageIds: string[],
+        ): number => {
+          return messages.filter(
+            (message) => message.unread && messageIds.includes(message.id),
+          ).length;
+        };
+
         if (!['trash', 'draft', 'outbox'].includes(folderId!)) {
-          unreadTrashedCount = data.pages.reduce((count, page) => {
-            return (
-              count +
-              page.filter(
-                (message) => message.unread && messageIds.includes(message.id),
-              ).length
-            );
-          }, 0);
+          unreadTrashedCount = data.pages.reduce(
+            (count, page) => count + countUnreadMessages(page, messageIds),
+            0,
+          );
         }
+
+        // Filter out deleted messages
+        const pages = data.pages.map((page: Message[]) =>
+          page.filter((message: Message) => !messageIds.includes(message.id)),
+        );
 
         return {
           ...data,
-          pages: data.pages.map((page: Message[]) =>
-            page.filter((message: Message) => !messageIds.includes(message.id)),
-          ),
+          pages,
         };
       },
     );
@@ -55,4 +62,18 @@ export const useDeleteMessagesFromQueryCache = () => {
     }
   };
   return { deleteMessagesFromQueryCache };
+};
+
+const reorganizePages = (pages: Message[][]): Message[][] => {
+  // Flatten all pages and remove deleted messages
+  const pageSize = 20;
+  const allMessages = pages.flat();
+
+  // Create new pages with the specified page size
+  const newPages: Message[][] = [];
+  for (let i = 0; i < allMessages.length; i += pageSize) {
+    newPages.push(allMessages.slice(i, i + pageSize));
+  }
+
+  return newPages;
 };

--- a/conversation/frontend/src/services/queries/hooks/useDeleteMessageFromQueryCache.ts
+++ b/conversation/frontend/src/services/queries/hooks/useDeleteMessageFromQueryCache.ts
@@ -39,22 +39,24 @@ export const useDeleteMessagesFromQueryCache = () => {
         const totalItems = data.pages[0][0].count;
         const newTotalItems = totalItems - messageIds.length;
 
-        const pages = data.pages.map((page: MessageMetadata[]) => {
-          return (
-            page
-              // Filter out deleted messages
-              .filter(
-                (message: MessageMetadata) => !messageIds.includes(message.id),
-              )
-              // update count
-              .map((message: MessageMetadata) => ({
-                ...message,
-                count: newTotalItems,
-              }))
-          );
-        });
+        const pages = data.pages
+          .map((page: MessageMetadata[]) => {
+            return (
+              page
+                // Filter out deleted messages
+                .filter(
+                  (message: MessageMetadata) =>
+                    !messageIds.includes(message.id),
+                )
 
-        //update message count
+                // update message count
+                .map((message: MessageMetadata) => ({
+                  ...message,
+                  count: newTotalItems,
+                }))
+            );
+          })
+          .filter((page: MessageMetadata[]) => page.length > 0);
 
         return {
           ...data,

--- a/conversation/frontend/src/services/queries/hooks/useDeleteMessageFromQueryCache.ts
+++ b/conversation/frontend/src/services/queries/hooks/useDeleteMessageFromQueryCache.ts
@@ -1,5 +1,4 @@
-import { InfiniteData } from '@tanstack/react-query';
-import { useQueryClient } from '@tanstack/react-query';
+import { InfiniteData, useQueryClient } from '@tanstack/react-query';
 import { Message } from '~/models';
 import { folderQueryOptions } from '~/services';
 import { useUpdateFolderBadgeCountQueryCache } from './useUpdateFolderBadgeCountQueryCache';
@@ -19,6 +18,7 @@ export const useDeleteMessagesFromQueryCache = () => {
     queryClient.setQueriesData(
       { queryKey: folderQueryOptions.getMessagesQuerykey(folderId, {}) },
       (data: InfiniteData<Message[]>) => {
+        if (!data) return;
         const countUnreadMessages = (
           messages: Message[],
           messageIds: string[],
@@ -62,18 +62,4 @@ export const useDeleteMessagesFromQueryCache = () => {
     }
   };
   return { deleteMessagesFromQueryCache };
-};
-
-const reorganizePages = (pages: Message[][]): Message[][] => {
-  // Flatten all pages and remove deleted messages
-  const pageSize = 20;
-  const allMessages = pages.flat();
-
-  // Create new pages with the specified page size
-  const newPages: Message[][] = [];
-  for (let i = 0; i < allMessages.length; i += pageSize) {
-    newPages.push(allMessages.slice(i, i + pageSize));
-  }
-
-  return newPages;
 };

--- a/conversation/frontend/src/services/queries/hooks/useDeleteMessageFromQueryCache.ts
+++ b/conversation/frontend/src/services/queries/hooks/useDeleteMessageFromQueryCache.ts
@@ -1,5 +1,5 @@
 import { InfiniteData, useQueryClient } from '@tanstack/react-query';
-import { Message, MessageMetadata } from '~/models';
+import { MessageMetadata } from '~/models';
 import { folderQueryOptions } from '~/services';
 import { useUpdateFolderBadgeCountQueryCache } from './useUpdateFolderBadgeCountQueryCache';
 

--- a/conversation/frontend/src/services/queries/hooks/useUpdateFolderBadgeCountQueryCache.ts
+++ b/conversation/frontend/src/services/queries/hooks/useUpdateFolderBadgeCountQueryCache.ts
@@ -11,7 +11,7 @@ export const useUpdateFolderBadgeCountQueryCache = () => {
     if (folderId === 'inbox') {
       // Update inbox count unread
       queryClient.setQueryData(
-        ['folder', 'inbox', 'count', { unread: true }],
+        ['folder', 'count', 'inbox', { unread: true }],
         ({ count }: { count: number }) => {
           return { count: count + countDelta };
         },
@@ -19,7 +19,7 @@ export const useUpdateFolderBadgeCountQueryCache = () => {
     } else if (folderId === 'draft') {
       // Update draft count
       queryClient.setQueryData(
-        ['folder', 'draft', 'count', null],
+        ['folder', 'count', 'draft', null],
         ({ count }: { count: number }) => {
           return { count: count + countDelta };
         },

--- a/conversation/frontend/src/services/queries/hooks/useUpdateFolderBadgeCountQueryCache.ts
+++ b/conversation/frontend/src/services/queries/hooks/useUpdateFolderBadgeCountQueryCache.ts
@@ -16,14 +16,6 @@ export const useUpdateFolderBadgeCountQueryCache = () => {
           return { count: count + countDelta };
         },
       );
-
-      // Update conversation navbar count unread
-      queryClient.setQueryData(
-        ['conversation-navbar-count'],
-        ({ count }: { count: number }) => {
-          return { count: count + countDelta };
-        },
-      );
     } else if (folderId === 'draft') {
       // Update draft count
       queryClient.setQueryData(

--- a/conversation/frontend/src/services/queries/hooks/useUpdateFolderBadgeCountQueryCache.ts
+++ b/conversation/frontend/src/services/queries/hooks/useUpdateFolderBadgeCountQueryCache.ts
@@ -1,0 +1,58 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { Folder } from '~/models';
+import { searchFolder } from '~/services';
+
+export const useUpdateFolderBadgeCountQueryCache = () => {
+  const queryClient = useQueryClient();
+  const updateFolderBadgeCountQueryCache = (
+    folderId: string,
+    countDelta: number,
+  ) => {
+    if (folderId === 'inbox') {
+      // Update inbox count unread
+      queryClient.setQueryData(
+        ['folder', 'inbox', 'count', { unread: true }],
+        ({ count }: { count: number }) => {
+          return { count: count + countDelta };
+        },
+      );
+
+      // Update conversation navbar count unread
+      queryClient.setQueryData(
+        ['conversation-navbar-count'],
+        ({ count }: { count: number }) => {
+          return { count: count + countDelta };
+        },
+      );
+    } else if (folderId === 'draft') {
+      // Update draft count
+      queryClient.setQueryData(
+        ['folder', 'draft', 'count', null],
+        ({ count }: { count: number }) => {
+          return { count: count + countDelta };
+        },
+      );
+    } else if (!['inbox', 'trash', 'draft', 'outbox'].includes(folderId)) {
+      // Update custom folder count unread
+      queryClient.setQueryData(['folder', 'tree'], (folders: Folder[]) => {
+        // go trow the folder tree to find the folder to update
+        const result = searchFolder(folderId, folders);
+        if (!result?.parent) {
+          return folders.map((folder) => {
+            if (folder.id === folderId) {
+              return { ...folder, nbUnread: folder.nbUnread + countDelta };
+            }
+            return folder;
+          });
+        } else if (result?.folder) {
+          result.folder = {
+            ...result.folder,
+            nbUnread: result.folder.nbUnread + countDelta,
+          };
+          return [...folders];
+        }
+      });
+    }
+  };
+  return { updateFolderBadgeCountQueryCache };
+};

--- a/conversation/frontend/src/services/queries/message.ts
+++ b/conversation/frontend/src/services/queries/message.ts
@@ -344,6 +344,10 @@ export const useDeleteMessage = () => {
  */
 export const useMoveMessage = () => {
   const queryClient = useQueryClient();
+  const { folderId } = useParams() as { folderId: string };
+
+  const { deleteMessagesFromQueryCache } = useDeleteMessagesFromQueryCache();
+
   return useMutation({
     mutationFn: ({
       folderId,
@@ -359,8 +363,15 @@ export const useMoveMessage = () => {
           queryKey: messageQueryOptions.getById(messageId).queryKey,
         });
       });
+
+      // Delete messages from query cache
+      deleteMessagesFromQueryCache(folderId, messageIds);
+
       queryClient.invalidateQueries({
-        queryKey: ['folder'],
+        queryKey: ['folder', 'tree'],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['folder', 'count'],
       });
     },
   });
@@ -486,6 +497,8 @@ export const useCreateDraft = () => {
       queryClient.resetQueries({
         queryKey: ['folder', 'messages', 'draft'],
       });
+
+      //update message details query cache
     },
   });
 };
@@ -519,6 +532,7 @@ export const useUpdateDraft = () => {
 
       setMessage({ ...messageUpdated });
 
+      //update message details query cache
       queryClient.setQueryData(
         messageQueryOptions.getById(draftId).queryKey,
         (message: Message | undefined) => {
@@ -587,6 +601,8 @@ export const useSendDraft = () => {
 
       // Delete message from draft list in query cache
       deleteMessagesFromQueryCache('draft', [draftId]);
+
+      //update message details query cache
     },
   });
 };

--- a/conversation/frontend/src/services/queries/message.ts
+++ b/conversation/frontend/src/services/queries/message.ts
@@ -617,8 +617,6 @@ export const useSendDraft = () => {
       // Delete message from draft list in query cache
       deleteMessagesFromQueryCache('draft', [draftId]);
 
-      //update message details query cache
-
       // Invalidate message details
       queryClient.invalidateQueries({
         queryKey: messageQueryOptions.getById(draftId).queryKey,

--- a/conversation/frontend/src/services/queries/message.ts
+++ b/conversation/frontend/src/services/queries/message.ts
@@ -565,7 +565,6 @@ export const useSendDraft = () => {
     }) => messageService.send(draftId, payload, inReplyToId),
     onSuccess: (_response, { payload, draftId }) => {
       toast.success(t('message.sent'));
-      // updateFolderBadgeCountQueryCache('draft', -1);
 
       if (
         payload &&

--- a/conversation/frontend/src/services/queries/message.ts
+++ b/conversation/frontend/src/services/queries/message.ts
@@ -276,6 +276,13 @@ export const useRestoreMessage = () => {
     onSuccess: async (_data, { id }) => {
       const messageIds = typeof id === 'string' ? [id] : id;
 
+      // Invalidate message details
+      messageIds.forEach((messageId) => {
+        queryClient.invalidateQueries({
+          queryKey: messageQueryOptions.getById(messageId).queryKey,
+        });
+      });
+
       deleteMessagesFromQueryCache('trash', messageIds);
 
       // Reset all queries except trash folder
@@ -321,6 +328,8 @@ export const useEmptyTrash = () => {
 export const useDeleteMessage = () => {
   const toast = useToast();
   const { t } = useTranslation(appCodeName);
+  const queryClient = useQueryClient();
+
   const { deleteMessagesFromQueryCache } = useDeleteMessagesFromQueryCache();
 
   return useMutation({
@@ -328,6 +337,13 @@ export const useDeleteMessage = () => {
       messageService.delete(id),
     onSuccess: (_data, { id }) => {
       const messageIds = typeof id === 'string' ? [id] : id;
+
+      // Invalidate message details
+      messageIds.forEach((messageId) => {
+        queryClient.invalidateQueries({
+          queryKey: messageQueryOptions.getById(messageId).queryKey,
+        });
+      });
 
       deleteMessagesFromQueryCache('trash', messageIds);
 
@@ -357,6 +373,7 @@ export const useMoveMessage = () => {
       id: string | string[];
     }) => messageService.moveToFolder(folderId, id),
     onSuccess: (_data, { id }) => {
+      // invalidate messages details
       const messageIds = typeof id === 'string' ? [id] : id;
       messageIds.forEach((messageId) => {
         queryClient.invalidateQueries({
@@ -497,8 +514,6 @@ export const useCreateDraft = () => {
       queryClient.resetQueries({
         queryKey: ['folder', 'messages', 'draft'],
       });
-
-      //update message details query cache
     },
   });
 };
@@ -603,6 +618,11 @@ export const useSendDraft = () => {
       deleteMessagesFromQueryCache('draft', [draftId]);
 
       //update message details query cache
+
+      // Invalidate message details
+      queryClient.invalidateQueries({
+        queryKey: messageQueryOptions.getById(draftId).queryKey,
+      });
     },
   });
 };
@@ -617,7 +637,6 @@ export const useRecallMessage = () => {
     mutationFn: ({ messageId }: { messageId: string }) =>
       messageService.recall(messageId),
     onSuccess: (_data, { messageId }) => {
-      // TODO optimistic update ?
       queryClient.invalidateQueries({
         queryKey: messageQueryOptions.getById(messageId).queryKey,
       });

--- a/conversation/frontend/src/services/queries/message.ts
+++ b/conversation/frontend/src/services/queries/message.ts
@@ -164,13 +164,6 @@ const useToggleUnread = (unread: boolean) => {
             ? { ...oldMessage, unread }
             : oldMessage,
         );
-
-        // force refetch of the folder messages with filter unread
-        queryClient.invalidateQueries({
-          queryKey: folderQueryOptions.getMessagesQuerykey(folderId, {
-            unread: true,
-          }),
-        });
       }
 
       // Update the message unread status in the message details

--- a/conversation/frontend/src/services/queries/message.ts
+++ b/conversation/frontend/src/services/queries/message.ts
@@ -221,8 +221,9 @@ export const useTrashMessage = () => {
     mutationFn: ({ id }: { id: string | string[] }) =>
       messageService.moveToFolder('trash', id),
     onMutate: async ({ id }: { id: string | string[] }) => {
+      const messageIds = typeof id === 'string' ? [id] : id;
       // avoid to display placeholder if have next page
-      if (messages?.length === id.length && hasNextPage) {
+      if (messages?.length === messageIds.length && hasNextPage) {
         await fetchNextPage();
       }
     },
@@ -269,7 +270,9 @@ export const useRestoreMessage = () => {
     mutationFn: async ({ id }: { id: string | string[] }) =>
       messageService.restore(id),
     onMutate: async ({ id }: { id: string | string[] }) => {
-      if (messages?.length === id.length && hasNextPage) {
+      const messageIds = typeof id === 'string' ? [id] : id;
+
+      if (messages?.length === messageIds.length && hasNextPage) {
         await fetchNextPage();
       }
     },


### PR DESCRIPTION
# Description

- update message hooks (react-query cache and invalidations)
 fix draft issues :
- Le brouillon s'enregistre automatiquement une seule fois
- La liste des messages dans les brouillons ne se met pas à jour automatiquement si on clique sur sauvegardé
- Brouillon non souhaité créé

## Fixes

(Enter here Jira or Redmine ticket(s) links)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [x] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: