### PR TITLE
fix: #PEDAGO-2646, config to disable broker

### DIFF
--- a/broker-parent/broker/src/main/java/org/entcore/broker/client/BrokerClientFactory.java
+++ b/broker-parent/broker/src/main/java/org/entcore/broker/client/BrokerClientFactory.java
@@ -2,11 +2,35 @@ package org.entcore.broker.client;
 
 import io.vertx.core.Vertx;
 
+/**
+ * Factory class for creating BrokerClient instances based on configuration.
+ * Returns the appropriate implementation depending on the "broker-type" config value.
+ */
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
 public class BrokerClientFactory {
+
+  private static final Logger log = LoggerFactory.getLogger(BrokerClientFactory.class);
+
+  /**
+   * Returns a BrokerClient instance according to the broker-type configuration.
+   * Supported types:
+   *   - "nats": returns NATSBrokerClient
+   *   - "none": returns NoOpBrokerClient (does nothing)
+   *   - any other value: returns RESTBrokerClient
+   *
+   * @param vertx Vert.x instance
+   * @return BrokerClient implementation
+   */
   public static BrokerClient getClient(final Vertx vertx) {
     final String brokerType = vertx.getOrCreateContext().config().getString("broker-type", "rest");
+    log.debug("Broker type selected: {}", brokerType);
     if ("nats".equalsIgnoreCase(brokerType)) {
       return new NATSBrokerClient(vertx);
+    } else if ("none".equalsIgnoreCase(brokerType)) {
+      log.warn("Broker is disabled (broker-type=none). No broker operations will be performed.");
+      return new NoOpBrokerClient(vertx);
     } else {
       return new RESTBrokerClient(vertx);
     }

--- a/broker-parent/broker/src/main/java/org/entcore/broker/client/NoOpBrokerClient.java
+++ b/broker-parent/broker/src/main/java/org/entcore/broker/client/NoOpBrokerClient.java
@@ -1,0 +1,107 @@
+package org.entcore.broker.client;
+
+import io.vertx.core.Future;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.entcore.broker.listener.BrokerListener;
+
+/**
+ * No-operation implementation of BrokerClient that does nothing and returns successful Futures.
+ * This implementation is used when broker-type is set to "none" and ensures no errors or timeouts
+ * are generated for the caller.
+ */
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.MessageConsumer;
+import io.vertx.core.json.JsonObject;
+
+public class NoOpBrokerClient implements BrokerClient {
+
+  // Logger for debug/info output
+  private static final Logger log = LoggerFactory.getLogger(NoOpBrokerClient.class);
+
+  private final Vertx vertx;
+  private MessageConsumer<JsonObject> publishConsumer;
+
+  /**
+   * Constructor for NoOpBrokerClient.
+   * @param vertx Vert.x instance used for event bus consumption
+   */
+  public NoOpBrokerClient(Vertx vertx) {
+    this.vertx = vertx;
+  }
+
+  /**
+   * Starts the NoOpBrokerClient. Registers a consumer for 'broker.publish' that always replies with success.
+   */
+  @Override
+  public Future<Void> start() {
+    log.info("NoOpBrokerClient started - no actual broker operations will be performed");
+    // Unregister previous consumer if any
+    if (publishConsumer != null) {
+      publishConsumer.unregister();
+    }
+    publishConsumer = vertx.eventBus().<JsonObject>consumer("broker.publish", message -> {
+      log.debug("NoOpBrokerClient received broker.publish for subject: {} (replying with dummy success)", message.body().getString("subject"));
+      message.reply(null); // Always reply with success (null)
+    });
+    return Future.succeededFuture();
+  }
+
+  /**
+   * Ignores any message sent and always returns a succeeded Future.
+   */
+  @Override
+  public <K> Future<Void> sendMessage(String subject, K message) {
+    log.warn("NoOpBrokerClient.sendMessage called for subject: {} - message ignored", subject);
+    return Future.succeededFuture();
+  }
+
+  /**
+   * Ignores any request and always returns a succeeded Future with null response.
+   */
+  @Override
+  public <K, V> Future<V> request(String subject, K message) {
+    log.warn("NoOpBrokerClient.request called for subject: {} - returning null response", subject);
+    return Future.succeededFuture(null);
+  }
+
+  /**
+   * Ignores any request and always returns a succeeded Future with null response, regardless of timeout.
+   */
+  @Override
+  public <K, V> Future<V> request(String subject, K message, long timeout) {
+    log.warn("NoOpBrokerClient.request called for subject: {} with timeout: {} - returning null response", subject, timeout);
+    return Future.succeededFuture(null);
+  }
+
+  /**
+   * Ignores unsubscribe requests and always returns a succeeded Future.
+   */
+  @Override
+  public Future<Void> unsubscribe(String subject) {
+    log.warn("NoOpBrokerClient.unsubscribe called for subject: {} - no operation performed", subject);
+    return Future.succeededFuture();
+  }
+
+  /**
+   * Ignores subscription requests and always returns a succeeded Future.
+   */
+  @Override
+  public <K, V> Future<Void> subscribe(String subject, BrokerListener<K, V> listener) {
+    log.warn("NoOpBrokerClient.subscribe called for subject: {} - no actual subscription performed", subject);
+    return Future.succeededFuture();
+  }
+
+  /**
+   * Closes the NoOpBrokerClient. Unregisters the event bus consumer and always succeeds.
+   */
+  @Override
+  public Future<Void> close() {
+    log.info("NoOpBrokerClient closed - no cleanup needed");
+    if (publishConsumer != null) {
+      publishConsumer.unregister();
+      publishConsumer = null;
+    }
+    return Future.succeededFuture();
+  }
+}


### PR DESCRIPTION
# Description

Ce commit fournit une implémentation du BrokerClient qui ne fait rien et renvoie toujours une réponse pour éviter des erreurs dans les environnement sans nats (donc sans broker)

## Fixes

#PEDAGO-2646

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [X] broker
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley: