### PR TITLE
fix(feeder): #IMPULS-6208, clean specials chars in externalIds

### DIFF
--- a/feeder/src/main/java/org/entcore/feeder/csv/CsvValidator.java
+++ b/feeder/src/main/java/org/entcore/feeder/csv/CsvValidator.java
@@ -560,10 +560,26 @@ public class CsvValidator extends CsvReport implements ImportValidator {
 		});
 	}
 
+	/**
+	 * Ajoute l'externalId d'un enfant à la liste des rattachements, débarrassé de ses
+	 * caractères réservés. Une valeur qui n'en contient que est ignorée.
+	 */
+	private void addLinkStudent(JsonArray linkStudents, String childExternalId) {
+		final String childExtId = ExternalIdValidator.clean(childExternalId);
+		if (isEmpty(childExtId)) {
+			log.warn("Ignored childExternalId with reserved chars only : " + childExternalId);
+			return;
+		}
+		if (!childExternalId.equals(childExtId)) {
+			log.warn("Reserved chars removed in childExternalId : " + childExternalId + " -> " + childExtId);
+		}
+		linkStudents.add(childExtId);
+	}
+
 	private void filterExternalIdExists(List<String> admlStructures, String profile,
 			Set<String> externalIds, final Handler<AsyncResult<JsonArray>> handler) {
 		final List<String> cleanExtIds = externalIds.stream()
-				.map(s -> s.contains(" ") ? s.replaceAll("\\s+", "") : s)
+				.map(ExternalIdValidator::clean)
 				.collect(Collectors.toList());
 		final JsonObject params = new JsonObject().put("externalIds", new JsonArray(cleanExtIds));
 		try {
@@ -787,8 +803,10 @@ public class CsvValidator extends CsvReport implements ImportValidator {
 							}
 							state = State.NEW;
 						} else {
-							if (externalId.contains(" ")) {
-								externalId = externalId.replaceAll("\\s+", "");
+							final String cleanExternalId = ExternalIdValidator.clean(externalId);
+							if (!externalId.equals(cleanExternalId)) {
+								log.warn("Reserved chars removed in externalId : " + externalId + " -> " + cleanExternalId);
+								externalId = cleanExternalId;
 								user.put("externalId", externalId);
 							}
 							if (existExternalIdLogin.containsKey(externalId)) {
@@ -844,18 +862,10 @@ public class CsvValidator extends CsvReport implements ImportValidator {
 										if (o instanceof JsonArray) {
 											for (Object c : (JsonArray) o) {
 												if (!(c instanceof String)) continue;
-												String childExtId = (String) c;
-												if (childExtId.contains(" ")) {
-													childExtId = childExtId.replaceAll("\\s+", "");
-												}
-												linkStudents.add(childExtId);
+												addLinkStudent(linkStudents, (String) c);
 											}
 										} else if (o instanceof String){
-											String childExtId = (String) o;
-											if (childExtId.contains(" ")) {
-												childExtId = childExtId.replaceAll("\\s+", "");
-											}
-											linkStudents.add(childExtId);
+											addLinkStudent(linkStudents, (String) o);
 										}
 									} else if ("childUsername".equals(attr)) {
 										Object childUsername = user.getValue(attr);

--- a/feeder/src/main/java/org/entcore/feeder/utils/ExternalIdValidator.java
+++ b/feeder/src/main/java/org/entcore/feeder/utils/ExternalIdValidator.java
@@ -1,0 +1,51 @@
+/* Copyright © "Open Digital Education", 2026
+ *
+ * This program is published by "Open Digital Education".
+ * You must indicate the name of the software and the company in any production /contribution
+ * using the software and indicate on the home page of the software industry in question,
+ * "powered by Open Digital Education" with a reference to the website: https://opendigitaleducation.com/.
+ *
+ * This program is free software, licensed under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, version 3 of the License.
+ *
+ * You can redistribute this application and/or modify it since you respect the terms of the GNU Affero General Public License.
+ * If you modify the source code and then use this modified source code in your creation, you must make available the source code of your modifications.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with the software.
+ * If not, please see : <http://www.gnu.org/licenses/>. Full compliance requires reading the terms of this license and following its directives.
+
+ *
+ */
+
+package org.entcore.feeder.utils;
+
+import java.util.regex.Pattern;
+
+/**
+ * Neutralise dans les externalId les caractères réservés du QueryParser Lucene.
+ */
+public final class ExternalIdValidator {
+
+	/** Réservés où qu'ils soient dans la valeur. */
+	private static final Pattern RESERVED_CHARS = Pattern.compile("[\\s/\"()\\[\\]{}:^~*?!\\\\]+");
+
+	/** '-' et '+' ne sont réservés qu'en tête : ailleurs ce sont des caractères de terme ordinaires. */
+	private static final Pattern LEADING_OPERATORS = Pattern.compile("^[-+]+");
+
+	private ExternalIdValidator() {
+	}
+
+	/**
+	 * Retourne l'externalId débarrassé de ses caractères réservés.
+	 *
+	 * @param externalId valeur d'origine, éventuellement nulle
+	 * @return la valeur assainie, ou l'entrée telle quelle si elle est nulle ou vide
+	 */
+	public static String clean(String externalId) {
+		if (externalId == null || externalId.isEmpty()) {
+			return externalId;
+		}
+		final String withoutReservedChars = RESERVED_CHARS.matcher(externalId).replaceAll("");
+		return LEADING_OPERATORS.matcher(withoutReservedChars).replaceAll("");
+	}
+}

--- a/feeder/src/test/java/org/entcore/feeder/utils/ExternalIdValidatorTest.java
+++ b/feeder/src/test/java/org/entcore/feeder/utils/ExternalIdValidatorTest.java
@@ -1,0 +1,79 @@
+package org.entcore.feeder.utils;
+
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class ExternalIdValidatorTest {
+
+    @Test
+    public void testCleanKeepsValidExternalId(final TestContext context) {
+        // Cas nominal : un externalId généré (sha1) n'est pas touché
+        context.assertEquals("9a3f1ce773860dac7d32bd4c82e55b87ca5715f5",
+                ExternalIdValidator.clean("9a3f1ce773860dac7d32bd4c82e55b87ca5715f5"));
+
+        // Un uuid non plus : les tirets internes ne sont pas réservés
+        context.assertEquals("786ed343-8865-4d34-8e01-8637be049a69",
+                ExternalIdValidator.clean("786ed343-8865-4d34-8e01-8637be049a69"));
+
+        // Caractères non réservés par le QueryParser Lucene
+        context.assertEquals("ID#12.34_56;78=90@ab%cd&ef|gh<i>j'k,l",
+                ExternalIdValidator.clean("ID#12.34_56;78=90@ab%cd&ef|gh<i>j'k,l"));
+
+        // Les accents passent par l'analyzer sans être interprétés
+        context.assertEquals("ELEVEéÉàçÎ", ExternalIdValidator.clean("ELEVEéÉàçÎ"));
+    }
+
+    @Test
+    public void testCleanRemovesReservedChars(final TestContext context) {
+        // Le cas du ticket : deux slashes suffisent à faire échouer la requête
+        context.assertEquals("ABCDEFGHI", ExternalIdValidator.clean("ABC/DEF/GHI"));
+
+        // Espaces et tabulations : l'index est un fulltext, ils découpent la valeur en tokens
+        context.assertEquals("ABCDEF", ExternalIdValidator.clean("ABC DEF"));
+        context.assertEquals("ABCDEF", ExternalIdValidator.clean("ABC\tDEF"));
+        context.assertEquals("ABCDEF", ExternalIdValidator.clean("  ABC   DEF  "));
+
+        // Erreurs de syntaxe
+        context.assertEquals("ABCDEF", ExternalIdValidator.clean("ABC\"DEF"));
+        context.assertEquals("ABCDEF", ExternalIdValidator.clean("ABC(DEF)"));
+        context.assertEquals("ABCDEF", ExternalIdValidator.clean("ABC[DEF]"));
+        context.assertEquals("ABCDEF", ExternalIdValidator.clean("ABC{DEF}"));
+        context.assertEquals("ABCDEF", ExternalIdValidator.clean("ABC:DEF"));
+        context.assertEquals("ABCDEF", ExternalIdValidator.clean("ABC^DEF"));
+        context.assertEquals("ABCDEF", ExternalIdValidator.clean("ABC!DEF"));
+
+        // Requêtes silencieusement fausses : jokers, recherche floue, échappement
+        context.assertEquals("ABCDEF", ExternalIdValidator.clean("ABC*DEF"));
+        context.assertEquals("ABCDEF", ExternalIdValidator.clean("ABC?DEF"));
+        context.assertEquals("ABCDEF", ExternalIdValidator.clean("ABC~DEF"));
+        context.assertEquals("ABCDEF", ExternalIdValidator.clean("ABC\\DEF"));
+    }
+
+    @Test
+    public void testCleanRemovesLeadingOperatorsOnly(final TestContext context) {
+        // '-' et '+' en tête sont les opérateurs NOT et MUST
+        context.assertEquals("ABC", ExternalIdValidator.clean("-ABC"));
+        context.assertEquals("ABC", ExternalIdValidator.clean("+ABC"));
+        context.assertEquals("ABC", ExternalIdValidator.clean("+-ABC"));
+
+        // ailleurs ce sont des caractères de terme ordinaires, à conserver
+        context.assertEquals("AB-C", ExternalIdValidator.clean("AB-C"));
+        context.assertEquals("AB+C", ExternalIdValidator.clean("AB+C"));
+        context.assertEquals("ABC-", ExternalIdValidator.clean("ABC-"));
+
+        // un caractère réservé peut démasquer un opérateur en tête
+        context.assertEquals("ABC", ExternalIdValidator.clean(" -ABC"));
+        context.assertEquals("ABC", ExternalIdValidator.clean("/-/ABC"));
+    }
+
+    @Test
+    public void testCleanHandlesEmptyValues(final TestContext context) {
+        context.assertNull(ExternalIdValidator.clean(null));
+        context.assertEquals("", ExternalIdValidator.clean(""));
+        context.assertEquals("", ExternalIdValidator.clean("   "));
+        context.assertEquals("", ExternalIdValidator.clean("///"));
+    }
+}


### PR DESCRIPTION
# Description

Clean specials chars in externalIds.

## Fixes

[IMPULS-6208](https://edifice-community.atlassian.net/browse/IMPULS-6208)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [x] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley:

[IMPULS-6208]: https://edifice-community.atlassian.net/browse/IMPULS-6208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ