### PR TITLE
feat: #RBACk-90, support the detection of @BrokerListener on methods inherited from super classes

### DIFF
--- a/broker-parent/broker-api/src/main/java/org/entcore/broker/api/BrokerListener.java
+++ b/broker-parent/broker-api/src/main/java/org/entcore/broker/api/BrokerListener.java
@@ -1,10 +1,7 @@
 package org.entcore.broker.api;
 
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * Annotation to mark methods that should listen on a broker particular subject.

--- a/broker-parent/broker-api/src/test/java/org/entcore/broker/api/utils/BrokerProxyUtilsTest.java
+++ b/broker-parent/broker-api/src/test/java/org/entcore/broker/api/utils/BrokerProxyUtilsTest.java
@@ -1,0 +1,94 @@
+package org.entcore.broker.api.utils;
+
+import io.vertx.core.json.JsonObject;
+import org.entcore.broker.api.BrokerListener;
+import org.entcore.broker.api.utils.dummy.*;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class BrokerProxyUtilsTest {
+  @Test
+  public void testGetListenersWithoutAnnotation() {
+    assertTrue("A class which does not implement @BrokerListener should not have listeners", BrokerProxyUtils.getListeners(new JsonObject()).isEmpty());
+  }
+  @Test
+  public void testGetListenersWithAnnotatedMethods() {
+    final List<BrokerProxyUtils.Listener> listeners = BrokerProxyUtils.getListeners(new Object() {
+      @BrokerListener(subject = "simple.test", proxy = true, broadcast = true)
+      public void simpleTest() {
+      }
+      @BrokerListener(subject = "simple.test", proxy = true, broadcast = true)
+      public ExempleResponseDTO hello(ExempleRequestDTO request) {
+        return null;
+      }
+      public void notAListener() {
+      }
+    });
+    assertEquals("Should find all listeners and just these functions", 2, listeners.size());
+  }
+  @Test
+  public void testGetListenersWithAnnotatedMethodsInheritedFromDirectInterface() {
+    final List<BrokerProxyUtils.Listener> listeners = BrokerProxyUtils.getListeners(new DummyProxy() {
+      @Override
+      public void simpleTest() {
+
+      }
+
+      @Override
+      public ExempleResponseDTO hello(ExempleRequestDTO request) {
+        return null;
+      }
+
+      @Override
+      public void notAListener() {
+
+      }
+    });
+    assertEquals("Should find all listeners and just these functions", 2, listeners.size());
+  }
+  @Test
+  public void testGetListenersWithAnnotatedMethodsInheritedFromNestedInterface() {
+    final List<BrokerProxyUtils.Listener> listeners = BrokerProxyUtils.getListeners(new DummierProxy() {
+      @Override
+      public void simpleTest() {
+
+      }
+
+      @Override
+      public ExempleResponseDTO hello(ExempleRequestDTO request) {
+        return null;
+      }
+
+      @Override
+      public void notAListener() {
+
+      }
+    });
+    assertEquals("Should find all listeners and just these functions", 2, listeners.size());
+  }
+  @Test
+  public void testGetListenersWithAnnotatedMethodsInheritedFromNestedClass() {
+    final List<BrokerProxyUtils.Listener> listeners = BrokerProxyUtils.getListeners(new DummyProxyImpl() {
+      @Override
+      public void simpleTest() {
+
+      }
+
+      @Override
+      public ExempleResponseDTO hello(ExempleRequestDTO request) {
+        return null;
+      }
+
+      @Override
+      public void notAListener() {
+
+      }
+    });
+    assertEquals("Should find all listeners and just these functions", 2, listeners.size());
+  }
+
+}

--- a/broker-parent/broker-api/src/test/java/org/entcore/broker/api/utils/dummy/DummierProxy.java
+++ b/broker-parent/broker-api/src/test/java/org/entcore/broker/api/utils/dummy/DummierProxy.java
@@ -1,0 +1,4 @@
+package org.entcore.broker.api.utils.dummy;
+
+public interface DummierProxy extends DummyProxy {
+}

--- a/broker-parent/broker-api/src/test/java/org/entcore/broker/api/utils/dummy/DummyProxy.java
+++ b/broker-parent/broker-api/src/test/java/org/entcore/broker/api/utils/dummy/DummyProxy.java
@@ -1,0 +1,13 @@
+package org.entcore.broker.api.utils.dummy;
+
+import org.entcore.broker.api.BrokerListener;
+
+public interface DummyProxy {
+  @BrokerListener(subject = "simple.test", proxy = true, broadcast = true)
+  void simpleTest();
+
+  @BrokerListener(subject = "simple.test", proxy = true, broadcast = true)
+  ExempleResponseDTO hello(ExempleRequestDTO request);
+
+  void notAListener();
+}

--- a/broker-parent/broker-api/src/test/java/org/entcore/broker/api/utils/dummy/DummyProxyImpl.java
+++ b/broker-parent/broker-api/src/test/java/org/entcore/broker/api/utils/dummy/DummyProxyImpl.java
@@ -1,0 +1,18 @@
+package org.entcore.broker.api.utils.dummy;
+
+public class DummyProxyImpl implements DummierProxy {
+  @Override
+  public void simpleTest() {
+
+  }
+
+  @Override
+  public ExempleResponseDTO hello(ExempleRequestDTO request) {
+    return null;
+  }
+
+  @Override
+  public void notAListener() {
+
+  }
+}

--- a/broker-parent/broker-api/src/test/java/org/entcore/broker/api/utils/dummy/ExempleRequestDTO.java
+++ b/broker-parent/broker-api/src/test/java/org/entcore/broker/api/utils/dummy/ExempleRequestDTO.java
@@ -1,4 +1,4 @@
 package org.entcore.broker.api.utils.dummy;
 
-public class ExempleRequestDTO {
+public class ExampleRequestDTO {
 }

--- a/broker-parent/broker-api/src/test/java/org/entcore/broker/api/utils/dummy/ExempleRequestDTO.java
+++ b/broker-parent/broker-api/src/test/java/org/entcore/broker/api/utils/dummy/ExempleRequestDTO.java
@@ -1,0 +1,4 @@
+package org.entcore.broker.api.utils.dummy;
+
+public class ExempleRequestDTO {
+}

--- a/broker-parent/broker-api/src/test/java/org/entcore/broker/api/utils/dummy/ExempleResponseDTO.java
+++ b/broker-parent/broker-api/src/test/java/org/entcore/broker/api/utils/dummy/ExempleResponseDTO.java
@@ -1,0 +1,4 @@
+package org.entcore.broker.api.utils.dummy;
+
+public class ExempleResponseDTO {
+}

--- a/broker-parent/broker-api/src/test/java/org/entcore/broker/api/utils/dummy/ExempleResponseDTO.java
+++ b/broker-parent/broker-api/src/test/java/org/entcore/broker/api/utils/dummy/ExempleResponseDTO.java
@@ -1,4 +1,4 @@
 package org.entcore.broker.api.utils.dummy;
 
-public class ExempleResponseDTO {
+public class ExampleResponseDTO {
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   maven:
-    image: maven.opendigitaleducation.com/docker/repository/sre-docker-hosted/mvn-java8-node22:1.2.5
+    image: maven.opendigitaleducation.com/docker/repository/sre-docker-hosted/mvn-java8-node22:latest
     user: "$DEFAULT_DOCKER_USER"
     working_dir: /usr/src/maven
     volumes:


### PR DESCRIPTION
# Description

Cette PR permet au mécanisme de création des proxy NATS/EventBus de mieux détecter les annotations @BrokerListener lorsque celles-ci proviennent d'une classe héritée. Comme en Java les annotations de méthode ne sont pas héritées il faut "manuellement" aller les chercher récursivement sur la `super` classe.

## Fixes

RBACK-90

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [x] broker
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Ajout de nouveaux tests unitaires.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: