### PR TITLE
fix(portal): #ENABLING-1174 security fix

### DIFF
--- a/portal/backend/src/main/java/org/entcore/portal/controllers/PortalController.java
+++ b/portal/backend/src/main/java/org/entcore/portal/controllers/PortalController.java
@@ -280,10 +280,28 @@ public class PortalController extends BaseController {
 	}
 
 	private String getThemePrefix(HttpServerRequest request) {
-		return "/assets/themes/" + getSkinFromConditions(request);
+		// Sanitize theme name to avoid file system access
+		final String skin = getSkinFromConditions(request).replaceAll("[^A-Za-z0-9_-]", "");
+		return "/assets/themes/" + skin;
+	}
+
+	// Check that path is a subdirectory of assetsPath
+	private static boolean isPathUnder(String root, String candidate) {
+		if (candidate == null) return false;
+		try {
+			final java.nio.file.Path base = java.nio.file.Paths.get(root).toAbsolutePath().normalize();
+			final java.nio.file.Path p = java.nio.file.Paths.get(candidate).toAbsolutePath().normalize();
+			return p.startsWith(base);
+		} catch (Exception e) {
+			return false;
+		}
 	}
 
 	private void sendWithLastModified(final HttpServerRequest request, final String path, final boolean decodeIfNeeded) {
+		if (!isPathUnder(assetsPath, path)) {
+			notFound(request);
+			return;
+		}
 		if (staticRessources.containsKey(request.uri())) {
 			final String safePath = fixResources.getOrDefault(request.uri(), path);
 			final String modifiedDate = staticRessources.get(request.uri());
@@ -298,6 +316,10 @@ public class PortalController extends BaseController {
 					if(decodeIfNeeded && af.cause() instanceof FileSystemException && af.cause().getCause() != null && af.cause().getCause() instanceof NoSuchFileException){
 						try {
 							final String decoded = URLDecoder.decode(path, "UTF-8");
+							if (!isPathUnder(assetsPath, decoded)) { 
+								notFound(request);
+								return;
+							}
 							fixResources.put(request.uri(), decoded);
 							sendWithLastModified(request, decoded, false);
 							return;


### PR DESCRIPTION
# Description

Security check to avoid parsing FS through theme cookie

## Fixes
Ticket #ENABLING-1174

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [x] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

/!\ It goes with another PR on web-utils

## Tests

curl -sS -i --cookie "theme=../../../../../.." \   "https://recette-release.edifice.io/current/assets/etc/passwd" to reproduce security issue

Without the fix : returns 200 with the content of the specified file. With the fix, it returns a 404.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: