### PR TITLE
fix(conversation): COCO-4233, allow ADMLs to search by pressing enter

### DIFF
--- a/conversation/frontend/src/features/message-edit/hooks/useSearchRecipients.tsx
+++ b/conversation/frontend/src/features/message-edit/hooks/useSearchRecipients.tsx
@@ -115,26 +115,21 @@ export const useSearchRecipients = ({
       type: 'isSearching',
       payload: true,
     });
-    const minSearchLength = isAdml ? 3 : 1;
-    if (
-      defaultBookmarks ||
-      debouncedSearchInputValue.length >= minSearchLength ||
-      force
-    ) {
-      let searchVisibles = defaultBookmarks || [];
-      if (
-        debouncedSearchInputValue.length >= minSearchLength ||
-        (force && debouncedSearchInputValue.length > 0)
-      ) {
-        searchVisibles = await searchVisible(debouncedSearchInputValue);
-      }
+    const minSearchLength = !isAdml || force ? 1 : 3;
+
+    let searchVisibles = defaultBookmarks ?? null;
+    if (defaultBookmarks) searchVisibles = defaultBookmarks;
+    if (debouncedSearchInputValue.length >= minSearchLength) {
+      searchVisibles = await searchVisible(debouncedSearchInputValue);
+    }
+
+    if (searchVisibles !== null) {
       updateVisiblesFound(searchVisibles);
     } else {
       dispatch({
         type: 'emptyResult',
         payload: [],
       });
-      Promise.resolve();
     }
 
     dispatch({

--- a/conversation/frontend/src/services/queries/user.ts
+++ b/conversation/frontend/src/services/queries/user.ts
@@ -93,11 +93,6 @@ function applySearchRules(
   getVisibleStrategy: Config['getVisibleStrategy'],
   search: string,
 ) {
-  // Do not search unless at least 3 characters are typed in.
-  if (isAdml && (!search || search.length < 3)) {
-    return { triggerSearch: false };
-  }
-
   const backendFiltering = 'all-at-once' !== getVisibleStrategy || isAdml;
   const startText = backendFiltering ? search.substring(0, 3) : undefined;
   const frontendFiltering = !backendFiltering || search.length > 3;


### PR DESCRIPTION
# Description

Fixe une régression introduite lors de l'implem de la recherche iso
+ simplification d'un bout de code tout en conservant sa logique.

## Fixes

https://edifice-community.atlassian.net/browse/COCO-4233

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [X] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: