### PR TITLE
fix(communication): #PEDAGO-3031, exclude CommunityMemberGroup and CommunityAdminGroup from visibles and share search

### DIFF
--- a/common/src/main/java/org/entcore/common/communication/CommunicationUtils.java
+++ b/common/src/main/java/org/entcore/common/communication/CommunicationUtils.java
@@ -15,6 +15,9 @@ public class CommunicationUtils {
     private static final Logger log = LoggerFactory.getLogger(CommunicationUtils.class);
     private static final String COMMUNICATION_ADDRESS = "wse.communication";
 
+    public static final String COMMUNITY_MEMBER_GROUP = "CommunityMemberGroup";
+    public static final String COMMUNITY_ADMIN_GROUP = "CommunityAdminGroup";
+
     /**
      * Direction of communication links
      */

--- a/common/src/main/java/org/entcore/common/share/impl/GenericShareService.java
+++ b/common/src/main/java/org/entcore/common/share/impl/GenericShareService.java
@@ -32,6 +32,7 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.shareddata.LocalMap;
 
+import org.entcore.common.communication.CommunicationUtils;
 import org.entcore.common.events.EventStore;
 import org.entcore.common.events.EventStoreFactory;
 import org.entcore.common.neo4j.Neo4j;
@@ -269,8 +270,11 @@ public abstract class GenericShareService implements ShareService {
 				userParams.put("search", sanitizedSearch);
 				//
 				preFilterUserBuilder.append(" AND m.displayNameSearchField CONTAINS {search} ");
+
 				// Exclude CommunityMemberGroup and CommunityAdminGroup from search
-				preFilterGroupBuilder.append(" AND NOT ANY(label IN ['CommunityMemberGroup', 'CommunityAdminGroup'] WHERE label IN labels(m)) ");
+				preFilterGroupBuilder.append(" AND NOT m:" + CommunicationUtils.COMMUNITY_MEMBER_GROUP + " ");
+				preFilterGroupBuilder.append(" AND NOT m:" + CommunicationUtils.COMMUNITY_ADMIN_GROUP + " ");
+
 				// historically this filter was not user. should it be?
 				//preFilterGroupBuilder.append(" AND profileGroup.displayNameSearchField CONTAINS {search} ");
 			}

--- a/common/src/main/java/org/entcore/common/share/impl/GenericShareService.java
+++ b/common/src/main/java/org/entcore/common/share/impl/GenericShareService.java
@@ -269,6 +269,8 @@ public abstract class GenericShareService implements ShareService {
 				userParams.put("search", sanitizedSearch);
 				//
 				preFilterUserBuilder.append(" AND m.displayNameSearchField CONTAINS {search} ");
+				// Exclude CommunityMemberGroup and CommunityAdminGroup from search
+				preFilterGroupBuilder.append(" AND NOT ANY(label IN ['CommunityMemberGroup', 'CommunityAdminGroup'] WHERE label IN labels(m)) ");
 				// historically this filter was not user. should it be?
 				//preFilterGroupBuilder.append(" AND profileGroup.displayNameSearchField CONTAINS {search} ");
 			}

--- a/communication/src/main/java/org/entcore/communication/controllers/CommunicationController.java
+++ b/communication/src/main/java/org/entcore/communication/controllers/CommunicationController.java
@@ -37,6 +37,7 @@ import io.vertx.core.eventbus.Message;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import org.entcore.common.communication.CommunicationUtils;
 import org.entcore.common.http.filter.AdminFilter;
 import org.entcore.common.http.filter.ResourceFilter;
 import org.entcore.common.user.UserUtils;
@@ -240,8 +241,11 @@ public class CommunicationController extends BaseController {
 								final String search = filter.getString(criteria);
 								if (isNotEmpty(search)) {
 									preFilter = "AND m.displayNameSearchField CONTAINS {search} ";
+
 									// Exclude CommunityMemberGroup and CommunityAdminGroup from search
-									preFilter += "AND NOT ANY(label IN ['CommunityMemberGroup', 'CommunityAdminGroup'] WHERE label IN labels(m)) ";
+									preFilter += " AND NOT m:" + CommunicationUtils.COMMUNITY_MEMBER_GROUP + " ";
+									preFilter += " AND NOT m:" + CommunicationUtils.COMMUNITY_ADMIN_GROUP + " ";
+
 									String sanitizedSearch = StringValidation.sanitize(search);
 									params.put("search", sanitizedSearch);
 								}

--- a/communication/src/main/java/org/entcore/communication/controllers/CommunicationController.java
+++ b/communication/src/main/java/org/entcore/communication/controllers/CommunicationController.java
@@ -240,6 +240,8 @@ public class CommunicationController extends BaseController {
 								final String search = filter.getString(criteria);
 								if (isNotEmpty(search)) {
 									preFilter = "AND m.displayNameSearchField CONTAINS {search} ";
+									// Exclude CommunityMemberGroup and CommunityAdminGroup from search
+									preFilter += "AND NOT ANY(label IN ['CommunityMemberGroup', 'CommunityAdminGroup'] WHERE label IN labels(m)) ";
 									String sanitizedSearch = StringValidation.sanitize(search);
 									params.put("search", sanitizedSearch);
 								}


### PR DESCRIPTION
# Description

Exclude `CommunityMemberGroup` and `CommunityAdminGroup` from search in:
- `POST /communication/visible` API
- `GenericSearchService`, used in applications share panel to search users and groups

## Fixes

https://edifice-community.atlassian.net/browse/PEDAGO-3031

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [X] common
- [X] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: