### PR TITLE
feat(broker): #RBACK-80, do not reserialize a serialized value

### DIFF
--- a/broker-parent/broker/src/main/java/org/entcore/broker/client/NATSBrokerClient.java
+++ b/broker-parent/broker/src/main/java/org/entcore/broker/client/NATSBrokerClient.java
@@ -99,7 +99,8 @@ public class NATSBrokerClient implements BrokerClient {
             }
             promise.future().onSuccess(response -> {
               try {
-                final byte[] payload = mapper.writeValueAsString(response).getBytes(charset);
+                // We can cast here as string because BrokerProxyUtils serialize the response as a String
+                final byte[] payload = ((String)response).getBytes(charset);
                 natsClient.publish(msg.getReplyTo(), payload);
               } catch (Exception e) {
                 sendError(msg, e);


### PR DESCRIPTION
# Description

BrokerProxyUtils diffusait sur l'eventbus des objets sérialisés en Json sous forme de String qui était ensuite resérialisées par NATSBrokerClient.
Cette PR enlève la sérialisation par NATSBrokerClient, ce qui fait que tous les clients (quarkus, nestjs) n'ont plus besoin de désérialiser 2 fois
