### PR TITLE
fix-(bookmark): #COCO-4022 optimize visible query to filter bookmark …

### DIFF
--- a/common/src/main/java/org/entcore/common/share/ShareService.java
+++ b/common/src/main/java/org/entcore/common/share/ShareService.java
@@ -33,6 +33,10 @@ import java.util.Set;
 
 public interface ShareService {
 
+	/**
+	 * Parameter use in userUtils to add a filter on the visible query on group or ids.
+	 * This constant is used as a key in additionalParams to pass the list of ids to check
+	 */
 	String EXPECTED_IDS_USERS_GROUPS = "expectedIdsOfUsersAndGroups";
 
 	void inheritShareInfos(String userId, String resourceId, String acceptLanguage, String search,

--- a/common/src/main/java/org/entcore/common/share/ShareService.java
+++ b/common/src/main/java/org/entcore/common/share/ShareService.java
@@ -32,6 +32,9 @@ import java.util.Optional;
 import java.util.Set;
 
 public interface ShareService {
+
+	String EXPECTED_IDS_USERS_GROUPS = "expectedIdsOfUsersAndGroups";
+
 	void inheritShareInfos(String userId, String resourceId, String acceptLanguage, String search,
 			Handler<Either<String, JsonObject>> handler);
 

--- a/common/src/main/java/org/entcore/common/share/impl/GenericShareService.java
+++ b/common/src/main/java/org/entcore/common/share/impl/GenericShareService.java
@@ -30,7 +30,6 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-
 import org.entcore.common.events.EventStore;
 import org.entcore.common.events.EventStoreFactory;
 import org.entcore.common.neo4j.Neo4j;
@@ -46,9 +45,7 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static fr.wseduc.webutils.Utils.getOrElse;
-import static fr.wseduc.webutils.Utils.isEmpty;
-import static fr.wseduc.webutils.Utils.isNotEmpty;
+import static fr.wseduc.webutils.Utils.*;
 import static org.entcore.common.neo4j.Neo4jResult.validResultHandler;
 import static org.entcore.common.user.UserUtils.findVisibleProfilsGroups;
 import static org.entcore.common.user.UserUtils.findVisibleUsers;
@@ -70,6 +67,7 @@ public abstract class GenericShareService implements ShareService {
 	private JsonArray resourceActions;
 	private final Vertx vertx = Vertx.currentContext().owner();
 	private final EventStore eventStore;
+
 
 	public GenericShareService(EventBus eb, Map<String, SecuredAction> securedActions,
 			Map<String, List<String>> groupedActions) {
@@ -489,11 +487,11 @@ public abstract class GenericShareService implements ShareService {
 			final JsonArray idsOfShare = new JsonArray();
 			idsOfShareChunk.forEach(idsOfShare::add);
 			final JsonObject extraParams = new JsonObject()
-					.put(UserUtils.EXPECTED_IDS_USERS_GROUPS, idsOfShare);
+					.put(EXPECTED_IDS_USERS_GROUPS, idsOfShare);
 			UserUtils.findVisibles(eb, userId, customReturn,
 					extraParams,
 					true, true, false,
-					"fr", "AND (m.id IN {" + UserUtils.EXPECTED_IDS_USERS_GROUPS + "}) ",
+					"fr", "AND (m.id IN {" + EXPECTED_IDS_USERS_GROUPS + "}) ",
 					visiblePromise::complete);
 			visibleFutures.add(visiblePromise.future());
 		});

--- a/common/src/main/java/org/entcore/common/share/impl/GenericShareService.java
+++ b/common/src/main/java/org/entcore/common/share/impl/GenericShareService.java
@@ -30,7 +30,6 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-import io.vertx.core.shareddata.LocalMap;
 
 import org.entcore.common.events.EventStore;
 import org.entcore.common.events.EventStoreFactory;
@@ -482,7 +481,7 @@ public abstract class GenericShareService implements ShareService {
 		final String customReturn = "RETURN DISTINCT visibles.id as id, has(visibles.login) as isUser";
 
 		// Parallelizing the process of fetching the visibles
-		final int partitionSize = UserUtils.getSharesPartitionSize();
+		final int partitionSize = UserUtils.getMaxCheckIdsSize();
 		final List<List<String>> idsOfShareChunks = Lists.partition(getIdOfGroupsAndUsersConcernedByShares(originalShares, shareUpdates), partitionSize);
 		final List<Future<JsonArray>> visibleFutures = new ArrayList<>();
 		idsOfShareChunks.forEach(idsOfShareChunk -> {

--- a/common/src/main/java/org/entcore/common/share/impl/GenericShareService.java
+++ b/common/src/main/java/org/entcore/common/share/impl/GenericShareService.java
@@ -490,11 +490,11 @@ public abstract class GenericShareService implements ShareService {
 			final JsonArray idsOfShare = new JsonArray();
 			idsOfShareChunk.forEach(idsOfShare::add);
 			final JsonObject extraParams = new JsonObject()
-					.put("expectedIdsOfUsersAndGroups", idsOfShare);
+					.put(UserUtils.EXPECTED_IDS_USERS_GROUPS, idsOfShare);
 			UserUtils.findVisibles(eb, userId, customReturn,
 					extraParams,
 					true, true, false,
-					"fr", "AND (m.id IN {expectedIdsOfUsersAndGroups}) ",
+					"fr", "AND (m.id IN {" + UserUtils.EXPECTED_IDS_USERS_GROUPS + "}) ",
 					visiblePromise::complete);
 			visibleFutures.add(visiblePromise.future());
 		});

--- a/common/src/main/java/org/entcore/common/user/UserUtils.java
+++ b/common/src/main/java/org/entcore/common/user/UserUtils.java
@@ -645,8 +645,9 @@ public class UserUtils {
 	}
 
 	/**
-	 * Check if a user can communicate with some other (visible) users or groups.
-	 *
+	 * Check if a user can communicate with some other (visible) users or groups. Fallback on returning all visible
+	 * if too many checkIds should be checked to avoid performance issue.
+	 * cf sharesMaxCheckSize in server configuration
 	 * @param userId  id of the sender
 	 * @param checkIds list of ids to check
 	 * @return JsonArray of JsonObjects:
@@ -654,7 +655,7 @@ public class UserUtils {
 	 * id: recipient ID which the sender can communicate with
 	 * }
 	 */
-	public static Future<JsonArray> filterVisibles(EventBus eb, String userId, JsonArray checkIds) {
+	public static Future<JsonArray> filterFewOrGetAllVisibles(EventBus eb, String userId, JsonArray checkIds) {
 		if(StringUtils.isEmpty(userId) || checkIds == null || checkIds.isEmpty()) {
 			return Future.succeededFuture(new JsonArray());
 		}

--- a/common/src/main/java/org/entcore/common/user/UserUtils.java
+++ b/common/src/main/java/org/entcore/common/user/UserUtils.java
@@ -53,6 +53,7 @@ import java.util.stream.Collectors;
 import static fr.wseduc.webutils.Utils.*;
 import static fr.wseduc.webutils.http.Renders.unauthorized;
 import static org.entcore.common.http.filter.AppOAuthResourceProvider.getTokenId;
+import static org.entcore.common.share.ShareService.EXPECTED_IDS_USERS_GROUPS;
 
 public class UserUtils {
 
@@ -76,7 +77,7 @@ public class UserUtils {
 	public static final String FIND_SESSION = "findSession";
 	public static final String MONITORINGEVENTS = "monitoringevents";
 	public static final String SESSION_ADDRESS = "wse.session";
-	public static final String EXPECTED_IDS_USERS_GROUPS = "expectedIdsOfUsersAndGroups";
+
 
 	private static void findUsers(final EventBus eb, HttpServerRequest request,
 								  final JsonObject query, final Handler<JsonArray> handler) {

--- a/common/src/main/java/org/entcore/common/user/UserUtils.java
+++ b/common/src/main/java/org/entcore/common/user/UserUtils.java
@@ -656,6 +656,11 @@ public class UserUtils {
 	 * }
 	 */
 	public static Future<JsonArray> filterFewOrGetAllVisibles(EventBus eb, String userId, JsonArray checkIds) {
+		return filterFewOrGetAllVisibles(eb, userId, checkIds, false, null, " MATCH (visibles) RETURN DISTINCT visibles.id as id ", true);
+	};
+
+	public static Future<JsonArray> filterFewOrGetAllVisibles(EventBus eb, String userId, JsonArray checkIds,
+															  boolean itself, String language, String customReturn, boolean reverseUnion) {
 		if(StringUtils.isEmpty(userId) || checkIds == null || checkIds.isEmpty()) {
 			return Future.succeededFuture(new JsonArray());
 		}
@@ -665,26 +670,26 @@ public class UserUtils {
 			params.put(EXPECTED_IDS_USERS_GROUPS, checkIds);
 		}
 		visibleFutures.add(findVisibles(eb,
-			userId,
-			" MATCH (visibles) RETURN DISTINCT visibles.id as id ",
-			params,
-			false,
-			true,
-			false,
-			null,
-			null,
-			null,
-			true
+				userId,
+				customReturn,
+				params,
+				itself,
+				true,
+				false,
+				language,
+				null,
+				null,
+				reverseUnion
 		));
 
 		return Future.all(visibleFutures)
-			.map(futures -> {
-				return futures.list().stream()
-				.map(JsonArray.class::cast)
-				.flatMap(arr -> arr.stream().map(JsonObject.class::cast))
-				.collect(Collector.of(JsonArray::new, JsonArray::add, JsonArray::add));
-			});
-	};
+				.map(futures -> {
+					return futures.list().stream()
+							.map(JsonArray.class::cast)
+							.flatMap(arr -> arr.stream().map(JsonObject.class::cast))
+							.collect(Collector.of(JsonArray::new, JsonArray::add, JsonArray::add));
+				});
+	}
 
 	public static void getSession(EventBus eb, final HttpServerRequest request,
 								  final Handler<JsonObject> handler) {

--- a/common/src/main/java/org/entcore/common/user/UserUtils.java
+++ b/common/src/main/java/org/entcore/common/user/UserUtils.java
@@ -280,7 +280,7 @@ public class UserUtils {
 			} else {
 				partitionSize = DEFAULT_MAX_CHECK_ID;
 			}
-			VISIBLE_CONFIG.put("sharesPartitionSize", partitionSize);
+			VISIBLE_CONFIG.put("sharesMaxCheckSize", partitionSize);
 		}
 		return partitionSize <= 0 ? DEFAULT_MAX_CHECK_ID : partitionSize;
 	}

--- a/common/src/main/java/org/entcore/common/user/UserUtils.java
+++ b/common/src/main/java/org/entcore/common/user/UserUtils.java
@@ -39,7 +39,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.shareddata.LocalMap;
-import org.apache.commons.collections4.CollectionUtils;
 import org.entcore.common.neo4j.Neo4j;
 import org.entcore.common.session.SessionRecreationRequest;
 import org.entcore.common.utils.HostUtils;
@@ -268,7 +267,7 @@ public class UserUtils {
 		return timeout <= 0 ? DEFAULT_VISIBLES_TIMEOUT : timeout;
 	}
 
-	static public int getSharesPartitionSize() {
+	static public int getMaxCheckIdsSize() {
 		final int partitionSize;
 		if( VISIBLE_CONFIG.containsKey("sharesMaxCheckSize")) {
 			partitionSize = VISIBLE_CONFIG.getInteger("sharesMaxCheckSize");
@@ -660,7 +659,7 @@ public class UserUtils {
 		}
 		final List<Future<JsonArray>> visibleFutures = new ArrayList<>();
 		final JsonObject params = new JsonObject();
-		if(checkIds.size() < DEFAULT_MAX_CHECK_ID) {
+		if(checkIds.size() < getMaxCheckIdsSize()) {
 			params.put(EXPECTED_IDS_USERS_GROUPS, checkIds);
 		}
 		visibleFutures.add(findVisibles(eb,

--- a/communication/src/main/java/org/entcore/communication/services/impl/DefaultCommunicationService.java
+++ b/communication/src/main/java/org/entcore/communication/services/impl/DefaultCommunicationService.java
@@ -601,10 +601,10 @@ public class DefaultCommunicationService implements CommunicationService {
 			query.append("WITH (REDUCE(acc=[], groups IN COLLECT(COALESCE(g.communiqueWith, [])) | acc+groups) + ")
 					.append(myGroupQuery).append(") as comGroups ");
 			//filter user and group with a distinction on the type to help neo4j to optimize
-			if (additionalParams.getJsonArray("expectedIdsOfUsersAndGroups") != null) {
-				query.append("OPTIONAL MATCH (u:User) WHERE u.id IN {expectedIdsOfUsersAndGroups} and u.id <> {userId} ");
+			if (additionalParams.getJsonArray(UserUtils.EXPECTED_IDS_USERS_GROUPS) != null) {
+				query.append("OPTIONAL MATCH (u:User) WHERE u.id IN {" + UserUtils.EXPECTED_IDS_USERS_GROUPS + "} and u.id <> {userId} ");
 				query.append("WITH comGroups, collect(u) as cu ");
-				query.append("OPTIONAL MATCH (g:Group) WHERE g.id IN {expectedIdsOfUsersAndGroups} ");
+				query.append("OPTIONAL MATCH (g:Group) WHERE g.id IN {" + UserUtils.EXPECTED_IDS_USERS_GROUPS + "} ");
 				query.append("WITH comGroups, cu, collect(g) as cg with comGroups, cg+cu as cug unwind cug as m ");
 			}
 			query.append("MATCH p=(g:Group)<-[:DEPENDS*0..1]-cg-[:COMMUNIQUE*0..1]->m ");

--- a/communication/src/main/java/org/entcore/communication/services/impl/DefaultCommunicationService.java
+++ b/communication/src/main/java/org/entcore/communication/services/impl/DefaultCommunicationService.java
@@ -611,6 +611,13 @@ public class DefaultCommunicationService implements CommunicationService {
 			query.append(" MATCH (n:User {id: {userId}})-[:COMMUNIQUE]->(g:Group) ");
 			query.append("WITH (REDUCE(acc=[], groups IN COLLECT(COALESCE(g.communiqueWith, [])) | acc+groups) + ")
 					.append(myGroupQuery).append(") as comGroups ");
+			//filter user and group with a distinction on the type to help neo4j to optimize
+			if (additionalParams.getJsonArray("expectedIdsOfUsersAndGroups") != null) {
+				query.append("OPTIONAL MATCH (u:User) WHERE u.id IN {expectedIdsOfUsersAndGroups} and u.id <> {userId} ");
+				query.append("WITH comGroups, collect(u) as cu ");
+				query.append("OPTIONAL MATCH (g:Group) WHERE g.id IN {expectedIdsOfUsersAndGroups} ");
+				query.append("WITH comGroups, cu, collect(g) as cg with comGroups, cg+cu as cug unwind cug as m ");
+			}
 			query.append("MATCH p=(g:Group)<-[:DEPENDS*0..1]-cg-[:COMMUNIQUE*0..1]->m ");
 			if (userProfile == null || "Student".equals(userProfile) || "Relative".equals(userProfile) || discoverVisibleExpectedProfile.contains(userProfile) ) {
 				union = new StringBuilder("MATCH p=(n:User)-[:COMMUNIQUE_DIRECT]->m " +

--- a/communication/src/main/java/org/entcore/communication/services/impl/DefaultCommunicationService.java
+++ b/communication/src/main/java/org/entcore/communication/services/impl/DefaultCommunicationService.java
@@ -40,23 +40,12 @@ import org.entcore.common.utils.StringUtils;
 import org.entcore.common.validation.StringValidation;
 import org.entcore.communication.services.CommunicationService;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 import static io.vertx.core.json.JsonObject.mapFrom;
-import static org.entcore.common.neo4j.Neo4jResult.fullNodeMergeHandler;
-import static org.entcore.common.neo4j.Neo4jResult.validEmptyHandler;
-import static org.entcore.common.neo4j.Neo4jResult.validResultHandler;
-import static org.entcore.common.neo4j.Neo4jResult.validUniqueResult;
-import static org.entcore.common.neo4j.Neo4jResult.validUniqueResultHandler;
+import static org.entcore.common.neo4j.Neo4jResult.*;
 
 public class DefaultCommunicationService implements CommunicationService {
 

--- a/communication/src/main/java/org/entcore/communication/services/impl/DefaultCommunicationService.java
+++ b/communication/src/main/java/org/entcore/communication/services/impl/DefaultCommunicationService.java
@@ -46,6 +46,7 @@ import java.util.stream.Collectors;
 
 import static io.vertx.core.json.JsonObject.mapFrom;
 import static org.entcore.common.neo4j.Neo4jResult.*;
+import static org.entcore.common.share.ShareService.EXPECTED_IDS_USERS_GROUPS;
 
 public class DefaultCommunicationService implements CommunicationService {
 
@@ -601,10 +602,10 @@ public class DefaultCommunicationService implements CommunicationService {
 			query.append("WITH (REDUCE(acc=[], groups IN COLLECT(COALESCE(g.communiqueWith, [])) | acc+groups) + ")
 					.append(myGroupQuery).append(") as comGroups ");
 			//filter user and group with a distinction on the type to help neo4j to optimize
-			if (additionalParams.getJsonArray(UserUtils.EXPECTED_IDS_USERS_GROUPS) != null) {
-				query.append("OPTIONAL MATCH (u:User) WHERE u.id IN {" + UserUtils.EXPECTED_IDS_USERS_GROUPS + "} and u.id <> {userId} ");
+			if (additionalParams.getJsonArray(EXPECTED_IDS_USERS_GROUPS) != null) {
+				query.append("OPTIONAL MATCH (u:User) WHERE u.id IN {" + EXPECTED_IDS_USERS_GROUPS + "} and u.id <> {userId} ");
 				query.append("WITH comGroups, collect(u) as cu ");
-				query.append("OPTIONAL MATCH (g:Group) WHERE g.id IN {" + UserUtils.EXPECTED_IDS_USERS_GROUPS + "} ");
+				query.append("OPTIONAL MATCH (g:Group) WHERE g.id IN {" + EXPECTED_IDS_USERS_GROUPS + "} ");
 				query.append("WITH comGroups, cu, collect(g) as cg with comGroups, cg+cu as cug unwind cug as m ");
 			}
 			query.append("MATCH p=(g:Group)<-[:DEPENDS*0..1]-cg-[:COMMUNIQUE*0..1]->m ");

--- a/directory/src/main/java/org/entcore/directory/controllers/ShareBookmarkController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/ShareBookmarkController.java
@@ -30,14 +30,12 @@ import fr.wseduc.webutils.http.BaseController;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-
 import org.entcore.common.http.filter.AdminFilter;
 import org.entcore.common.http.filter.ResourceFilter;
 import org.entcore.common.user.UserUtils;
 import org.entcore.directory.services.ShareBookmarkService;
 
 import static fr.wseduc.webutils.request.RequestUtils.bodyToJson;
-
 import static org.entcore.common.http.response.DefaultResponseHandler.*;
 
 public class ShareBookmarkController extends BaseController {

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultShareBookmarkService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultShareBookmarkService.java
@@ -131,7 +131,7 @@ public class DefaultShareBookmarkService implements ShareBookmarkService {
 
 			// Check bookmarked members' visibility
 			final Set<String> membersMapIds = membersMap.keySet();
-			UserUtils.filterVisibles(
+			UserUtils.filterFewOrGetAllVisibles(
 				eb, 
 				userId,
 				new JsonArray( membersMapIds.stream().collect(Collectors.toList()) )

--- a/tests/src/test/js/it/scenarios/communication/_sharebookmark-utils.ts
+++ b/tests/src/test/js/it/scenarios/communication/_sharebookmark-utils.ts
@@ -1,0 +1,18 @@
+import { getHeaders, ShareBookMark } from "../../../node_modules/edifice-k6-commons/dist/index.js";
+import { check } from "k6";
+import http, { RefinedResponse } from "k6/http";
+
+
+
+export function checkNbBookmarkVisible(
+  bookmark: ShareBookMark,
+  expectedCount: number,
+  checkName: string
+) {
+  const checks = {};
+  checks[`${checkName} - Bookmark number`] = (b) => b.users.length === expectedCount;
+  const ok = check(bookmark, checks);
+  if (!ok) {
+    console.error(checkName, bookmark.users.length);
+  }
+}

--- a/tests/src/test/js/it/scenarios/communication/sharebookmark.ts
+++ b/tests/src/test/js/it/scenarios/communication/sharebookmark.ts
@@ -1,0 +1,79 @@
+import {describe } from "https://jslib.k6.io/k6chaijs/4.3.4.0/index.js";
+
+import {
+  authenticateWeb,
+  getUsersOfSchool,
+  addCommRuleToGroup,
+  attachStructureAsChild,
+  initStructure,
+  getRandomUserWithProfile,
+  Session,
+  searchVisibles,
+  Structure,
+  getProfileGroupOfStructureByType,
+  UserProfileType
+} from "../../../node_modules/edifice-k6-commons/dist/index.js";
+
+const maxDuration = __ENV.MAX_DURATION || "1m";
+const schoolName = __ENV.DATA_SCHOOL_NAME || "Maxi Users";
+const gracefulStop = parseInt(__ENV.GRACEFUL_STOP || "2s");
+
+export const options = {
+  setupTimeout: "1h",
+  thresholds: {
+    checks: ["rate == 1.00"],
+  },
+  scenarios: {
+    testCanSeeUsersFromBookMark: {
+      executor: "per-vu-iterations",
+      exec: "testCanSeeUsersFromBookMark",
+      vus: 1,
+      maxDuration: maxDuration,
+      gracefulStop,
+    },
+  },
+};
+
+type InitData = {
+  head: Structure;
+  structures: Structure[];
+}
+
+export function setup() {
+  let head :Structure|null = null;
+  const structures: Structure[] = [];
+  const profiles: UserProfileType[] = ['Teacher', 'Student', 'Relative'];
+  describe("[Bookmark-Init] Initialize data", () => {
+    <Session>authenticateWeb(__ENV.ADMC_LOGIN, __ENV.ADMC_PASSWORD);
+    const head = initStructure(`${schoolName} - Head`)
+    const teacherProfileGroup = getProfileGroupOfStructureByType('Teacher', head)
+    const attachedStructuresGroups: string[] = []
+    for(let i=0; i < 10; i++) {
+      const school = initStructure(`${schoolName} - School ${i}`);
+      structures.push(school);
+      attachStructureAsChild(head, school)
+      for(let profile of profiles) {
+        const schoolProfileGroup = getProfileGroupOfStructureByType(profile, school);
+        attachedStructuresGroups.push(schoolProfileGroup.id);
+      }
+    }
+    addCommRuleToGroup(teacherProfileGroup.id, attachedStructuresGroups)
+  });
+  return { head, structures};
+}
+
+export function testCanSeeUsersFromBookMark(data: InitData){
+  describe('[Bookmark] Test that a user can see favourite users ', () => {
+    const headUsers = getUsersOfSchool(data.head);
+    const headTeacher = getRandomUserWithProfile(headUsers, 'Teacher');
+    // Create a share bookmark with the users of all the structures
+    for(let structure of data.structures) {
+      const users = getUsersOfSchool(structure);
+      for(let user of users) {
+      }
+    }
+    // Now call /conversation/visibles to see if the users are visible
+    authenticateWeb(headTeacher.login);
+    searchVisibles();
+  });
+};

--- a/tests/src/test/js/it/scenarios/communication/sharebookmark.ts
+++ b/tests/src/test/js/it/scenarios/communication/sharebookmark.ts
@@ -8,15 +8,12 @@ import {
   initStructure,
   getRandomUserWithProfile,
   Session,
-  searchVisibles,
   Structure,
   getTeacherRole,
-  getProfileGroupOfStructureByType,
   getRolesOfStructure,
   UserProfileType,
   ShareBookMarkCreationRequest,
-  createShareBookMarkOrFail,
-  UserInfo
+  createShareBookMarkOrFail
 } from "../../../node_modules/edifice-k6-commons/dist/index.js";
 import {
   checkNbBookmarkVisible

--- a/tests/src/test/js/package.json
+++ b/tests/src/test/js/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
     "@types/k6": "^0.54.2",
-    "edifice-k6-commons": "develop"
+    "edifice-k6-commons": "latest"
   }
 }

--- a/tests/src/test/js/pnpm-lock.yaml
+++ b/tests/src/test/js/pnpm-lock.yaml
@@ -1,24 +1,31 @@
-lockfileVersion: '6.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-devDependencies:
-  '@types/k6':
-    specifier: ^0.54.2
-    version: 0.54.2
-  edifice-k6-commons:
-    specifier: develop
-    version: 1.0.1-develop.2
+importers:
+
+  .:
+    devDependencies:
+      '@types/k6':
+        specifier: ^0.54.2
+        version: 0.54.2
+      edifice-k6-commons:
+        specifier: latest
+        version: 2.1.1
 
 packages:
 
-  /@types/k6@0.54.2:
+  '@types/k6@0.54.2':
     resolution: {integrity: sha512-B5LPxeQm97JnUTpoKNE1UX9jFp+JiJCAXgZOa2P7aChxVoPQXKfWMzK+739xHq3lPkKj1aV+HeOxkP56g/oWBg==}
-    dev: true
 
-  /edifice-k6-commons@1.0.1-develop.2:
-    resolution: {integrity: sha512-+Ac72BHzFi8kO/UofjtR7gOoUEMt5rULEUPk4hdGvXdC+NmjYAFiqKo3M9BCj27zQu2JtqQaekt4uOnEBptX+w==}
+  edifice-k6-commons@2.1.1:
+    resolution: {integrity: sha512-r+eeO3hjTj4thRwDckG0SsCFkBIw0nuOVVJaZFOoDKHbidxjkgiRYA0Ygmu+yWCffBHpcHUiFMZtANaxYxlnJQ==}
     engines: {node: 18 || 20}
-    dev: true
+
+snapshots:
+
+  '@types/k6@0.54.2': {}
+
+  edifice-k6-commons@2.1.1: {}


### PR DESCRIPTION
…users

# Description

Bookmark are not updated when a visible rule is updated at some point. To avoid problems when sending a message using a bookmark, it was decided to filter visible in the bookmark in the backend, so the front end will only see a correct list of visibles.
A first implementation was made by jcbe with a partition list on visible to check, in parallel. But performance of this strategy was problematic. In this MR, we change the strategy, and modify the inital query on neo4j to check visible with an optimized query. This query is much faster, but there is a threshold where it is quicker to get all the visible and make an intersection with the visible we need to check.

## Fixes

[(Enter here Jira or Redmine ticket(s) links)](https://edifice-community.atlassian.net/browse/COCO-4022)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [x] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

In the message interface, use a bookmark that contain many users, some of them no longer visible
When adding the bookmark as TO in the message
Then the time spend should be acceptable and not visible users should not appear in the list of users.

In the blog and actuality interface, in the share interface, 
test should be done on adding, updating or removing share
Time spend on numerous share should be try

Use the PUT actualites/thread/3/info/share/resource/6 to add a share on a user not seen by the sharer
The server return a 200 OK but doesn't add the share and a message log a rejection


# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: