### PR TITLE
fix(admin): #IMPULS-6230, allow notifications for flash message on an…

### DIFF
--- a/admin/src/main/ts/src/app/management/message-flash/form/message-flash-form/message-flash-form.component.ts
+++ b/admin/src/main/ts/src/app/management/message-flash/form/message-flash-form/message-flash-form.component.ts
@@ -170,7 +170,7 @@ export class MessageFlashFormComponent extends OdeComponent implements OnInit, O
     }
 
     isToday(): boolean {
-        const startDate = this.message.startDate; // already formated as 'YYYY-MM-DD' or empty string or undefined;
+        const startDate = this.message.startDate; // already formatted as 'YYYY-MM-DD', an empty string, or undefined
         const now = dayjs().format('YYYY-MM-DD');
         if (now !== startDate) {
             this.mailNotification = false;

--- a/admin/src/main/ts/src/app/management/message-flash/form/message-flash-form/message-flash-form.component.ts
+++ b/admin/src/main/ts/src/app/management/message-flash/form/message-flash-form/message-flash-form.component.ts
@@ -170,16 +170,14 @@ export class MessageFlashFormComponent extends OdeComponent implements OnInit, O
     }
 
     isToday(): boolean {
-        const now: Date = new Date();
-        const startDate: Date = new Date(this.message.startDate);
-        const res = now.getDate() === startDate.getDate()
-            && now.getMonth() === startDate.getMonth()
-            && now.getFullYear() === startDate.getFullYear();
-        if (!res) {
+        const startDate = this.message.startDate; // already formated as 'YYYY-MM-DD' or empty string or undefined;
+        const now = dayjs().format('YYYY-MM-DD');
+        if (now !== startDate) {
             this.mailNotification = false;
             this.pushNotification = false;
+            return false;
         }
-        return res;
+        return true;
     }
 
     public showUserPositionField(): boolean {


### PR DESCRIPTION
…other timezone

# Description

Corrige un soucis de case à cocher grisée lorsque la timezone de l'utilisateur n'est pas identique à celle du serveur.

## Fixes

https://edifice-community.atlassian.net/browse/IMPULS-6230

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [X] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

- changer le fuseau horaire de son PC,
- ouvrir admin,
- choisir une structure,
- aller dans le menu structure -> message flash,
- sélectionner la date de début = aujourd'hui.

=> les cases à cocher permettant d'envoyer des notifications doivent se dégriser.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley: