### PR TITLE
hotfix: #ENABLING-393, add a new route to paginate events fetch

### DIFF
--- a/infra/src/main/java/org/entcore/infra/services/EventStoreService.java
+++ b/infra/src/main/java/org/entcore/infra/services/EventStoreService.java
@@ -43,7 +43,10 @@ public interface EventStoreService {
 
 	void storeCustomEvent(String baseEventType, JsonObject payload);
 
+  @Deprecated
 	void listEvents(String eventStoreType, long startEpoch, long duration, boolean skipSynced, List<String> eventTypes, boolean sorted, Handler<AsyncResult<JsonArray>> handler);
+
+  void listEventsPartial(String eventStoreType, long startEpoch, long duration, boolean skipSynced, List<String> eventTypes, boolean sorted, Handler<AsyncResult<PartialResults>> handler);
 
 	void markSyncedEvents(String eventStoreType, long startEpoch, long duration, Handler<AsyncResult<JsonObject>> handler);
 

--- a/infra/src/main/java/org/entcore/infra/services/PartialResults.java
+++ b/infra/src/main/java/org/entcore/infra/services/PartialResults.java
@@ -1,0 +1,24 @@
+package org.entcore.infra.services;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.vertx.core.json.JsonArray;
+
+public class PartialResults {
+  private final boolean partial;
+  private final JsonArray results;
+  @JsonCreator
+  public PartialResults(@JsonProperty("partial") boolean partial,
+                        @JsonProperty("results") JsonArray results) {
+    this.partial = partial;
+    this.results = results;
+  }
+
+  public boolean isPartial() {
+    return partial;
+  }
+
+  public JsonArray getResults() {
+    return results;
+  }
+}


### PR DESCRIPTION
# Description

Ajout d'une nouvelle route retournant les événements de l'ENT avec une pagination simple afin d'éviter des requêtes en base trop coûteuse.
Lorsque la requête arrive, on va chercher n+1 (n étant configurable) événements. Si on en trouve n+1 alors on en renvoie que n mais on positionne le header X-HAS-MORE à true