### PR TITLE
fix-(communication,feeder): #COCO-4720 display name search field keep ', delete it

### DIFF
--- a/communication/src/main/java/org/entcore/communication/services/impl/DefaultCommunicationService.java
+++ b/communication/src/main/java/org/entcore/communication/services/impl/DefaultCommunicationService.java
@@ -2106,7 +2106,7 @@ public class DefaultCommunicationService implements CommunicationService {
 					StringUtils.isEmpty(search) ? null : search,
 					true);
 			if(!result.relativeAddedToTheList.isEmpty()) {
-				//recheck addoed users
+				//recheck added users
 				UserUtils.filterFewOrGetAllVisibles(eventBus, user.getUserId(), result.relativeAddedToTheList)
 						.onSuccess(relatives -> {
 							List<String> idsToRemove = Lists.newLinkedList();

--- a/communication/src/main/java/org/entcore/communication/services/impl/DefaultCommunicationService.java
+++ b/communication/src/main/java/org/entcore/communication/services/impl/DefaultCommunicationService.java
@@ -2106,7 +2106,7 @@ public class DefaultCommunicationService implements CommunicationService {
 					StringUtils.isEmpty(search) ? null : search,
 					true);
 			if(!result.relativeAddedToTheList.isEmpty()) {
-				//recheck added users
+				//recheck addoed users
 				UserUtils.filterFewOrGetAllVisibles(eventBus, user.getUserId(), result.relativeAddedToTheList)
 						.onSuccess(relatives -> {
 							List<String> idsToRemove = Lists.newLinkedList();

--- a/feeder/src/main/java/org/entcore/feeder/utils/Validator.java
+++ b/feeder/src/main/java/org/entcore/feeder/utils/Validator.java
@@ -22,6 +22,7 @@ package org.entcore.feeder.utils;
 import fr.wseduc.webutils.I18n;
 import org.entcore.common.neo4j.Neo4j;
 import org.entcore.common.utils.MapFactory;
+import org.entcore.common.utils.SanitizerUtils;
 import org.entcore.common.utils.StringUtils;
 import org.joda.time.DateTime;
 import io.vertx.core.Handler;
@@ -36,6 +37,7 @@ import java.security.NoSuchAlgorithmException;
 import java.text.Normalizer;
 import java.util.*;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static fr.wseduc.webutils.Utils.isNotEmpty;
 
@@ -395,6 +397,7 @@ public class Validator {
 	private String generateDisplayNamePermutations(String displayName)
 	{
 		List<String> parts = StringUtils.split(removeAccents(displayName).toLowerCase().replaceAll("\\s+", " "), " ");
+		parts = parts.stream().map(Validator::sanitize).collect(Collectors.toList());
 		StringBuilder permutations = new StringBuilder();
 
 		if(parts.size() > 5) // Only compute the permutations for the first five terms, otherwise the string is too big

--- a/feeder/src/main/java/org/entcore/feeder/utils/Validator.java
+++ b/feeder/src/main/java/org/entcore/feeder/utils/Validator.java
@@ -20,11 +20,6 @@
 package org.entcore.feeder.utils;
 
 import fr.wseduc.webutils.I18n;
-import org.entcore.common.neo4j.Neo4j;
-import org.entcore.common.utils.MapFactory;
-import org.entcore.common.utils.SanitizerUtils;
-import org.entcore.common.utils.StringUtils;
-import org.joda.time.DateTime;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.Message;
@@ -32,6 +27,10 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import org.entcore.common.neo4j.Neo4j;
+import org.entcore.common.utils.MapFactory;
+import org.entcore.common.utils.StringUtils;
+import org.joda.time.DateTime;
 
 import java.security.NoSuchAlgorithmException;
 import java.text.Normalizer;


### PR DESCRIPTION
# Description

Le système garde les appostrophes dans le displayNameSearchField contrairement au nom et prenom, ce qui perturbe la recherche => suppression lors d'une mise à jour de l'appostrophe

## Fixes

https://edifice-community.atlassian.net/browse/COCO-4720

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [x] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: