### PR TITLE
fix(timeline):#IMPULS-5879 flashMessage on top on responsive

### DIFF
--- a/timeline/frontend/.prettierignore
+++ b/timeline/frontend/.prettierignore
@@ -3,3 +3,4 @@
 /coverage
 /.nx/cache
 /.nx/workspace-data
+/.pnpm-store

--- a/timeline/frontend/src/routes/root/index.test.tsx
+++ b/timeline/frontend/src/routes/root/index.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, within } from '~/mocks/setup';
+import { Root } from './index';
+
+/**
+ * Mock window.matchMedia used in useBreakpoint hook, and isolate Root's
+ * layout logic from the real PageLayout / homepage containers implementation.
+ */
+const mocks = vi.hoisted(() => ({
+  useBreakpoint: vi.fn(),
+}));
+
+vi.mock('@edifice.io/react', async () => {
+  const actual =
+    await vi.importActual<typeof import('@edifice.io/react')>(
+      '@edifice.io/react',
+    );
+
+  const PageLayoutMock = ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="page-layout">{children}</div>
+  );
+  PageLayoutMock.Header = () => <div data-testid="page-header" />;
+  PageLayoutMock.SidebarLeft = ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) => <div data-testid="sidebar-left">{children}</div>;
+  PageLayoutMock.Content = ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="content">{children}</div>
+  );
+  PageLayoutMock.SidebarRight = ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) => <div data-testid="sidebar-right">{children}</div>;
+  PageLayoutMock.Overlay = ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="overlay">{children}</div>
+  );
+
+  return {
+    ...actual,
+    useBreakpoint: mocks.useBreakpoint,
+    useEdificeClient: () => ({ init: true }),
+    useOverlay: () => ({ updateOverlayOpen: vi.fn() }),
+    PageLayout: PageLayoutMock,
+  };
+});
+
+vi.mock('@edifice.io/react/homepage', () => ({
+  MessageFlashListContainer: () => (
+    <div data-testid="message-flash-list-container" />
+  ),
+  FavoritesContainer: () => <div data-testid="favorites-container" />,
+  LastInfosContainer: () => <div data-testid="last-infos-container" />,
+  NotificationListContainer: () => (
+    <div data-testid="notification-list-container" />
+  ),
+  SchoolSpaceContainer: () => <div data-testid="school-space-container" />,
+  UserSpaceContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="user-space-container">{children}</div>
+  ),
+}));
+
+vi.mock('~/components/BetaSwitch/BetaSwitchContainer', () => ({
+  BetaSwitchContainer: () => <div data-testid="beta-switch-container" />,
+}));
+
+describe('Root - MessageFlashListContainer responsive placement', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders MessageFlashListContainer in the left sidebar on small/responsive screens (sm, not md)', () => {
+    mocks.useBreakpoint.mockReturnValue({ sm: true, md: false });
+
+    render(<Root />);
+
+    const sidebarLeft = screen.getByTestId('sidebar-left');
+    const content = screen.getByTestId('content');
+
+    expect(
+      within(sidebarLeft).getByTestId('message-flash-list-container'),
+    ).toBeInTheDocument();
+    expect(
+      within(content).queryByTestId('message-flash-list-container'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders MessageFlashListContainer in the main content on desktop screens (md)', () => {
+    mocks.useBreakpoint.mockReturnValue({ sm: true, md: true });
+
+    render(<Root />);
+
+    const sidebarLeft = screen.getByTestId('sidebar-left');
+    const content = screen.getByTestId('content');
+
+    expect(
+      within(content).getByTestId('message-flash-list-container'),
+    ).toBeInTheDocument();
+    expect(
+      within(sidebarLeft).queryByTestId('message-flash-list-container'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/timeline/frontend/src/routes/root/index.tsx
+++ b/timeline/frontend/src/routes/root/index.tsx
@@ -1,4 +1,9 @@
-import { LoadingScreen, PageLayout, useEdificeClient } from '@edifice.io/react';
+import {
+  LoadingScreen,
+  PageLayout,
+  useBreakpoint,
+  useEdificeClient,
+} from '@edifice.io/react';
 import {
   FavoritesContainer,
   LastInfosContainer,
@@ -19,6 +24,7 @@ export const Root = () => {
   const { init } = useEdificeClient();
   const { isSidebarOpen, toggleNotifications, closeNotifications } =
     useNotificationsLayout();
+  const { md, sm } = useBreakpoint();
 
   if (!init) return <LoadingScreen position={false} />;
 
@@ -33,6 +39,8 @@ export const Root = () => {
       <PageLayout.Header onNotificationsClick={toggleNotifications} />
       <PageLayout.SidebarLeft className="bg-white">
         <div className="d-flex flex-column py-16 gap-16 ">
+          {sm && !md && <MessageFlashListContainer />}
+
           <SchoolSpaceContainer />
           <LastInfosContainer />
         </div>
@@ -40,7 +48,7 @@ export const Root = () => {
       <PageLayout.Content>
         <div className="d-flex flex-column py-16 gap-16">
           <BetaSwitchContainer />
-          <MessageFlashListContainer />
+          {md && <MessageFlashListContainer />}
           <UserSpaceContainer>
             <FavoritesContainer />
           </UserSpaceContainer>

--- a/timeline/timeline.code-workspace
+++ b/timeline/timeline.code-workspace
@@ -33,6 +33,15 @@
     ],
     "git.openRepositoryInParentFolders": "never",
     "workbench.startupEditor": "none",
+    "files.exclude": {
+      "**/frontend-crna": true,
+    },
+    "search.exclude": {
+      "**/frontend-crna": true,
+    },
+    "files.watcherExclude": {
+      "**/frontend-crna/**": true,
+    },
     "scss.format.spaceAroundSelectorSeparator": true,
     "scss.format.enable": false,
     "eslint.format.enable": true,


### PR DESCRIPTION
# Description

Sur les écrans responsive (mobile/tablette), le `MessageFlashListContainer` ne s'affichait pas en haut de la page : il n'était rendu que dans la zone `Content`, invisible tant que l'utilisateur n'avait pas scrollé au-delà de la sidebar. Le composant est désormais affiché conditionnellement selon la largeur d'écran (`useBreakpoint`) : dans la `SidebarLeft` en responsive (`sm && !md`), dans le `Content` en desktop (`md`).

## Fixes

IMPULS-5879

## Type of change

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [x] timeline
- [ ] workspace

## Tests

1. Ouvrir la page d'accueil timeline (`pnpm dev`) en largeur desktop (≥ breakpoint `md`) : le message flash s'affiche dans le contenu principal, au-dessus de `UserSpaceContainer`.
2. Réduire la largeur de la fenêtre en dessous du breakpoint `md` (mais ≥ `sm`) : le message flash s'affiche désormais en haut de la sidebar gauche, avant `SchoolSpaceContainer`.
3. Test automatisé ajouté : `src/routes/root/index.test.tsx`, qui vérifie le placement de `MessageFlashListContainer` selon `useBreakpoint` (responsive vs desktop) — `pnpm test` passe.

# Reminder

- Security flaws: N/A
- Performance impacts (think bulk !): N/A
- Unit tests were replayed: oui (`pnpm test` — suite complète passe)
- Unit tests were added and/or changed: oui, `src/routes/root/index.test.tsx`
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: