### PR TITLE
Fix coco 4590 timeout on api person

### DIFF
--- a/directory/src/main/java/org/entcore/directory/controllers/UserBookController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/UserBookController.java
@@ -228,8 +228,8 @@ public class UserBookController extends BaseController {
 					userBookService.getCurrentUserInfos(user, forceReload, defaultResponseHandler(request));
 				} else {
 					Future<JsonArray> visible = UserUtils.filterFewOrGetAllVisibles(eb, user.getUserId(), new JsonArray(Lists.newArrayList(userId)));
-					visible.onComplete( arr -> {
-						boolean filter = arr.result().stream().noneMatch(o -> ((JsonObject)o).getString("id").equals(userId));
+					visible.onSuccess( arr -> {
+						boolean filter = arr.stream().noneMatch(o -> ((JsonObject)o).getString("id").equals(userId));
 						userBookService.getPersonInfos(userId, filter, defaultResponseHandler(request));
 					});
 					visible.onFailure(err -> unauthorized(request));

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserBookService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserBookService.java
@@ -525,7 +525,7 @@ public class DefaultUserBookService implements UserBookService {
 				return (new Either.Right<>(transformed));
 			} catch(IllegalArgumentException e) {
 				log.info("Argument is not to adapt must be a jsonArray with one element of type JsonObject", e);
-				return new Either.Left<>(res.left().getValue());
+				return new Either.Left<>("Unable to find a user with the provided id");
 			}
 		}else{
 			return (new Either.Left<>(res.left().getValue()));


### PR DESCRIPTION
# Description

Fix null pointer exception due to queryPerson result being empty because the used id is not a person but a group 

## Fixes

https://edifice-community.atlassian.net/browse/COCO-4590

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [x] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

call GET /userbook/api/person?id={id}&type=undefined with the id of a group => we must have a response with a http code 4xx.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: