### PR TITLE
fix(admin,auth): #IMPULS-6209, explicit error message reset code federate user

### DIFF
--- a/admin/src/main/resources/i18n/fr.json
+++ b/admin/src/main/resources/i18n/fr.json
@@ -1099,6 +1099,8 @@
   "notify.user.remove.structure.error.content": "La structure {{structure}} n'a pas pu être supprimée.",
   "notify.user.remove.structure.error.title": "Erreur lors de la suppression de la structure.",
   "notify.user.remove.structure.title": "Structure supprimée.",
+  "notify.user.renewal.error.content": "Le code de renouvellement de mot de passe n'a pas pu être généré.",
+  "notify.user.renewal.error.title": "Erreur lors de la génération du code.",
   "notify.user.restore.content": "L'utilisateur {{user}} a bien été restauré.",
   "notify.user.restore.error.content": "L'utilisateur {{user}} n'a pas pu être restauré.",
   "notify.user.restore.error.title": "Erreur lors de la restauration",

--- a/admin/src/main/resources/i18n/fr.json
+++ b/admin/src/main/resources/i18n/fr.json
@@ -1101,6 +1101,7 @@
   "notify.user.remove.structure.title": "Structure supprimée.",
   "notify.user.renewal.error.content": "Le code de renouvellement de mot de passe n'a pas pu être généré.",
   "notify.user.renewal.error.title": "Erreur lors de la génération du code.",
+  "federated.user.reset.code.error": "L'utilisateur doit se connecter via un guichet externe.",
   "notify.user.restore.content": "L'utilisateur {{user}} a bien été restauré.",
   "notify.user.restore.error.content": "L'utilisateur {{user}} n'a pas pu être restauré.",
   "notify.user.restore.error.title": "Erreur lors de la restauration",

--- a/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.ts
+++ b/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.ts
@@ -656,8 +656,8 @@ export class UserConnectionSectionComponent
         this.renewalCode = data.renewalCode;
         this.cdRef.markForCheck();
       },
-      error: (payload:{error:string}) => {
-        this.ns.error(payload.error || 'notify.user.renewal.error.content', 'notify.user.renewal.error.title')
+      error: (err) => {
+        this.ns.error('notify.user.renewal.error.content', 'notify.user.renewal.error.title', err);
       },
     });
   }

--- a/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.ts
+++ b/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.ts
@@ -651,9 +651,14 @@ export class UserConnectionSectionComponent
   clickOnGenerateRenewalCode() {
     if( this.isForbidden )
       return;
-    this.generateRenewalCode(this.user.login).subscribe(data => {
-      this.renewalCode = data.renewalCode;
-      this.cdRef.markForCheck();
+    this.generateRenewalCode(this.user.login).subscribe({
+      next: (data) => {
+        this.renewalCode = data.renewalCode;
+        this.cdRef.markForCheck();
+      },
+      error: (payload:{error:string}) => {
+        this.ns.error(payload.error || 'notify.user.renewal.error.content', 'notify.user.renewal.error.title')
+      },
     });
   }
 

--- a/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.ts
+++ b/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.ts
@@ -657,7 +657,7 @@ export class UserConnectionSectionComponent
         this.cdRef.markForCheck();
       },
       error: (err) => {
-        this.ns.error('notify.user.renewal.error.content', 'notify.user.renewal.error.title', err);
+        this.ns.error('notify.user.renewal.error.content', 'notify.user.renewal.error.title', { message: err?.error?.error ?? err?.message });
       },
     });
   }

--- a/auth/src/main/java/org/entcore/auth/controllers/AuthController.java
+++ b/auth/src/main/java/org/entcore/auth/controllers/AuthController.java
@@ -1641,6 +1641,8 @@ public class AuthController extends BaseController {
 		userAuthAccount.generateResetCode(login, checkFederatedLogin, (Either<String, JsonObject> either) -> {
 			if (either.isRight()) {
 				renderJson(request, new JsonObject().put("renewalCode", either.right().getValue().getString("code")));
+			} else if (isNotEmpty(either.left().getValue())) {
+				conflict(request, either.left().getValue());
 			} else {
 				renderError(request);
 			}

--- a/auth/src/main/java/org/entcore/auth/controllers/AuthController.java
+++ b/auth/src/main/java/org/entcore/auth/controllers/AuthController.java
@@ -1641,7 +1641,7 @@ public class AuthController extends BaseController {
 		userAuthAccount.generateResetCode(login, checkFederatedLogin, (Either<String, JsonObject> either) -> {
 			if (either.isRight()) {
 				renderJson(request, new JsonObject().put("renewalCode", either.right().getValue().getString("code")));
-			} else if (isNotEmpty(either.left().getValue())) {
+			} else if ("federated.user.reset.code.error".equals(either.left().getValue())) {
 				conflict(request, either.left().getValue());
 			} else {
 				renderError(request);

--- a/auth/src/main/java/org/entcore/auth/users/DefaultUserAuthAccount.java
+++ b/auth/src/main/java/org/entcore/auth/users/DefaultUserAuthAccount.java
@@ -69,6 +69,7 @@ public class DefaultUserAuthAccount extends TemplatedEmailRenders implements Use
 
 	private static final Logger log = LoggerFactory.getLogger(DefaultUserAuthAccount.class);
 	private static final long SEND_EMAIL_ACK_DELAY = 10000L;
+	private static final String FEDERATED_USER_RESET_CODE_ERROR = "federated.user.reset.code.error";
 
 	private final Neo neo;
 	private final Vertx vertx;
@@ -751,10 +752,11 @@ public class DefaultUserAuthAccount extends TemplatedEmailRenders implements Use
 		String query =
 				"MATCH (n:User) " +
 						"WHERE n.login={login} AND n.activationCode IS NULL " +
-						(checkFederatedLogin ? "AND (NOT(HAS(n.federated)) OR n.federated = false) " : "") +
-						"SET n.resetCode = {resetCode}, n.resetDate = {today} " +
-						"RETURN count(n) as nb, n.displayName as displayName";
-		JsonObject params = new JsonObject().put("login", login).put("resetCode", code).put("today", new Date().getTime());
+						"WITH n, (HAS(n.federated) AND n.federated = true) AS federated " +
+						"FOREACH (i IN CASE WHEN {checkFederatedLogin} AND federated THEN [] ELSE [1] END | " +
+						"SET n.resetCode = {resetCode}, n.resetDate = {today}) " +
+						"RETURN n.displayName as displayName, federated as federated";
+		JsonObject params = new JsonObject().put("login", login).put("resetCode", code).put("today", new Date().getTime()).put("checkFederatedLogin", checkFederatedLogin);
 		neo.execute(query, params, event -> {
 			if ("ok".equals(event.body().getString("status")))
 			{
@@ -762,15 +764,17 @@ public class DefaultUserAuthAccount extends TemplatedEmailRenders implements Use
 				if(result != null && result.size() == 1)
 				{
 					JsonObject result_data = result.getJsonObject(0);
-					if(result_data.getInteger("nb") == 1)
+					if(checkFederatedLogin && Boolean.TRUE.equals(result_data.getBoolean("federated")))
 					{
-						handler.handle(new Either.Right<>(
-							new JsonObject()
-								.put("code", code)
-								.put("displayName", result_data.getString("displayName"))
-						));
+						handler.handle(new Either.Left<>(FEDERATED_USER_RESET_CODE_ERROR));
 						return;
 					}
+					handler.handle(new Either.Right<>(
+						new JsonObject()
+							.put("code", code)
+							.put("displayName", result_data.getString("displayName"))
+					));
+					return;
 				}
 			}
 			handler.handle(new Either.Left<>("failed to set reset code"));


### PR DESCRIPTION
# Description

Adds explicit handling for password-reset attempts on federated users across the auth backend and admin UI.

Changes:

* Prevents reset-code generation for federated users when configured.
* Returns and displays a dedicated conflict error.
* Adds French notification translations.


## Fixes

https://edifice-community.atlassian.net/browse/IMPULS-6209

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [X] admin
- [ ] app-registry
- [ ] archive
- [X] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: