### PR TITLE
fix(conversation): #COCO-4475 refresh folder after delete folder

### DIFF
--- a/conversation/frontend/src/services/queries/folder.ts
+++ b/conversation/frontend/src/services/queries/folder.ts
@@ -14,6 +14,7 @@ import { Folder, MessageMetadata } from '~/models';
 import { queryClient } from '~/providers';
 import { useActionsStore } from '~/store/actions';
 import { folderService, searchFolder } from '..';
+import { invalidateQueriesWithFirstPage } from './utils';
 
 export const PAGE_SIZE = 20;
 
@@ -376,7 +377,7 @@ export const useTrashFolder = () => {
         if (found) {
           if (found.parent) {
             // All message go to the parent folder so we refresh
-            queryClient.invalidateQueries({
+            invalidateQueriesWithFirstPage(queryClient, {
               queryKey: folderQueryKeys.messages(found.parent.id),
             });
 
@@ -390,9 +391,10 @@ export const useTrashFolder = () => {
             ]);
           } else {
             // This is a root folder. All messages go to the trash so we refresh it.
-            queryClient.invalidateQueries({
+            invalidateQueriesWithFirstPage(queryClient, {
               queryKey: folderQueryKeys.messages('trash'),
             });
+
             // Optimistic update
             return queryClient.setQueryData(
               folderQueryKeys.tree(),

--- a/conversation/frontend/src/services/queries/folder.ts
+++ b/conversation/frontend/src/services/queries/folder.ts
@@ -370,6 +370,10 @@ export const useTrashFolder = () => {
     onSuccess: async (_data, { id }) => {
       const foldersTree = foldersTreeQuery.data;
 
+      invalidateQueriesWithFirstPage(queryClient, {
+        queryKey: folderQueryKeys.messages('trash'),
+      });
+
       // Try optimistic update...
       if (foldersTree) {
         const found = searchFolder(id, foldersTree);
@@ -377,9 +381,6 @@ export const useTrashFolder = () => {
         if (found) {
           if (found.parent) {
             // All message go to the parent folder so we refresh
-            invalidateQueriesWithFirstPage(queryClient, {
-              queryKey: folderQueryKeys.messages(found.parent.id),
-            });
 
             // This is a sub-folder. Remove it from its parent sub-folders list.
             found.parent.subFolders = found.parent.subFolders?.filter(
@@ -390,11 +391,6 @@ export const useTrashFolder = () => {
               ...foldersTree,
             ]);
           } else {
-            // This is a root folder. All messages go to the trash so we refresh it.
-            invalidateQueriesWithFirstPage(queryClient, {
-              queryKey: folderQueryKeys.messages('trash'),
-            });
-
             // Optimistic update
             return queryClient.setQueryData(
               folderQueryKeys.tree(),


### PR DESCRIPTION
# Description

When we delete a folder all the message go to the parent / trash we need to invalidate the query for this folder.

## Fixes

(Enter here Jira or Redmine ticket(s) links)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [x] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: