### PR TITLE
fix(common): #COCO-4321, fix object storage download content type

### DIFF
--- a/common/src/main/java/org/entcore/common/s3/S3Client.java
+++ b/common/src/main/java/org/entcore/common/s3/S3Client.java
@@ -361,7 +361,12 @@ public class S3Client {
 						log.warn("Client response Headers have already been written : " + resp.getStatusCode() + " \n" + resp.headers());
 					} else {
 						resp.putHeader("ETag", ((eTag != null) ? eTag : response.headers().get("ETag")));
-						resp.putHeader("Content-Type", response.headers().get("Content-Type"));
+						if (metadata != null && metadata.getString("content-type") != null) {
+							resp.putHeader("Content-Type", metadata.getString("content-type"));
+						}
+						else {
+							resp.putHeader("Content-Type", response.headers().get("Content-Type"));
+						}
 						resp.putHeader("Content-Length", response.headers().get("Content-Length"));
 					}
 				}


### PR DESCRIPTION
# Description

With ObjectStorage, if the content-type is wrong, downloads could be in error (mobile...).
If the content-type is present in mongo metadata and if metadata are passed to downloadFile, we will use it.

## Fixes

[#COCO-4321](https://edifice-community.atlassian.net/browse/COCO-4321)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: