### PR TITLE
Fix coco 4674 fix wrong handle result in sql convsersation

### DIFF
--- a/conversation/backend/src/main/java/org/entcore/conversation/service/impl/SqlConversationService.java
+++ b/conversation/backend/src/main/java/org/entcore/conversation/service/impl/SqlConversationService.java
@@ -355,7 +355,7 @@ public class SqlConversationService implements ConversationService{
 					builder.prepared(insertUserAttachmentBuilder.deleteCharAt(insertUserAttachmentBuilder.length()-1).toString(), new JsonArray());
 				}
 
-				sql.transaction(builder.build(),new DeliveryOptions().setSendTimeout(sendTimeout), SqlResult.validUniqueResultHandler(result));
+				sql.transaction(builder.build(),new DeliveryOptions().setSendTimeout(sendTimeout), SqlResult.validUniqueResultHandler(0, result));
 			}
 		});
 	}


### PR DESCRIPTION
# Description

Une mauvaise gestion d'un handler sur une requête sql dans SQLConversationService provoque une regression sur les notifications

## Fixes

https://edifice-community.atlassian.net/browse/COCO-4674

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [x] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: