### PR TITLE
fix(conversation): #COCO fix optimize infinite queries

### DIFF
--- a/conversation/frontend/src/features/menu/components/DesktopMenu.tsx
+++ b/conversation/frontend/src/features/menu/components/DesktopMenu.tsx
@@ -72,7 +72,9 @@ export function DesktopMenu() {
   };
 
   const navigateTo = (folderId: string, isUserFolder = false) => {
-    navigate((isUserFolder ? '/folder/' : '/') + folderId);
+    navigate((isUserFolder ? '/folder/' : '/') + folderId, {
+      state: { scrollToTop: true },
+    });
   };
 
   return (

--- a/conversation/frontend/src/features/message-list/MessageList.test.tsx
+++ b/conversation/frontend/src/features/message-list/MessageList.test.tsx
@@ -16,6 +16,11 @@ const mockIntersectionObserver = vi.fn().mockReturnValue({
   disconnect: vi.fn(),
 });
 
+const mockScrollIntoView = vi.fn();
+
+// Mock Element.prototype.scrollIntoView
+Element.prototype.scrollIntoView = mockScrollIntoView;
+
 vi.mock('~/hooks/useSelectedFolder', () => ({
   useSelectedFolder: mocks.useSelectedFolder,
 }));

--- a/conversation/frontend/src/features/message-list/MessageList.tsx
+++ b/conversation/frontend/src/features/message-list/MessageList.tsx
@@ -32,10 +32,11 @@ export function MessageList() {
 
   const {
     messages,
-    isPending: isLoadingMessage,
+    isPending: isLoadingMessages,
     isFetchingNextPage: isLoadingNextPage,
     hasNextPage,
     fetchNextPage,
+    shouldScrollToTop,
   } = useFolderMessages(folderId!);
   const {
     handleDelete,
@@ -70,7 +71,8 @@ export function MessageList() {
   useEffect(() => {
     const messageListItems =
       listRef.current?.getElementsByClassName('message-list-item');
-    if (isLoadingMessage || isLoadingNextPage) return;
+
+    if (isLoadingMessages || isLoadingNextPage) return;
     if (observer.current) observer.current.disconnect();
     observer.current = new IntersectionObserver(
       (entries) => {
@@ -80,12 +82,18 @@ export function MessageList() {
       },
       { threshold: 0.1 },
     );
-    if (messageListItems)
+    if (messageListItems) {
       observer.current.observe(messageListItems[messageListItems.length - 1]);
+
+      // Scroll to top if shouldScrollToTop define by the query
+      messageListItems[0].scrollIntoView({
+        block: 'center',
+      });
+    }
   }, [
     messages,
     hasNextPage,
-    isLoadingMessage,
+    isLoadingMessages,
     isLoadingNextPage,
     fetchNextPage,
   ]);
@@ -181,7 +189,7 @@ export function MessageList() {
           />
         )}
       />
-      {isLoadingMessage && (
+      {isLoadingMessages && (
         <Loading isLoading={true} className="justify-content-center my-12" />
       )}
     </div>

--- a/conversation/frontend/src/features/message-list/MessageList.tsx
+++ b/conversation/frontend/src/features/message-list/MessageList.tsx
@@ -14,7 +14,7 @@ import {
 } from '@edifice.io/react/icons';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSearchParams } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router-dom';
 import { useSelectedFolder } from '~/hooks/useSelectedFolder';
 import { useFolderMessages } from '~/services';
 import { useAppActions } from '~/store/actions';
@@ -29,6 +29,8 @@ export function MessageList() {
   const { appCode } = useEdificeClient();
   const { t } = useTranslation(appCode);
   const { setSelectedMessageIds } = useAppActions();
+  const location = useLocation();
+  const shouldScrollToTop = location.state?.scrollToTop;
 
   const {
     messages,
@@ -36,7 +38,6 @@ export function MessageList() {
     isFetchingNextPage: isLoadingNextPage,
     hasNextPage,
     fetchNextPage,
-    shouldScrollToTop,
   } = useFolderMessages(folderId!);
   const {
     handleDelete,
@@ -72,6 +73,12 @@ export function MessageList() {
     const messageListItems =
       listRef.current?.getElementsByClassName('message-list-item');
 
+    if (messageListItems && shouldScrollToTop) {
+      messageListItems[0].scrollIntoView({
+        block: 'center',
+      });
+    }
+
     if (isLoadingMessages || isLoadingNextPage) return;
     if (observer.current) observer.current.disconnect();
     observer.current = new IntersectionObserver(
@@ -84,11 +91,6 @@ export function MessageList() {
     );
     if (messageListItems) {
       observer.current.observe(messageListItems[messageListItems.length - 1]);
-      if (shouldScrollToTop) {
-        messageListItems[0].scrollIntoView({
-          block: 'center',
-        });
-      }
     }
   }, [
     messages,

--- a/conversation/frontend/src/features/message-list/MessageList.tsx
+++ b/conversation/frontend/src/features/message-list/MessageList.tsx
@@ -84,7 +84,6 @@ export function MessageList() {
     if (messageListItems) {
       observer.current.observe(messageListItems[messageListItems.length - 1]);
 
-      // Scroll to top if shouldScrollToTop define by the query
       messageListItems[0].scrollIntoView({
         block: 'center',
       });

--- a/conversation/frontend/src/features/message-list/MessageList.tsx
+++ b/conversation/frontend/src/features/message-list/MessageList.tsx
@@ -62,6 +62,8 @@ export function MessageList() {
 
   const [keyList, setKeyList] = useState(0);
   const listRef = useRef<HTMLDivElement>(null);
+  const messageListItems =
+    listRef.current?.getElementsByClassName('message-list-item');
   const observer = useRef<IntersectionObserver | null>(null);
 
   //handle reload list when search params change
@@ -70,15 +72,14 @@ export function MessageList() {
   }, [searchParams]);
 
   useEffect(() => {
-    const messageListItems =
-      listRef.current?.getElementsByClassName('message-list-item');
-
     if (messageListItems && shouldScrollToTop) {
       messageListItems[0].scrollIntoView({
         block: 'center',
       });
     }
+  }, [folderId]);
 
+  useEffect(() => {
     if (isLoadingMessages || isLoadingNextPage) return;
     if (observer.current) observer.current.disconnect();
     observer.current = new IntersectionObserver(
@@ -89,6 +90,7 @@ export function MessageList() {
       },
       { threshold: 0.1 },
     );
+
     if (messageListItems) {
       observer.current.observe(messageListItems[messageListItems.length - 1]);
     }

--- a/conversation/frontend/src/features/message-list/MessageList.tsx
+++ b/conversation/frontend/src/features/message-list/MessageList.tsx
@@ -36,6 +36,7 @@ export function MessageList() {
     isFetchingNextPage: isLoadingNextPage,
     hasNextPage,
     fetchNextPage,
+    shouldScrollToTop,
   } = useFolderMessages(folderId!);
   const {
     handleDelete,
@@ -83,10 +84,11 @@ export function MessageList() {
     );
     if (messageListItems) {
       observer.current.observe(messageListItems[messageListItems.length - 1]);
-
-      messageListItems[0].scrollIntoView({
-        block: 'center',
-      });
+      if (shouldScrollToTop) {
+        messageListItems[0].scrollIntoView({
+          block: 'center',
+        });
+      }
     }
   }, [
     messages,

--- a/conversation/frontend/src/features/message-list/MessageList.tsx
+++ b/conversation/frontend/src/features/message-list/MessageList.tsx
@@ -36,7 +36,6 @@ export function MessageList() {
     isFetchingNextPage: isLoadingNextPage,
     hasNextPage,
     fetchNextPage,
-    shouldScrollToTop,
   } = useFolderMessages(folderId!);
   const {
     handleDelete,

--- a/conversation/frontend/src/routes/pages/Message.tsx
+++ b/conversation/frontend/src/routes/pages/Message.tsx
@@ -7,7 +7,7 @@ import { useInitMessage } from '~/hooks/useInitMessage';
 import { useSelectedFolder } from '~/hooks/useSelectedFolder';
 import { useMessageIdAndAction } from '~/hooks/useMessageIdAndAction';
 
-import { messageQueryOptions } from '~/services';
+import { messageQueryOptions, useFolderUtils } from '~/services';
 
 export const loader =
   (queryClient: QueryClient, isPrint?: boolean) =>
@@ -27,6 +27,7 @@ export function Component() {
   const { isPrint } = useLoaderData() as { isPrint: boolean };
   const { folderId } = useSelectedFolder();
   const [currentKey, setCurrentKey] = useState(0);
+  const { updateFolderMessagesQueryCache } = useFolderUtils();
 
   const { messageId, action } = useMessageIdAndAction();
 
@@ -46,8 +47,18 @@ export function Component() {
       // Scroll to the top of the page
       window.scrollTo(0, 0);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    // Update the message unread status in the list
+    if (folderId) {
+      updateFolderMessagesQueryCache(folderId, (oldMessage) => {
+        return oldMessage.id === messageId
+          ? { ...oldMessage, unread: false }
+          : oldMessage;
+      });
+    }
+  }, [folderId]);
 
   useEffect(() => {
     if (messageId === message?.id) {

--- a/conversation/frontend/src/services/queries/folder.ts
+++ b/conversation/frontend/src/services/queries/folder.ts
@@ -28,13 +28,7 @@ export const folderQueryOptions = {
     folderId: string,
     options: { search?: string; unread?: boolean },
   ) {
-    return [
-      ...folderQueryOptions.base,
-      'messages',
-      folderId,
-      ,
-      options,
-    ] as const;
+    return [...folderQueryOptions.base, 'messages', folderId, options] as const;
   },
 
   /**

--- a/conversation/frontend/src/services/queries/folder.ts
+++ b/conversation/frontend/src/services/queries/folder.ts
@@ -213,6 +213,7 @@ export const useFolderMessages = (folderId: string, enabled = true) => {
   return {
     ...query,
     messages: query.data?.pages.flatMap((page) => page) as MessageMetadata[],
+    shouldScrollToTop: query.data?.shouldScrollToTop,
   };
 };
 

--- a/conversation/frontend/src/services/queries/folder.ts
+++ b/conversation/frontend/src/services/queries/folder.ts
@@ -213,6 +213,7 @@ export const useFolderMessages = (folderId: string, enabled = true) => {
   return {
     ...query,
     messages: query.data?.pages.flatMap((page) => page) as MessageMetadata[],
+    // @ts-ignore
     shouldScrollToTop: query.data?.shouldScrollToTop,
   };
 };

--- a/conversation/frontend/src/services/queries/folder.ts
+++ b/conversation/frontend/src/services/queries/folder.ts
@@ -213,8 +213,6 @@ export const useFolderMessages = (folderId: string, enabled = true) => {
   return {
     ...query,
     messages: query.data?.pages.flatMap((page) => page) as MessageMetadata[],
-    // @ts-ignore
-    shouldScrollToTop: query.data?.shouldScrollToTop,
   };
 };
 

--- a/conversation/frontend/src/services/queries/message.ts
+++ b/conversation/frontend/src/services/queries/message.ts
@@ -15,7 +15,6 @@ import { Message, MessageBase } from '~/models';
 import {
   baseUrl,
   createDefaultMessage,
-  folderQueryOptions,
   messageService,
   useFolderUtils,
 } from '~/services';

--- a/conversation/frontend/src/services/queries/message.ts
+++ b/conversation/frontend/src/services/queries/message.ts
@@ -232,9 +232,8 @@ export const useTrashMessage = () => {
       // Delete messages from query cache
       deleteMessagesFromQueryCache(folderId, messageIds);
 
-      // Invalidate trash folder
-      queryClient.resetQueries({
-        queryKey: folderQueryOptions.getMessagesQuerykey('trash', {}),
+      invalidateQueriesWithFirstPage(queryClient, {
+        queryKey: ['folder', 'messages', 'trash'],
       });
 
       toast.success(
@@ -299,7 +298,7 @@ export const useEmptyTrash = () => {
   return useMutation({
     mutationFn: () => messageService.emptyTrash(),
     onSuccess: () => {
-      queryClient.resetQueries({
+      invalidateQueriesWithFirstPage(queryClient, {
         queryKey: ['folder', 'messages', 'trash'],
       });
     },
@@ -511,7 +510,7 @@ export const useCreateDraft = () => {
       setMessage({ ...message });
       updateFolderBadgeCountQueryCache('draft', 1);
 
-      queryClient.resetQueries({
+      invalidateQueriesWithFirstPage(queryClient, {
         queryKey: ['folder', 'messages', 'draft'],
       });
     },
@@ -555,7 +554,7 @@ export const useUpdateDraft = () => {
         },
       );
 
-      queryClient.resetQueries({
+      invalidateQueriesWithFirstPage(queryClient, {
         queryKey: ['folder', 'messages', 'draft'],
       });
     },
@@ -605,12 +604,12 @@ export const useSendDraft = () => {
         ].includes(user.userId)
       ) {
         updateFolderBadgeCountQueryCache('inbox', +1);
-        queryClient.resetQueries({
+        invalidateQueriesWithFirstPage(queryClient, {
           queryKey: ['folder', 'messages', 'inbox'],
         });
       }
 
-      queryClient.resetQueries({
+      invalidateQueriesWithFirstPage(queryClient, {
         queryKey: ['folder', 'messages', 'outbox'],
       });
 

--- a/conversation/frontend/src/services/queries/message.ts
+++ b/conversation/frontend/src/services/queries/message.ts
@@ -23,6 +23,7 @@ import { useMessage, useMessageActions } from '~/store/messageStore';
 import { useDeleteMessagesFromQueryCache } from './hooks/useDeleteMessageFromQueryCache';
 import { useMessageListOnMutate } from './hooks/useMessageListOnMutate';
 import { useUpdateFolderBadgeCountQueryCache } from './hooks/useUpdateFolderBadgeCountQueryCache';
+import { invalidateQueriesWithFirstPage } from './utils';
 const appCodeName = 'conversation';
 /**
  * Message Query Options Factory.
@@ -269,16 +270,15 @@ export const useRestoreMessage = () => {
       });
 
       deleteMessagesFromQueryCache('trash', messageIds);
-
       // Reset all queries except trash folder
-      queryClient.resetQueries({
+      invalidateQueriesWithFirstPage(queryClient, {
         queryKey: ['folder', 'messages'],
         predicate: (query) => {
           const queryKey = query.queryKey as string[];
           return !queryKey.includes('trash');
         },
       });
-      // Invalidate folder tree to update the badge count
+
       queryClient.invalidateQueries({
         queryKey: ['folder', 'tree'],
       });

--- a/conversation/frontend/src/services/queries/message.ts
+++ b/conversation/frontend/src/services/queries/message.ts
@@ -86,8 +86,6 @@ export const useConversationConfig = () => {
  */
 export const useMessageQuery = (messageId: string) => {
   const result = useQuery(messageQueryOptions.getById(messageId));
-  const { folderId } = useSelectedFolder();
-  const { updateFolderMessagesQueryCache } = useFolderUtils();
   const { currentLanguage, user, userProfile } = useEdificeClient();
 
   if (result.isSuccess && result.data) {
@@ -99,15 +97,6 @@ export const useMessageQuery = (messageId: string) => {
       }
       if (message.body === null) {
         message.body = '';
-      }
-
-      // Update the message unread status in the list
-      if (folderId) {
-        updateFolderMessagesQueryCache(folderId, (oldMessage) =>
-          oldMessage.id === message.id
-            ? { ...oldMessage, unread: false }
-            : oldMessage,
-        );
       }
     } else {
       message = {

--- a/conversation/frontend/src/services/queries/utils.ts
+++ b/conversation/frontend/src/services/queries/utils.ts
@@ -1,0 +1,19 @@
+import { InvalidateQueryFilters, QueryClient } from '@tanstack/react-query';
+
+export function invalidateQueriesWithFirstPage(
+  queryClient: QueryClient,
+  options: InvalidateQueryFilters,
+) {
+  if (!options.queryKey) return;
+
+  queryClient.setQueriesData({ queryKey: options.queryKey }, (oldData: any) => {
+    if (!oldData?.pages) return oldData;
+    return {
+      ...oldData,
+      pages: [oldData.pages[0]],
+      pageParams: [oldData.pageParams[0]],
+    };
+  });
+
+  return queryClient.invalidateQueries(options);
+}

--- a/conversation/frontend/src/services/queries/utils.ts
+++ b/conversation/frontend/src/services/queries/utils.ts
@@ -12,6 +12,7 @@ export function invalidateQueriesWithFirstPage(
       ...oldData,
       pages: [oldData.pages[0]],
       pageParams: [oldData.pageParams[0]],
+      shouldScrollToTop: true,
     };
   });
 

--- a/conversation/frontend/src/services/queries/utils.ts
+++ b/conversation/frontend/src/services/queries/utils.ts
@@ -12,7 +12,6 @@ export function invalidateQueriesWithFirstPage(
       ...oldData,
       pages: [oldData.pages[0]],
       pageParams: [oldData.pageParams[0]],
-      shouldScrollToTop: true,
     };
   });
 

--- a/conversation/frontend/src/services/utils.ts
+++ b/conversation/frontend/src/services/utils.ts
@@ -1,5 +1,4 @@
 import { TreeItem } from '@edifice.io/react';
-import { InvalidateQueryFilters, QueryClient } from '@tanstack/react-query';
 import {
   Attachment,
   Folder,

--- a/conversation/frontend/src/services/utils.ts
+++ b/conversation/frontend/src/services/utils.ts
@@ -1,4 +1,5 @@
 import { TreeItem } from '@edifice.io/react';
+import { InvalidateQueryFilters, QueryClient } from '@tanstack/react-query';
 import {
   Attachment,
   Folder,


### PR DESCRIPTION
# Description

React-query optimisation
	•	Éviter de recharger plusieurs pages lorsque le cache est invalidé : création du helper invalidateQueriesWithFirstPage.
	•	Éviter le chargement de plusieurs pages à cause du scroll partagé entre différentes listes : remonter en haut de la liste lors du changement d’onglet.
	•	Correction du hook useMessage qui modifiait le cache d’une query. Si cette query était invalidée avant la modification, celle-ci était écrasée. L’action a été déplacée hors du hook et est désormais appelée directement dans le composant.

## Fixes

(Enter here Jira or Redmine ticket(s) links)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [x] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: