### PR TITLE
Fix coco 4474 display and slow problems when mass mailing

### DIFF
--- a/admin/src/main/ts/package.json
+++ b/admin/src/main/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin-app",
-  "version": "6.7-SNAPSHOT",
+  "version": "6.7-%branch%.%generateVersion%",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --host 0.0.0.0",

--- a/app-registry/src/main/java/org/entcore/registry/controllers/AppRegistryController.java
+++ b/app-registry/src/main/java/org/entcore/registry/controllers/AppRegistryController.java
@@ -697,7 +697,9 @@ public class AppRegistryController extends BaseController {
 				}
 				if (userSkinLevels != null && userSkinLevels.contains("2d")) {
 					// We apply default bookmarks for 2D themes only
-					appRegistryService.applyDefaultBookmarks(userId);
+					appRegistryService.applyDefaultBookmarks(userId, busResponseHandler(message));
+				} else {
+					message.reply(new JsonObject().put("status", "ok"));
 				}
 				break;
 			default:

--- a/app-registry/src/main/java/org/entcore/registry/services/AppRegistryService.java
+++ b/app-registry/src/main/java/org/entcore/registry/services/AppRegistryService.java
@@ -21,10 +21,7 @@ package org.entcore.registry.services;
 
 import fr.wseduc.webutils.Either;
 
-import static org.entcore.common.http.response.DefaultResponseHandler.arrayResponseHandler;
-
 import io.vertx.core.Handler;
-import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -94,5 +91,5 @@ public interface AppRegistryService {
 
 	void setDefaultBookmarks(String structureId, JsonObject apps, Handler<Either<String, JsonObject>> handler);
 
-	void applyDefaultBookmarks(String userId);
+	void applyDefaultBookmarks(String userId, Handler<Either<String, JsonObject>> eitherHandler);
 }

--- a/conversation/backend/src/main/java/org/entcore/conversation/Conversation.java
+++ b/conversation/backend/src/main/java/org/entcore/conversation/Conversation.java
@@ -51,6 +51,8 @@ public class Conversation extends BaseServer {
 	/** Default strategy for getting visible contacts. */
 	public final static String DEFAULT_GET_VISIBLE_STRATEGY = "all-at-once"; /* other expected value is "filtered" */
 
+	public final static int DEFAULT_CONVERSATION_BATCH_SIZE = 1000;
+
 	@Override
 	public void start(final Promise<Void> startPromise) throws Exception {
 		super.start(startPromise);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ent-core",
-  "version": "6.7.5-dev.2",
+  "version": "6.7-develop-b2school.0",
   "description": "",
   "main": "gulpfile.js",
   "directories": {
@@ -28,7 +28,7 @@
     "angular-sanitize": "1.8.3",
     "axios": "0.15.3",
     "core-js": "^2.4.1",
-    "entcore": "dev",
+    "entcore": "develop-b2school",
     "entcore-generic-icons": "https://github.com/edificeio/generic-icons.git",
     "entcore-toolkit": "^1.0.1",
     "humane-js": "^3.2.2",
@@ -76,8 +76,8 @@
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
     "merge2": "^1.0.3",
-    "ode-ngjs-front": "dev",
-    "ode-ts-client": "dev",
+    "ode-ngjs-front": "develop-b2school",
+    "ode-ts-client": "develop-b2school",
     "sass-loader": "^13.0.2",
     "source-map-loader": "^0.1.5",
     "ts-loader": "^3.1.1",

--- a/pom.xml
+++ b/pom.xml
@@ -56,20 +56,20 @@
     </modules>
 
     <properties>
-        <revision>6.7-SNAPSHOT</revision>
+        <revision>6.7-develop-b2school-SNAPSHOT</revision>
         <junitVersion>4.13.2</junitVersion>
         <testContainerVersion>1.19.3</testContainerVersion>
-        <modPostgresVersion>2.0-SNAPSHOT</modPostgresVersion>
+        <modPostgresVersion>2.0-develop-b2school-SNAPSHOT</modPostgresVersion>
         <modMongoVersion>4.0-SNAPSHOT</modMongoVersion>
-        <webUtilsVersion>3.1-SNAPSHOT</webUtilsVersion>
-        <mongodbHelperVersion>3.0-SNAPSHOT</mongodbHelperVersion>
+        <webUtilsVersion>3.1-develop-b2school-SNAPSHOT</webUtilsVersion>
+        <mongodbHelperVersion>4.0-develop-b2school-SNAPSHOT</mongodbHelperVersion>
         <jodaTimeVersion>2.9.4</jodaTimeVersion>
         <scramVersion>2.1</scramVersion>
         <micrometerPrometheusVersion>1.11.4</micrometerPrometheusVersion>
         <owaspVersion>20220608.1</owaspVersion>
         <jacksonVersion>2.15.2</jacksonVersion>
         <casVersion>0.2.2</casVersion>
-        <vertxCronTimerVersion>3.0-SNAPSHOT</vertxCronTimerVersion>
+        <vertxCronTimerVersion>3.0-develop-b2school-SNAPSHOT</vertxCronTimerVersion>
         <jnaVersion>3.0.2</jnaVersion>
         <lamejbVersion>0.2.0</lamejbVersion>
         <opencsvVersion>3.9</opencsvVersion>


### PR DESCRIPTION
# Description

Envoyer un message a un groupe comportant bcp d'utilisateur inactif, renvoit un tableau d'utilisateur inactif enrome que le client web essaye d'afficher dans une modale. En conséquence, le navigateur se fige. De plus l'envois en masse est assez lent.
=> limite au retour de la méthode send de conversationController le nombre d'utilisateur dans le tableau des inactifs renvoyer au navigateur
=> Optimisation de la création du message en utilisatant un INSERT ... VALUES au lieu d'insert individuel pour permettre à postgresql d'optimiser correctement l'insertion.

## Fixes

[(Enter here Jira or Redmine ticket(s) links)](https://edifice-community.atlassian.net/browse/COCO-4474)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: