### PR TITLE
fix-(communication): #COCO-4596 return 200 empty when error occured 

### DIFF
--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserBookService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserBookService.java
@@ -525,7 +525,7 @@ public class DefaultUserBookService implements UserBookService {
 				return (new Either.Right<>(transformed));
 			} catch(IllegalArgumentException e) {
 				log.info("Argument is not to adapt must be a jsonArray with one element of type JsonObject", e);
-				return new Either.Left<>("Unable to find a user with the provided id");
+				return new Either.Right<>(new JsonObject());
 			}
 		}else{
 			return (new Either.Left<>(res.left().getValue()));


### PR DESCRIPTION
# Description

Lorsque l'on utilise un ID de groupe au lieu d'un ID de person sur l'api /person, retourner une erreur provoque des problèmes dans zimbra. On doit retourner une reponse ok vide. Il faudra rétablir l'erreur lorsque l'on aura corrigé le problème des groupes dans les favoris dans la messagerie.

## Fixes

https://edifice-community.atlassian.net/browse/COCO-4596

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [x] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Dans la messagerie dans les destinataires, cliquer sur un groupe provenant dans un favori => on doit arriver sur une page blache avec un appel à /api/person en 200 vide

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: