### PR TITLE
fix(common, directory): COCO-4022, exclude non-visible from bookmarks…

### DIFF
--- a/common/src/main/java/org/entcore/common/share/impl/GenericShareService.java
+++ b/common/src/main/java/org/entcore/common/share/impl/GenericShareService.java
@@ -70,7 +70,6 @@ public abstract class GenericShareService implements ShareService {
 	protected static final I18n i18n = I18n.getInstance();
 	private JsonArray resourceActions;
 	private final Vertx vertx = Vertx.currentContext().owner();
-	private final int DEFAULT_SHARES_PARTITION_SIZE = 50;
 	private final EventStore eventStore;
 
 	public GenericShareService(EventBus eb, Map<String, SecuredAction> securedActions,
@@ -483,13 +482,7 @@ public abstract class GenericShareService implements ShareService {
 		final String customReturn = "RETURN DISTINCT visibles.id as id, has(visibles.login) as isUser";
 
 		// Parallelizing the process of fetching the visibles
-		final int partitionSize;
-		LocalMap<Object, Object> serverConfig = vertx.sharedData().getLocalMap("server");
-		if (serverConfig != null) {
-			partitionSize = (int) serverConfig.getOrDefault("sharesPartitionSize", DEFAULT_SHARES_PARTITION_SIZE);
-		} else {
-			partitionSize = DEFAULT_SHARES_PARTITION_SIZE;
-		}
+		final int partitionSize = UserUtils.getSharesPartitionSize();
 		final List<List<String>> idsOfShareChunks = Lists.partition(getIdOfGroupsAndUsersConcernedByShares(originalShares, shareUpdates), partitionSize);
 		final List<Future<JsonArray>> visibleFutures = new ArrayList<>();
 		idsOfShareChunks.forEach(idsOfShareChunk -> {

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultShareBookmarkService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultShareBookmarkService.java
@@ -108,10 +108,8 @@ public class DefaultShareBookmarkService implements ShareBookmarkService {
 
 	@Override
 	public void get(String userId, String id, boolean onlyVisibles, Handler<Either<String, JsonObject>> handler) {
-		get(userId, id, handler);
-		/* REVERT COCO-4022 
 		get(userId, id, r -> {
-			if (r.isLeft()) {
+			if (r.isLeft() || !onlyVisibles) {
 				handler.handle(r);
 				return;
 			}
@@ -154,7 +152,6 @@ public class DefaultShareBookmarkService implements ShareBookmarkService {
 				handler.handle(r);
 			});
 		});
-		*/
 	}
 
 	@Override


### PR DESCRIPTION
… by batch

# Description

Historique du [ticket 4022 ](https://edifice-community.atlassian.net/browse/COCO-4022): 
il s'agit de masquer les utilisateurs et groupes, placés en favoris, qui ne sont plus visibles suite au retrait d'un droit de communication.
Le filtre s'applique à la volée, mais le favori n'est pas mis à jour en base : si l'utilisateur retrouve un droit de communication, alors il retrouvera aussi ses favoris correspondants (notamment, en cas d'erreur de manip dans la console).

* [Le fix initial](https://github.com/edificeio/entcore/pull/716) fonctionnait bien pour des petits volumes.
* Puis ticket rouvert car ne fonctionnait plus dans le cas limite où le nombre de favoris est grand (3000+)

=> On traite ici le problème des gros volumes.

## Fixes

https://edifice-community.atlassian.net/browse/COCO-4022

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [X] common
- [ ] communication
- [ ] conversation
- [X] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Testé manuellement en local : 
* crer un favoris avec des parents, élèves, enseignants
* retirer les droits de comm vers les parents
* envoyer un message au favori : les parents ne sont plus visibles dans les destinataires.

A tester en recette pour gros volumes.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: