### PR TITLE
chore: updated build.sh to initialize MODULE from env

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,8 @@ esac
 # build options
 NO_DOCKER=""
 SPRINGBOARD="recette"
-MODULE=""
+# Initialize MODULE from env; --module=/-m= overrides it.
+MODULE="${MODULE:-}"
 MVN_OPTS="-Duser.home=/var/maven -T 4"
 for i in "$@"
 do


### PR DESCRIPTION
# Description

La variable MODULE de build.sh peut désormais être passée via variable d'environnement.
Spécifier l'option -m ou --module= permet de forcer manuellement sa valeur si besoin.

Voir détails dans le ticket.

## Fixes

[IMPULS-6202](https://edifice-community.atlassian.net/browse/IMPULS-6202)

## Type of change

Please check options that are relevant.

- [X] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Testé sur la branche develop-b2school

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley:

[IMPULS-6202]: https://edifice-community.atlassian.net/browse/IMPULS-6202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ