### PR TITLE
fix-COCO-3538-timezone-flash-message

### DIFF
--- a/admin/src/main/ts/package.json
+++ b/admin/src/main/ts/package.json
@@ -27,6 +27,7 @@
     "@angular/router": "^14.1.1",
     "axios": "^0.19.0",
     "chardet": "^1.4.0",
+    "dayjs": "^1.11.13",
     "entcore-generic-icons": "https://github.com/opendigitaleducation/generic-icons.git",
     "entcore-toolkit": "^1.4.0",
     "flatpickr": "2.6.1",

--- a/admin/src/main/ts/src/app/management/message-flash/form/message-flash-form/message-flash-form.component.ts
+++ b/admin/src/main/ts/src/app/management/message-flash/form/message-flash-form/message-flash-form.component.ts
@@ -9,6 +9,8 @@ import { MessageFlashStore } from '../../message-flash.store';
 import { StructureModel } from '../../../../core/store/models/structure.model';
 import { FlashMessageModel } from '../../../../core/store/models/flashmessage.model';
 import { TrumbowygOptions } from 'ngx-trumbowyg';
+import * as dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
 
 class StructureListItem {
     name: string;
@@ -58,6 +60,7 @@ export class MessageFlashFormComponent extends OdeComponent implements OnInit, O
     }
 
     ngOnInit(): void {
+        dayjs.extend(utc);
         super.ngOnInit();
         this.subscriptions.add(routing.observe(this.route, 'data').subscribe(async (data: Data) => {
             if (data.structure) {
@@ -74,10 +77,9 @@ export class MessageFlashFormComponent extends OdeComponent implements OnInit, O
                 }
                 this.message.id = this.originalMessage.id;
                 this.message.title = this.originalMessage.title;
-                const _startDate: Date = new Date(this.originalMessage.startDate);
-                this.message.startDate = new Date(_startDate.getTime() - (_startDate.getTimezoneOffset() * 60000)).toISOString();
-                const _endDate: Date = new Date(this.originalMessage.endDate);
-                this.message.endDate = new Date(_endDate.getTime() - (_endDate.getTimezoneOffset() * 60000)).toISOString();
+                this.message.startDate = dayjs.utc(this.originalMessage.startDate).local().format('YYYY-MM-DD');
+                this.message.endDate = dayjs.utc(this.originalMessage.endDate).local().format('YYYY-MM-DD');
+                
                 if (!!this.originalMessage.color) {
                     this.message.color = this.originalMessage.color;
                 }
@@ -261,6 +263,10 @@ export class MessageFlashFormComponent extends OdeComponent implements OnInit, O
         let promise;
         let key: string;
         this.loadedLanguages.forEach(lang => this.message.contents[lang] = this.replaceItalicTags(this.message.contents[lang]));
+       
+        this.message.startDate = dayjs(this.message.startDate).startOf('day').toISOString();
+        this.message.endDate = dayjs(this.message.endDate).endOf('day').toISOString();
+
         if (this.action === 'edit') {
             promise = MessageFlashService.editMessage(this.message);
             key = 'edit';


### PR DESCRIPTION
# Description

In Flash message management, using a timezone with an important gap lead to wrong date be persisted in database (for example, tahiti timezone). 

## Fixes

COCO-3538

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [x] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. As a user with rights to create / edit flash message, with UTC-10 in local at 3:00AM local, I create a message for today to tomorrow
2. I save the message
3. The message in the list should have the same boundaries
4. Editing the message should display the same boundaries

1. As a user with rights to create / edit flash message, with UTC+2 in local at 15:00 local, I create a message for today to tomorrow
2. I save the message
3. The message in the list should have the same boundaries
4. Editing the message should display the same boundaries

1. As a user with rights to create / edit flash message, with UTC-10 in local at 3:00AM local, I edit a message for today to tomorrow
2. I save the message
3. The message in the list should have the same boundaries
4. Editing the message should display the same boundaries

1. As a user with rights to create / edit flash message, with UTC+2 in local at 15:00 local, I edit a message for today to tomorrow
2. I save the message
3. The message in the list should have the same boundaries
4. Editing the message should display the same boundaries

# Reminder

- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: