### PR TITLE
fix(timeline): #COCO-1570 disable domain filter on flash message V2

### DIFF
--- a/timeline/src/main/java/org/entcore/timeline/services/impl/FlashMsgServiceMongoImpl.java
+++ b/timeline/src/main/java/org/entcore/timeline/services/impl/FlashMsgServiceMongoImpl.java
@@ -41,6 +41,7 @@ import fr.wseduc.mongodb.MongoDb;
 import fr.wseduc.mongodb.MongoQueryBuilder;
 import fr.wseduc.webutils.Either;
 
+@Deprecated
 public class FlashMsgServiceMongoImpl extends MongoDbCrudService implements FlashMsgService {
 
 	private final DateFormat mongoFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");

--- a/timeline/src/main/java/org/entcore/timeline/services/impl/FlashMsgServiceSqlImpl.java
+++ b/timeline/src/main/java/org/entcore/timeline/services/impl/FlashMsgServiceSqlImpl.java
@@ -154,6 +154,7 @@ public class FlashMsgServiceSqlImpl extends SqlCrudService implements FlashMsgSe
 			isADMLOfOneStructure = false;
 		}
 		// we don't need to check if the message is in the user's language he has to see it
+		// A distinction is made on structureId to disambiguate V1 and V2 and apply domain filter only on V1
 		String query = "SELECT id, contents, color, \"customColor\", signature, \"signatureColor\" FROM " + resourceTable + " m " +
 			"WHERE (profiles ? '" + user.getType() + "' " +
 				"OR (profiles ? 'AdminLocal' AND ("+
@@ -162,7 +163,7 @@ public class FlashMsgServiceSqlImpl extends SqlCrudService implements FlashMsgSe
 				"OR EXISTS (SELECT * FROM "+ STRUCT_JOIN_TABLE + " WHERE message_id = m.id AND structure_id IN (" + myADMLStructuresId + ")))))) " +
 			"AND \"startDate\" <= now() " +
 			"AND \"endDate\" > now() " +
-			"AND domain = '" + domain + "' " +
+			"AND ( \"structureId\" IS NOT NULL OR domain = '" + domain + "' )" +
 			"AND (\"structureId\" IS NULL " +
 				"OR (\"structureId\" IN (" + myStructuresIds + ")) " +
 				"OR EXISTS (SELECT * FROM "+ STRUCT_JOIN_TABLE + " WHERE message_id = m.id AND structure_id IN (" + myStructuresIds + "))) " +


### PR DESCRIPTION
# Description

change: Modify the query to retrieve flash message to differentiate V1 vs V2 and exclude domain check for V2
issue: V2 message can't be display on a different domain than the one use at its creation. This behavior is correct for t V1 messages but not for V2 messages.

## Fixes

[(Enter here Jira or Redmine ticket(s) links)](https://edifice-community.atlassian.net/browse/COCO-1570)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [x] timeline
- [ ] workspace

## Tests

Make a flash message into v2 console
View it on another URL

As central administrator I create a flash message V1 on domain localhost. 
When I navigate with another user to timeline on localhost1d
Then don't see the message

As central administrator I create a flash message V1 on domain localhost. 
When I navigate with another user to timeline on localhost
Then I see the message

As central administrator I create a flash message V2 on domain localhost. 
When I navigate with another user to timeline on localhost1d
Then I see the message

As central administrator I create a flash message V2 on domain localhost. 
When I navigate with another user to timeline on localhost
Then I see the message

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: