### PR TITLE
feat: #PEDAGO-2534, add user and request to events

### DIFF
--- a/infra/src/main/java/org/entcore/infra/controllers/EventStoreController.java
+++ b/infra/src/main/java/org/entcore/infra/controllers/EventStoreController.java
@@ -72,7 +72,10 @@ public class EventStoreController extends BaseController {
 			    if (!authorizedUser(event)) {
                     Renders.ok(request);
                 } else {
-                    eventStoreService.store(event, voidResponseHandler(request));
+                    // Retrieve user infos and pass to new store method
+                    UserUtils.getUserInfos(eb, request, user -> {
+                        eventStoreService.store(event, user, request, voidResponseHandler(request));
+                    });
                 }
 			}
 		});

--- a/infra/src/main/java/org/entcore/infra/services/EventStoreService.java
+++ b/infra/src/main/java/org/entcore/infra/services/EventStoreService.java
@@ -37,7 +37,19 @@ public interface EventStoreService {
 	List<String> EVENT_STORE_TYPES = Arrays.asList("events", "traces");
 	long ONE_DAY_DURATION = 24 * 3600 * 1000L;
 
-	void store(JsonObject event, Handler<Either<String, Void>> handler);
+	/**
+	 * Store an event with optional user and request context.
+	 * If user and request are not null, enrich the event with user and request info.
+	 */
+	void store(JsonObject event, UserInfos user, HttpServerRequest request, Handler<Either<String, Void>> handler);
+
+	/**
+	 * Default implementation for backward compatibility.
+	 * Delegates to the new store method with null user and request.
+	 */
+	default void store(JsonObject event, Handler<Either<String, Void>> handler) {
+		store(event, null, null, handler);
+	}
 
 	void generateMobileEvent(String eventType, UserInfos user, HttpServerRequest request, String module, final Handler<Either<String, Void>> handler);
 

--- a/infra/src/main/java/org/entcore/infra/services/impl/MongoDbEventStore.java
+++ b/infra/src/main/java/org/entcore/infra/services/impl/MongoDbEventStore.java
@@ -68,8 +68,33 @@ public class MongoDbEventStore implements EventStoreService {
 		}
 	}
 
+	/**
+	 * Store an event with optional user and request context.
+	 * If user and request are not null, enrich the event with user and request info.
+	 */
 	@Override
-	public void store(JsonObject event, final Handler<Either<String, Void>> handler) {
+	public void store(JsonObject event, UserInfos user, HttpServerRequest request, final Handler<Either<String, Void>> handler) {
+		// Enrich event with user info if user is provided
+		if (user != null) {
+			event.put("userId", user.getUserId());
+			if (user.getType() != null) {
+				event.put("profil", user.getType());
+			}
+			if (user.getStructures() != null) {
+				event.put("structures", new JsonArray(user.getStructures()));
+			}
+			if (user.getClasses() != null) {
+				event.put("classes", new JsonArray(user.getClasses()));
+			}
+			if (user.getGroupsIds() != null) {
+				event.put("groups", new JsonArray(user.getGroupsIds()));
+			}
+		}
+		// Enrich event with request info if request is provided
+		if (request != null && request.headers().get("User-Agent") != null) {
+			event.put("ua", request.headers().get("User-Agent"));
+		}
+		// Store event in MongoDB
 		mongoDb.save(COLLECTION, event, new Handler<Message<JsonObject>>() {
 			@Override
 			public void handle(Message<JsonObject> event) {


### PR DESCRIPTION
# Description

Ce fix ajoute les informations utilisateurs (et sur la request) dans certains event. cette route semble être appelé par des api front (mobile j'ai pas l'impression mais on sait jamais...). Par exemple TEXT_TO_SPEECH l'utilise...
Du coup j'ai évité de retourner des codes erreurs inconnus j'ai juste récupérer les informations sessions et si elles sont présentes je les ajoute à l'event

## Fixes

#PEDAGO-2534

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [X] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley: