### PR TITLE
fix(conversation): #COCO-4662 navigate to inbox after sending message

### DIFF
--- a/conversation/frontend/src/services/queries/hooks/useDeleteMessageFromQueryCache.ts
+++ b/conversation/frontend/src/services/queries/hooks/useDeleteMessageFromQueryCache.ts
@@ -36,7 +36,7 @@ export const useDeleteMessagesFromQueryCache = () => {
         }
 
         //total message count
-        const totalItems = data.pages[0][0].count;
+        const totalItems = data.pages[0][0] ? data.pages[0][0].count : 0;
         const newTotalItems = totalItems - messageIds.length;
 
         const pages = data.pages

--- a/conversation/frontend/src/services/queries/message.ts
+++ b/conversation/frontend/src/services/queries/message.ts
@@ -393,20 +393,22 @@ export const useCreateOrUpdateDraft = () => {
       ],
     };
 
-    if (messageUpdated.id && messageUpdated.state === 'DRAFT') {
-      return updateDraft.mutateAsync(
-        {
-          draftId: messageUpdated.id,
-          payload,
-        },
-        {
-          onSuccess: () => {
-            if (withNotification) {
-              toast.success(t('message.draft.saved'));
-            }
+    if (messageUpdated.id) {
+      if (messageUpdated.state === 'DRAFT') {
+        return updateDraft.mutateAsync(
+          {
+            draftId: messageUpdated.id,
+            payload,
           },
-        },
-      );
+          {
+            onSuccess: () => {
+              if (withNotification) {
+                toast.success(t('message.draft.saved'));
+              }
+            },
+          },
+        );
+      }
     } else {
       return createDraft.mutateAsync(
         {
@@ -531,6 +533,7 @@ export const useSendDraft = () => {
     useUpdateFolderBadgeCountQueryCache();
   const { deleteMessagesFromQueryCache } = useDeleteMessagesFromQueryCache();
   const queryClient = useQueryClient();
+  const setMessageNeedToSave = useMessageStore.use.setMessageNeedToSave();
 
   const { user } = useEdificeClient();
   const toast = useToast();
@@ -551,7 +554,10 @@ export const useSendDraft = () => {
         cci?: string[];
       };
       inReplyToId?: string;
-    }) => messageService.send(draftId, payload, inReplyToId),
+    }) => {
+      setMessageNeedToSave(false);
+      return messageService.send(draftId, payload, inReplyToId);
+    },
     onSuccess: (_response, { payload, draftId }) => {
       toast.success(t('message.sent'));
 


### PR DESCRIPTION
# Description

Navigate was blocked due to an error on useDeleteMessagesFromQueryCache
And draft could be created even if a message was already saved.

## Fixes

(Enter here Jira or Redmine ticket(s) links)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [x] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: