### PR TITLE
fix(conversation): COCO-4649, foreign key usermessagesattachments

### DIFF
--- a/conversation/backend/src/main/java/org/entcore/conversation/service/impl/SqlConversationService.java
+++ b/conversation/backend/src/main/java/org/entcore/conversation/service/impl/SqlConversationService.java
@@ -328,23 +328,25 @@ public class SqlConversationService implements ConversationService{
 					}
 					userMessageValueCount++;
 					insertUserMessageBuilder.append(String.format("('%s', '%s', %s ),", toObj, draftId, totalQuota));
-					if (userMessageValueCount > conversationBatchSize) {
-						userMessageValueCount = 0;
-						builder.prepared(insertUserMessageBuilder.deleteCharAt(insertUserMessageBuilder.length()-1).toString(), new JsonArray());
-						insertUserMessageBuilder = new StringBuilder(insertUserMessage);
-					}
-					if (threadId != null) {
-						builder.prepared(insertUserThread, new fr.wseduc.webutils.collections.JsonArray().add(toObj.toString()).add(threadId).add(1));
-					}
-
 					for(Object attachmentId : attachmentIds){
 						userMessageAttachementCount++;
 						insertUserAttachmentBuilder.append(String.format("('%s', '%s', '%s' ),", toObj, draftId, attachmentId));
-						if (userMessageAttachementCount > conversationBatchSize) {
-							userMessageAttachementCount = 0;
+					}
+					if (userMessageValueCount >= conversationBatchSize) {
+						// Messages
+						builder.prepared(insertUserMessageBuilder.deleteCharAt(insertUserMessageBuilder.length()-1).toString(), new JsonArray());
+						insertUserMessageBuilder = new StringBuilder(insertUserMessage);
+						userMessageValueCount = 0;
+						
+						// Pièces jointes
+						if (userMessageAttachementCount > 0) {
 							builder.prepared(insertUserAttachmentBuilder.deleteCharAt(insertUserAttachmentBuilder.length()-1).toString(), new JsonArray());
 							insertUserAttachmentBuilder = new StringBuilder(insertUserAttachment);
+							userMessageAttachementCount = 0;
 						}
+					}
+					if (threadId != null) {
+						builder.prepared(insertUserThread, new fr.wseduc.webutils.collections.JsonArray().add(toObj.toString()).add(threadId).add(1));
 					}
 				}
 


### PR DESCRIPTION
# Description

En cas de message à de nombreux utilisateurs (~530 remonté par le support) et deux PJ, un erreur de contrainte peut subvenir. Les PJ pouvaient être insérées avant les messages.

## Fixes

[#COCO-4690](https://edifice-community.atlassian.net/browse/COCO-4690)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [x] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: