### PR TITLE
fix: #IMPULS-5987, bad UTC date in emails templates

### DIFF
--- a/auth/src/main/java/org/entcore/auth/users/DefaultUserAuthAccount.java
+++ b/auth/src/main/java/org/entcore/auth/users/DefaultUserAuthAccount.java
@@ -55,8 +55,6 @@ import org.entcore.common.validation.StringValidation;
 import org.joda.time.DateTime;
 
 import java.security.NoSuchAlgorithmException;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -479,7 +477,7 @@ public class DefaultUserAuthAccount extends TemplatedEmailRenders implements Use
 
 		JsonObject templateParams = new JsonObject()
 				.put("displayName", firstName)
-				.put("date", LocalDateTime.now().toEpochSecond(ZoneOffset.UTC) * 1000);
+				.put("date", System.currentTimeMillis());
 
 		final String emailTemplate = reset ? "email/resetPassword.html" : "email/changedPassword.html";
 		final String i18nKey = reset ? "email.password.reset.subject" : "email.password.change.subject";

--- a/auth/src/main/java/org/entcore/auth/users/NewDeviceWarningTask.java
+++ b/auth/src/main/java/org/entcore/auth/users/NewDeviceWarningTask.java
@@ -46,7 +46,7 @@ import org.entcore.common.neo4j.Neo4j;
 import org.entcore.common.user.UserUtils;
 
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -381,7 +381,7 @@ public class NewDeviceWarningTask extends TemplatedEmailRenders implements Handl
         JsonObject templateParams = new JsonObject()
             .put("displayName", user.displayName)
             .put("device", c.device.toString())
-            .put("date", LocalDateTime.parse(c.date).toEpochSecond(ZoneOffset.UTC) * 1000)
+            .put("date", LocalDateTime.parse(c.date).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli())
             .put("ip", c.ip.indexOf("/") > -1 ? c.ip.substring(0, c.ip.indexOf("/")) : c.ip)
             .put("changePasswordLink", user.scheme + "://" + user.host);
 


### PR DESCRIPTION
# Description

Suffixe "UTC" mais date en Europe/Paris.
Les dates sont maintenant bien en UTC.

## Fixes

[IMPULS-5987](https://edifice-community.atlassian.net/browse/IMPULS-5987)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [x] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley:

[IMPULS-5987]: https://edifice-community.atlassian.net/browse/IMPULS-5987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ