### PR TITLE
 feat: #pedago-3032, add session refresh api to broker

### DIFF
--- a/broker-parent/broker-api/src/main/java/org/entcore/broker/api/dto/session/RefreshSessionRequestDTO.java
+++ b/broker-parent/broker-api/src/main/java/org/entcore/broker/api/dto/session/RefreshSessionRequestDTO.java
@@ -1,0 +1,58 @@
+package org.entcore.broker.api.dto.session;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * DTO for the session refresh (recreate) request.
+ */
+public class RefreshSessionRequestDTO {
+    private final String userId;
+    private final String sessionId;
+    private final boolean refreshOnly;
+
+    /**
+     * Constructor for RefreshSessionRequestDTO.
+     * @param userId The user whose session should be refreshed.
+     * @param sessionId The current session id.
+     * @param refreshOnly If true, only refresh session info, otherwise drop and recreate.
+     */
+    @JsonCreator
+    public RefreshSessionRequestDTO(
+            @JsonProperty("userId") String userId,
+            @JsonProperty("sessionId") String sessionId,
+            @JsonProperty("refreshOnly") boolean refreshOnly) {
+        this.userId = userId;
+        this.sessionId = sessionId;
+        this.refreshOnly = refreshOnly;
+    }
+
+    /**
+     * @return The user id.
+     */
+    public String getUserId() { return userId; }
+    /**
+     * @return The session id.
+     */
+    public String getSessionId() { return sessionId; }
+    /**
+     * @return True if only refresh, false to drop and recreate.
+     */
+    public boolean isRefreshOnly() { return refreshOnly; }
+    /**
+     * Checks if the request is valid (userId and sessionId must not be empty).
+     * @return true if valid, false otherwise.
+     */
+    public boolean isValid() {
+        return userId != null && !userId.isEmpty() && sessionId != null && !sessionId.isEmpty();
+    }
+
+    @Override
+    public String toString() {
+        return "RefreshSessionRequestDTO{" +
+                "userId='" + (userId != null ? userId : "null") + '\'' +
+                ", sessionId='" + (sessionId != null ? "***" : "null") + '\'' +
+                ", refreshOnly=" + refreshOnly +
+                '}';
+    }
+}

--- a/broker-parent/broker-api/src/main/java/org/entcore/broker/api/dto/session/RefreshSessionResponseDTO.java
+++ b/broker-parent/broker-api/src/main/java/org/entcore/broker/api/dto/session/RefreshSessionResponseDTO.java
@@ -1,0 +1,32 @@
+package org.entcore.broker.api.dto.session;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * DTO for the session refresh (recreate) response.
+ */
+public class RefreshSessionResponseDTO {
+    private final String sessionId;
+
+    /**
+     * Constructor for RefreshSessionResponseDTO.
+     * @param sessionId The id of the refreshed session.
+     */
+    @JsonCreator
+    public RefreshSessionResponseDTO(@JsonProperty("sessionId") String sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    /**
+     * @return The session id.
+     */
+    public String getSessionId() { return sessionId; }
+
+    @Override
+    public String toString() {
+        return "RefreshSessionResponseDTO{" +
+                "sessionId='" + (sessionId != null ? "***" : "null") + '\'' +
+                '}';
+    }
+}

--- a/broker-parent/broker-api/src/main/java/org/entcore/broker/api/dto/session/SessionDto.java
+++ b/broker-parent/broker-api/src/main/java/org/entcore/broker/api/dto/session/SessionDto.java
@@ -101,8 +101,16 @@ public class SessionDto {
     private final boolean superAdmin;
 
     /**
+     * The unique session ID for this user session.
+     * This identifier is used to reference the session in the system and is required for session refresh and validation.
+     */
+    @JsonProperty("sessionId")
+    private final String sessionId;
+
+    /**
      * Creates a new instance of SessionDto with all user information.
      *
+     * @param sessionId The unique session ID for this user session.
      * @param userId The internal user ID.
      * @param externalId The external user ID.
      * @param firstName The first name of the user.
@@ -118,11 +126,12 @@ public class SessionDto {
      * @param classes The list of classes the user belongs to.
      * @param groups The list of groups the user belongs to.
      * @param structures The list of structures the user is associated with.
-     * @param functions Map of functions assigned to the user.
+     * @param functions List of functions assigned to the user.
      * @param isSuperAdmin Whether the user is a super administrator.
      */
     @JsonCreator
     public SessionDto(
+            @JsonProperty("sessionId") String sessionId,
             @JsonProperty("userId") String userId,
             @JsonProperty("externalId") String externalId,
             @JsonProperty("firstName") String firstName,
@@ -140,6 +149,7 @@ public class SessionDto {
             @JsonProperty("structures") List<StructureDto> structures,
             @JsonProperty("functions") List<UserFunctionDto> functions,
             @JsonProperty("superAdmin") boolean isSuperAdmin) {
+        this.sessionId = sessionId;
         this.userId = userId;
         this.externalId = externalId;
         this.firstName = firstName;
@@ -277,4 +287,11 @@ public class SessionDto {
      * @return true if the user is a super administrator, false otherwise.
      */
     public boolean isSuperAdmin() { return superAdmin; }
+
+    /**
+     * Gets the unique session ID for this user session.
+     *
+     * @return The session ID string.
+     */
+    public String getSessionId() { return sessionId; }
 }

--- a/broker-parent/broker-proxy/src/main/java/org/entcore/broker/proxy/SessionBrokerListener.java
+++ b/broker-parent/broker-proxy/src/main/java/org/entcore/broker/proxy/SessionBrokerListener.java
@@ -4,6 +4,8 @@ import io.vertx.core.Future;
 import org.entcore.broker.api.BrokerListener;
 import org.entcore.broker.api.dto.session.FindSessionRequestDTO;
 import org.entcore.broker.api.dto.session.FindSessionResponseDTO;
+import org.entcore.broker.api.dto.session.RefreshSessionRequestDTO;
+import org.entcore.broker.api.dto.session.RefreshSessionResponseDTO;
 
 
 /**
@@ -21,4 +23,14 @@ public interface SessionBrokerListener {
    */
   @BrokerListener(subject = "session.find", proxy = true)
   Future<FindSessionResponseDTO> findSession(FindSessionRequestDTO request);
+
+  /**
+   * This method is called to refresh (recreate) a session.
+   * It takes a RefreshSessionRequestDTO as input and returns a RefreshSessionResponseDTO.
+   *
+   * @param request The request containing the session info to refresh.
+   * @return The response containing the new sessionId.
+   */
+  @BrokerListener(subject = "session.refresh", proxy = true)
+  Future<RefreshSessionResponseDTO> refreshSession(RefreshSessionRequestDTO request);
 }


### PR DESCRIPTION
# Description

Cette évo permet de mettre à jour la session via le broker (si refreshonly est à vrai le sessionId ne change pas)

## Fixes

#pedago-2640

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [X] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley: