### PR TITLE
fix(feeder): #IMPULS-6274, avoid dupe PREFERS relations

### DIFF
--- a/feeder/src/main/java/org/entcore/feeder/dictionary/structures/DuplicateUsers.java
+++ b/feeder/src/main/java/org/entcore/feeder/dictionary/structures/DuplicateUsers.java
@@ -1075,12 +1075,20 @@ public class DuplicateUsers {
 						"DELETE r"; // We only delete the relationship between the old user and the userbook if it was transfered to the new user
 									// So we will be able to delete unlinked UserBook nodes with query4
 		tx.add(query1, params);
+		// Transfer old UserAppConf only if the principal user doesn't already have one, to avoid duplicate PREFERS relations
 		final String query2 =
 				"MATCH (old:User {id: {oldId}})-[r:PREFERS]->(ub:UserAppConf), (u:User {id: {id}}) " +
+						"WHERE NOT (u)-[:PREFERS]->(:UserAppConf) " +
 						"SET ub.theme = null " +
-						"CREATE UNIQUE u-[:PREFERS]->ub " +
+						"CREATE UNIQUE (u)-[:PREFERS]->(ub) " +
 						"DELETE r";
 		tx.add(query2, params);
+		// Otherwise the principal's UserAppConf is kept and the old one is discarded entirely (no orphan node left)
+		final String query2b =
+				"MATCH (old:User {id: {oldId}})-[:PREFERS]->(ub:UserAppConf), (u:User {id: {id}}) " +
+						"WHERE (u)-[:PREFERS]->(:UserAppConf) " +
+						"DETACH DELETE ub";
+		tx.add(query2b, params);
 		if (!relative) {
 			final String query3 =
 					"MATCH (old:User {id: {oldId}})-[r:RELATED]->(ub:User), (u:User {id: {id}}) " +

--- a/feeder/src/main/java/org/entcore/feeder/dictionary/structures/DuplicateUsers.java
+++ b/feeder/src/main/java/org/entcore/feeder/dictionary/structures/DuplicateUsers.java
@@ -1091,7 +1091,7 @@ public class DuplicateUsers {
 						"CREATE UNIQUE (u)-[:PREFERS]->(ub) " +
 						"DELETE r";
 		tx.add(query2b, params);
-		// Deduplicate UserAppConf after transfer, keeping rich prefs and salvaging quietHours.
+		// Deduplicate UserAppConf after transfer, keeping rich prefs and salvaging quietHours/timezone.
 		final String query2c =
 				"MATCH (u:User {id: {id}})-[:PREFERS]->(uac:UserAppConf) " +
 						"WITH u, uac ORDER BY CASE WHEN HAS(uac.language) OR HAS(uac.timeline) THEN 0 ELSE 1 END, " +
@@ -1099,8 +1099,8 @@ public class DuplicateUsers {
 						"WITH u, collect(DISTINCT uac) AS uacs " +
 						"WHERE size(uacs) > 0 " +
 						"WITH u, uacs[0] AS canonical, uacs[1..] AS duplicates " +
-						"WITH u, canonical, duplicates, head([duplicate IN duplicates WHERE HAS(duplicate.quietHours) | duplicate.quietHours]) AS duplicateQuietHours " +
-						"FOREACH (_ IN CASE WHEN canonical.quietHours IS NULL AND duplicateQuietHours IS NOT NULL THEN [1] ELSE [] END | SET canonical.quietHours = duplicateQuietHours) " +
+						"WITH u, canonical, duplicates, head([duplicate IN duplicates WHERE HAS(duplicate.quietHours) | duplicate]) AS duplicateQuietHoursSource " +
+						"FOREACH (_ IN CASE WHEN canonical.quietHours IS NULL AND duplicateQuietHoursSource IS NOT NULL THEN [1] ELSE [] END | SET canonical.quietHours = duplicateQuietHoursSource.quietHours, canonical.timezone = duplicateQuietHoursSource.timezone) " +
 						"REMOVE canonical.mergeDuplicateIneTransferred " +
 						"WITH u, duplicates " +
 						"UNWIND duplicates AS duplicate " +

--- a/feeder/src/main/java/org/entcore/feeder/dictionary/structures/DuplicateUsers.java
+++ b/feeder/src/main/java/org/entcore/feeder/dictionary/structures/DuplicateUsers.java
@@ -1079,16 +1079,39 @@ public class DuplicateUsers {
 		final String query2a =
 				"MATCH (old:User {id: {oldId}})-[r:PREFERS]->(ub:UserAppConf), (u:User {id: {id}}) " +
 						"WHERE NOT (u)-[:PREFERS]->(:UserAppConf) " +
-						"SET ub.theme = null " +
+						"SET ub.theme = null, ub.mergeDuplicateIneTransferred = true " +
 						"CREATE UNIQUE (u)-[:PREFERS]->(ub) " +
 						"DELETE r";
 		tx.add(query2a, params);
-		// Otherwise the principal's UserAppConf is kept and the old one is discarded entirely (no orphan node left)
+		// Otherwise the principal's UserAppConf is kept as canonical and old ones are transferred for deduplication.
 		final String query2b =
-				"MATCH (old:User {id: {oldId}})-[:PREFERS]->(ub:UserAppConf), (u:User {id: {id}}) " +
+				"MATCH (old:User {id: {oldId}})-[r:PREFERS]->(ub:UserAppConf), (u:User {id: {id}}) " +
 						"WHERE (u)-[:PREFERS]->(:UserAppConf) " +
-						"DETACH DELETE ub";
+						"SET ub.theme = null, ub.mergeDuplicateIneTransferred = true " +
+						"CREATE UNIQUE (u)-[:PREFERS]->(ub) " +
+						"DELETE r";
 		tx.add(query2b, params);
+		// Deduplicate UserAppConf after transfer, keeping rich prefs and salvaging quietHours.
+		final String query2c =
+				"MATCH (u:User {id: {id}})-[:PREFERS]->(uac:UserAppConf) " +
+						"WITH u, uac ORDER BY CASE WHEN HAS(uac.language) OR HAS(uac.timeline) THEN 0 ELSE 1 END, " +
+						"CASE WHEN HAS(uac.mergeDuplicateIneTransferred) THEN 1 ELSE 0 END, id(uac) " +
+						"WITH u, collect(DISTINCT uac) AS uacs " +
+						"WHERE size(uacs) > 0 " +
+						"WITH u, uacs[0] AS canonical, uacs[1..] AS duplicates " +
+						"WITH u, canonical, duplicates, head([duplicate IN duplicates WHERE HAS(duplicate.quietHours) | duplicate.quietHours]) AS duplicateQuietHours " +
+						"FOREACH (_ IN CASE WHEN canonical.quietHours IS NULL AND duplicateQuietHours IS NOT NULL THEN [1] ELSE [] END | SET canonical.quietHours = duplicateQuietHours) " +
+						"REMOVE canonical.mergeDuplicateIneTransferred " +
+						"WITH u, duplicates " +
+						"UNWIND duplicates AS duplicate " +
+						"MATCH (u)-[r:PREFERS]->(duplicate) " +
+						"DELETE r " +
+						"WITH duplicate " +
+						"OPTIONAL MATCH (:User)-[r:PREFERS]->(duplicate) " +
+						"WITH duplicate, count(r) AS remainingPreferenceLinks " +
+						"WHERE remainingPreferenceLinks = 0 " +
+						"DETACH DELETE duplicate";
+		tx.add(query2c, params);
 		if (!relative) {
 			final String query3 =
 					"MATCH (old:User {id: {oldId}})-[r:RELATED]->(ub:User), (u:User {id: {id}}) " +

--- a/feeder/src/main/java/org/entcore/feeder/dictionary/structures/DuplicateUsers.java
+++ b/feeder/src/main/java/org/entcore/feeder/dictionary/structures/DuplicateUsers.java
@@ -1076,13 +1076,13 @@ public class DuplicateUsers {
 									// So we will be able to delete unlinked UserBook nodes with query4
 		tx.add(query1, params);
 		// Transfer old UserAppConf only if the principal user doesn't already have one, to avoid duplicate PREFERS relations
-		final String query2 =
+		final String query2a =
 				"MATCH (old:User {id: {oldId}})-[r:PREFERS]->(ub:UserAppConf), (u:User {id: {id}}) " +
 						"WHERE NOT (u)-[:PREFERS]->(:UserAppConf) " +
 						"SET ub.theme = null " +
 						"CREATE UNIQUE (u)-[:PREFERS]->(ub) " +
 						"DELETE r";
-		tx.add(query2, params);
+		tx.add(query2a, params);
 		// Otherwise the principal's UserAppConf is kept and the old one is discarded entirely (no orphan node left)
 		final String query2b =
 				"MATCH (old:User {id: {oldId}})-[:PREFERS]->(ub:UserAppConf), (u:User {id: {id}}) " +

--- a/feeder/src/test/java/org/entcore/feeder/dictionary/structures/MergeUsersINETest.java
+++ b/feeder/src/test/java/org/entcore/feeder/dictionary/structures/MergeUsersINETest.java
@@ -1,12 +1,5 @@
 package org.entcore.feeder.dictionary.structures;
 
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.entcore.common.events.EventStoreFactory;
 import org.entcore.common.neo4j.Neo4j;
 import org.entcore.common.neo4j.TransactionHelper;
@@ -19,6 +12,14 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.Neo4jContainer;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
 
 @RunWith(VertxUnitRunner.class)
 public class MergeUsersINETest {
@@ -117,6 +118,78 @@ public class MergeUsersINETest {
     }
 
     /**
+     * <h2>Goal</h2>
+     * <p>Test that when we merge 2 users with the same INE and each with a UserAppConf (PREFERS), we don't end up
+     * with a user linked to 2 UserAppConf, nor with the old one left as an orphan node.</p>
+     */
+    @Test
+    public void testMergeSameINEWithEachAUserAppConfNoDuplicatePreferences(final TestContext testContext) {
+        final String ine = "my-duplicated-ine-3";
+        final Async async = testContext.async(2);
+        prepareSameINEUsersWithAUserAppConfEach(ine).onComplete(testContext.asyncAssertSuccess(h -> {
+            duplicateUsers.mergeSameINE(true, testContext.asyncAssertSuccess(e -> {
+                neo4j.execute(
+                    "MATCH (u:User{ine:{ine}, tag: 'unitTest3'})-[r:PREFERS]->(uac:UserAppConf) return u.id as id, uac.owner as uac_owner",
+                    new JsonObject().put("ine", ine),
+                    result -> {
+                        if ("ok".equals(result.body().getString("status"))) {
+                            final JsonArray users = result.body().getJsonArray("result");
+                            testContext.assertEquals(1, users.size(), "There should be only one user left, linked to exactly one UserAppConf");
+                            final JsonObject principalUser = users.getJsonObject(0);
+                            testContext.assertEquals("userToRemove3", principalUser.getString("id"), "The remaining user is not the expected one. Have source priorities changed ?");
+                            testContext.assertEquals("userToKeep3", principalUser.getString("uac_owner"), "The connected UserAppConf should be the principal's own one, not the old duplicate");
+                            async.countDown();
+                        } else {
+                            testContext.fail("Could not fetch users with the same ine");
+                        }
+                    });
+                neo4j.execute(
+                        "MATCH (uac:UserAppConf) WHERE uac.tag STARTS WITH 'unitTest3' return uac.owner as owner",
+                        new JsonObject(),
+                        result -> {
+                            if ("ok".equals(result.body().getString("status"))) {
+                                final JsonArray uacs = result.body().getJsonArray("result");
+                                testContext.assertEquals(1, uacs.size(), "There should be only one UserAppConf left, the old duplicate must be deleted, not left as an orphan");
+                                testContext.assertEquals("userToKeep3", uacs.getJsonObject(0).getString("owner"), "The remaining UserAppConf is not the expected one");
+                                async.complete();
+                            } else {
+                                testContext.fail("Could not fetch UserAppConf nodes");
+                            }
+                        });
+            }));
+        }));
+    }
+
+    /**
+     * <h2>Goal</h2>
+     * <p>Test that when we merge 2 users with the same INE and only one has a UserAppConf linked, the preference is
+     * correctly transferred to the surviving user.</p>
+     */
+    @Test
+    public void testMergeSameINEWithOnlyOneUserAppConf(final TestContext testContext) {
+        final String ine = "my-duplicated-ine-4";
+        final Async async = testContext.async();
+        prepareSameINEUsersWithOnlyOneUserAppConf(ine).onComplete(testContext.asyncAssertSuccess(h -> {
+            duplicateUsers.mergeSameINE(true, testContext.asyncAssertSuccess(e -> {
+                neo4j.execute(
+                        "MATCH (u:User{ine:{ine}, tag: 'unitTest4'})-[r:PREFERS]->(uac:UserAppConf) return u.id as id, uac.owner as uac_owner",
+                        new JsonObject().put("ine", ine),
+                        result -> {
+                            if ("ok".equals(result.body().getString("status"))) {
+                                final JsonArray users = result.body().getJsonArray("result");
+                                testContext.assertEquals(1, users.size(), "There should be only one user left, linked to the transferred UserAppConf");
+                                final JsonObject principalUser = users.getJsonObject(0);
+                                testContext.assertEquals("userToRemove4", principalUser.getString("uac_owner"), "The transferred UserAppConf's owner is not the expected one");
+                                async.complete();
+                            } else {
+                                testContext.fail("Could not fetch users with the same ine");
+                            }
+                        });
+            }));
+        }));
+    }
+
+    /**
      * Creates 2 users as follows :
      * <ol>
      *     <li>(:User{id: 'userToKeep', source: 'AAF', ine: ine, activationCode: 'toto'})-[:USERBOOK]->(:UserBook{tag: 'unitTest', userid: 'userToKeep'})</li>
@@ -163,6 +236,66 @@ public class MergeUsersINETest {
             txl.add("match (u) detach delete u", new JsonObject());
             txl.add("create (u1:User{id: 'userToKeep1Userbook', source: 'AAF', activationCode: 'toto', ine: {ine}, tag: 'unitTest2'})", params);
             txl.add("create (u2:User{id: 'userToRemove1Userbook', source: 'MANUAL', ine: {ine}, tag: 'unitTest2'})-[:USERBOOK]->(:UserBook{tag: 'unitTest', userid: 'userToRemove1Userbook'})", params);
+            txl.commit(event -> {
+                if ("ok".equals(event.body().getString("status"))) {
+                    promise.complete();
+                } else {
+                    promise.fail(event.body().encodePrettily());
+                }
+            });
+        } catch (TransactionException e) {
+            promise.fail(e);
+        }
+        return promise.future();
+    }
+
+    /**
+     * Creates 2 users as follows :
+     * <ol>
+     *     <li>(:User{id: 'userToKeep3', source: 'AAF', ine: ine, activationCode: 'toto'})-[:PREFERS]->(:UserAppConf{tag: 'unitTest3', owner: 'userToKeep3'})</li>
+     *     <li>(:User{id: 'userToRemove3', source: 'MANUAL', ine: ine})-[:PREFERS]->(:UserAppConf{tag: 'unitTest3-old', owner: 'userToRemove3'})</li>
+     * </ol>
+     * @param ine The ine to use for both users
+     */
+    public static Future<Void> prepareSameINEUsersWithAUserAppConfEach(final String ine) {
+        final JsonObject params = new JsonObject().put("ine", ine);
+        final Promise<Void> promise = Promise.promise();
+        TransactionHelper txl = null;
+        try {
+            txl = TransactionManager.getTransaction();
+            txl.add("match (u) detach delete u", new JsonObject());
+            txl.add("create (u1:User{id: 'userToKeep3', source: 'AAF', activationCode: 'toto', ine: {ine}, tag: 'unitTest3', activated:true})-[:PREFERS]->(:UserAppConf{tag: 'unitTest3', owner: 'userToKeep3'})", params);
+            txl.add("create (u2:User{id: 'userToRemove3', source: 'MANUAL', ine: {ine}, tag: 'unitTest3'})-[:PREFERS]->(:UserAppConf{tag: 'unitTest3-old', owner: 'userToRemove3'})", params);
+            txl.commit(event -> {
+                if ("ok".equals(event.body().getString("status"))) {
+                    promise.complete();
+                } else {
+                    promise.fail(event.body().encodePrettily());
+                }
+            });
+        } catch (TransactionException e) {
+            promise.fail(e);
+        }
+        return promise.future();
+    }
+
+    /**
+     * Creates 2 users as follows :
+     * <ol>
+     *     <li>(:User{id: 'userToKeep4', source: 'AAF', ine: ine, activationCode: 'toto'})</li>
+     *     <li>(:User{id: 'userToRemove4', source: 'MANUAL', ine: ine})-[:PREFERS]->(:UserAppConf{tag: 'unitTest4', owner: 'userToRemove4'})</li>
+     * </ol>
+     * @param ine The ine to use for both users
+     */
+    public static Future<Void> prepareSameINEUsersWithOnlyOneUserAppConf(final String ine) {
+        final JsonObject params = new JsonObject().put("ine", ine);
+        final Promise<Void> promise = Promise.promise();
+        TransactionHelper txl = null;
+        try {
+            txl = TransactionManager.getTransaction();
+            txl.add("match (u) detach delete u", new JsonObject());
+            txl.add("create (u1:User{id: 'userToKeep4', source: 'AAF', activationCode: 'toto', ine: {ine}, tag: 'unitTest4'})", params);
+            txl.add("create (u2:User{id: 'userToRemove4', source: 'MANUAL', ine: {ine}, tag: 'unitTest4'})-[:PREFERS]->(:UserAppConf{tag: 'unitTest4', owner: 'userToRemove4'})", params);
             txl.commit(event -> {
                 if ("ok".equals(event.body().getString("status"))) {
                     promise.complete();

--- a/feeder/src/test/java/org/entcore/feeder/dictionary/structures/MergeUsersINETest.java
+++ b/feeder/src/test/java/org/entcore/feeder/dictionary/structures/MergeUsersINETest.java
@@ -204,7 +204,7 @@ public class MergeUsersINETest {
         prepareSameINEUsersWithAlreadyDuplicatedPreferences(ine).onComplete(testContext.asyncAssertSuccess(h -> {
             duplicateUsers.mergeSameINE(true, testContext.asyncAssertSuccess(e -> {
                 neo4j.execute(
-                    "MATCH (u:User{ine:{ine}, tag: 'unitTest5'})-[r:PREFERS]->(uac:UserAppConf) return u.id as id, uac.owner as owner, uac.language as language, uac.timeline as timeline, uac.quietHours as quietHours",
+                    "MATCH (u:User{ine:{ine}, tag: 'unitTest5'})-[r:PREFERS]->(uac:UserAppConf) return u.id as id, uac.owner as owner, uac.language as language, uac.timeline as timeline, uac.quietHours as quietHours, uac.timezone as timezone",
                     new JsonObject().put("ine", ine),
                     result -> {
                         if ("ok".equals(result.body().getString("status"))) {
@@ -215,6 +215,7 @@ public class MergeUsersINETest {
                             testContext.assertEquals("fr", principalUser.getString("language"), "The canonical's own property should be preserved");
                             testContext.assertEquals("timeline-config", principalUser.getString("timeline"), "The canonical's own timeline should be preserved");
                             testContext.assertEquals("quiet-hours-principal-duplicate", principalUser.getString("quietHours"), "One quietHours value from the duplicates should be recovered");
+                            testContext.assertEquals("Europe/Paris", principalUser.getString("timezone"), "Timezone should be recovered from the same duplicate as quietHours");
                             async.countDown();
                         } else {
                             testContext.fail("Could not fetch users with the same ine");
@@ -249,7 +250,7 @@ public class MergeUsersINETest {
             duplicateUsers.mergeSameINE(true, testContext.asyncAssertSuccess(e -> {
                 neo4j.execute(
                         "MATCH (u:User)-[:PREFERS]->(uac:UserAppConf) WHERE u.tag IN ['unitTest6-rich', 'unitTest6-quiet-hours', 'unitTest6-minimal'] " +
-                                "RETURN u.tag as tag, uac.owner as owner, uac.language as language, uac.timeline as timeline, uac.quietHours as quietHours ORDER BY tag",
+                                "RETURN u.tag as tag, uac.owner as owner, uac.language as language, uac.timeline as timeline, uac.quietHours as quietHours, uac.timezone as timezone ORDER BY tag",
                         new JsonObject(),
                         result -> {
                             if ("ok".equals(result.body().getString("status"))) {
@@ -262,6 +263,7 @@ public class MergeUsersINETest {
                                 testContext.assertNull(users.getJsonObject(0).getString("quietHours"));
                                 testContext.assertEquals("unitTest6-quiet-hours", users.getJsonObject(1).getString("tag"));
                                 testContext.assertEquals("quiet-hours-principal", users.getJsonObject(1).getString("quietHours"));
+                                testContext.assertEquals("Europe/Paris", users.getJsonObject(1).getString("timezone"));
                                 testContext.assertEquals("unitTest6-rich", users.getJsonObject(2).getString("tag"));
                                 testContext.assertEquals("fr", users.getJsonObject(2).getString("language"));
                                 testContext.assertEquals("timeline-principal", users.getJsonObject(2).getString("timeline"));
@@ -285,7 +287,7 @@ public class MergeUsersINETest {
         prepareOldQuietHoursAndPrincipalRichUserAppConf(ine).onComplete(testContext.asyncAssertSuccess(h -> {
             duplicateUsers.mergeSameINE(true, testContext.asyncAssertSuccess(e -> {
                 neo4j.execute(
-                        "MATCH (u:User{ine:{ine}, tag: 'unitTest7'})-[r:PREFERS]->(uac:UserAppConf) RETURN uac.owner as owner, uac.language as language, uac.timeline as timeline, uac.quietHours as quietHours",
+                        "MATCH (u:User{ine:{ine}, tag: 'unitTest7'})-[r:PREFERS]->(uac:UserAppConf) RETURN uac.owner as owner, uac.language as language, uac.timeline as timeline, uac.quietHours as quietHours, uac.timezone as timezone",
                         new JsonObject().put("ine", ine),
                         result -> {
                             if ("ok".equals(result.body().getString("status"))) {
@@ -296,6 +298,7 @@ public class MergeUsersINETest {
                                 testContext.assertEquals("fr", userAppConf.getString("language"));
                                 testContext.assertEquals("timeline-principal", userAppConf.getString("timeline"));
                                 testContext.assertEquals("quiet-hours-old", userAppConf.getString("quietHours"));
+                                testContext.assertEquals("Europe/Paris", userAppConf.getString("timezone"));
                                 async.countDown();
                             } else {
                                 testContext.fail("Could not fetch merged UserAppConf");
@@ -327,7 +330,7 @@ public class MergeUsersINETest {
         prepareOldSeveralQuietHoursAndPrincipalRichUserAppConf(ine).onComplete(testContext.asyncAssertSuccess(h -> {
             duplicateUsers.mergeSameINE(true, testContext.asyncAssertSuccess(e -> {
                 neo4j.execute(
-                        "MATCH (u:User{ine:{ine}, tag: 'unitTest8'})-[r:PREFERS]->(uac:UserAppConf) RETURN uac.owner as owner, uac.language as language, uac.timeline as timeline, uac.quietHours as quietHours",
+                        "MATCH (u:User{ine:{ine}, tag: 'unitTest8'})-[r:PREFERS]->(uac:UserAppConf) RETURN uac.owner as owner, uac.language as language, uac.timeline as timeline, uac.quietHours as quietHours, uac.timezone as timezone",
                         new JsonObject().put("ine", ine),
                         result -> {
                             if ("ok".equals(result.body().getString("status"))) {
@@ -338,6 +341,7 @@ public class MergeUsersINETest {
                                 testContext.assertEquals("fr", userAppConf.getString("language"));
                                 testContext.assertEquals("timeline-principal-multiple", userAppConf.getString("timeline"));
                                 testContext.assertTrue(userAppConf.getString("quietHours").startsWith("quiet-hours-old-"), "One old quietHours value should be recovered");
+                                testContext.assertTrue(userAppConf.getString("timezone").startsWith("Europe/"), "Timezone should be recovered from a duplicate quietHours node");
                                 async.countDown();
                             } else {
                                 testContext.fail("Could not fetch merged UserAppConf");
@@ -370,7 +374,7 @@ public class MergeUsersINETest {
         prepareOldRichAndPrincipalSeveralQuietHoursUserAppConfs(ine).onComplete(testContext.asyncAssertSuccess(h -> {
             duplicateUsers.mergeSameINE(true, testContext.asyncAssertSuccess(e -> {
                 neo4j.execute(
-                        "MATCH (u:User{ine:{ine}, tag: 'unitTest9'})-[r:PREFERS]->(uac:UserAppConf) RETURN uac.owner as owner, uac.language as language, uac.timeline as timeline, uac.quietHours as quietHours",
+                        "MATCH (u:User{ine:{ine}, tag: 'unitTest9'})-[r:PREFERS]->(uac:UserAppConf) RETURN uac.owner as owner, uac.language as language, uac.timeline as timeline, uac.quietHours as quietHours, uac.timezone as timezone",
                         new JsonObject().put("ine", ine),
                         result -> {
                             if ("ok".equals(result.body().getString("status"))) {
@@ -381,6 +385,7 @@ public class MergeUsersINETest {
                                 testContext.assertEquals("fr", userAppConf.getString("language"));
                                 testContext.assertEquals("timeline-old-multiple", userAppConf.getString("timeline"));
                                 testContext.assertTrue(userAppConf.getString("quietHours").startsWith("quiet-hours-principal-"), "One principal quietHours value should be recovered");
+                                testContext.assertTrue(userAppConf.getString("timezone").startsWith("Europe/"), "Timezone should be recovered from a duplicate quietHours node");
                                 async.countDown();
                             } else {
                                 testContext.fail("Could not fetch merged UserAppConf");
@@ -538,7 +543,7 @@ public class MergeUsersINETest {
             txl.add("match (u) detach delete u", new JsonObject());
                 txl.add("create (u1:User{id: 'userToKeep5', source: 'AAF', activationCode: 'toto', ine: {ine}, tag: 'unitTest5'}) " +
                     "create (u1)-[:PREFERS]->(:UserAppConf{tag: 'unitTest5-a', owner: 'userToKeep5A', language: 'fr', timeline: 'timeline-config'}) " +
-                    "create (u1)-[:PREFERS]->(:UserAppConf{tag: 'unitTest5-b', owner: 'userToKeep5B', quietHours: 'quiet-hours-principal-duplicate'})", params);
+                    "create (u1)-[:PREFERS]->(:UserAppConf{tag: 'unitTest5-b', owner: 'userToKeep5B', quietHours: 'quiet-hours-principal-duplicate', timezone: 'Europe/Paris'})", params);
                 txl.add("create (u2:User{id: 'userToRemove5', source: 'MANUAL', ine: {ine}, tag: 'unitTest5'})-[:PREFERS]->(:UserAppConf{tag: 'unitTest5-old', owner: 'userToRemove5', quietHours: 'quiet-hours-old-user'})", params);
             txl.commit(event -> {
                 if ("ok".equals(event.body().getString("status"))) {
@@ -567,7 +572,7 @@ public class MergeUsersINETest {
             txl.add("match (u) detach delete u", new JsonObject());
             txl.add("create (u1:User{id: 'userToKeep6A', source: 'AAF', activationCode: 'toto', ine: {inePrefix} + '-a', tag: 'unitTest6-rich'})-[:PREFERS]->(:UserAppConf{tag: 'unitTest6-rich', owner: 'principal-rich', language: 'fr', timeline: 'timeline-principal'})", params);
             txl.add("create (u2:User{id: 'userToRemove6A', source: 'MANUAL', ine: {inePrefix} + '-a', tag: 'unitTest6-rich'})", params);
-            txl.add("create (u1:User{id: 'userToKeep6B', source: 'AAF', activationCode: 'toto', ine: {inePrefix} + '-b', tag: 'unitTest6-quiet-hours'})-[:PREFERS]->(:UserAppConf{tag: 'unitTest6-quiet-hours', owner: 'principal-quiet-hours', quietHours: 'quiet-hours-principal'})", params);
+            txl.add("create (u1:User{id: 'userToKeep6B', source: 'AAF', activationCode: 'toto', ine: {inePrefix} + '-b', tag: 'unitTest6-quiet-hours'})-[:PREFERS]->(:UserAppConf{tag: 'unitTest6-quiet-hours', owner: 'principal-quiet-hours', quietHours: 'quiet-hours-principal', timezone: 'Europe/Paris'})", params);
             txl.add("create (u2:User{id: 'userToRemove6B', source: 'MANUAL', ine: {inePrefix} + '-b', tag: 'unitTest6-quiet-hours'})", params);
             txl.add("create (u1:User{id: 'userToKeep6C', source: 'AAF', activationCode: 'toto', ine: {inePrefix} + '-c', tag: 'unitTest6-minimal'})-[:PREFERS]->(:UserAppConf{tag: 'unitTest6-minimal', owner: 'principal-minimal'})", params);
             txl.add("create (u2:User{id: 'userToRemove6C', source: 'MANUAL', ine: {inePrefix} + '-c', tag: 'unitTest6-minimal'})", params);
@@ -596,7 +601,7 @@ public class MergeUsersINETest {
             txl = TransactionManager.getTransaction();
             txl.add("match (u) detach delete u", new JsonObject());
             txl.add("create (u1:User{id: 'userToKeep7', source: 'AAF', activationCode: 'toto', ine: {ine}, tag: 'unitTest7'})-[:PREFERS]->(:UserAppConf{tag: 'unitTest7-rich', owner: 'principal-rich', language: 'fr', timeline: 'timeline-principal'})", params);
-            txl.add("create (u2:User{id: 'userToRemove7', source: 'MANUAL', ine: {ine}, tag: 'unitTest7'})-[:PREFERS]->(:UserAppConf{tag: 'unitTest7-old', owner: 'old-quiet-hours', quietHours: 'quiet-hours-old'})", params);
+            txl.add("create (u2:User{id: 'userToRemove7', source: 'MANUAL', ine: {ine}, tag: 'unitTest7'})-[:PREFERS]->(:UserAppConf{tag: 'unitTest7-old', owner: 'old-quiet-hours', quietHours: 'quiet-hours-old', timezone: 'Europe/Paris'})", params);
             txl.commit(event -> {
                 if ("ok".equals(event.body().getString("status"))) {
                     promise.complete();
@@ -623,9 +628,9 @@ public class MergeUsersINETest {
             txl.add("match (u) detach delete u", new JsonObject());
             txl.add("create (u1:User{id: 'userToKeep8', source: 'AAF', activationCode: 'toto', ine: {ine}, tag: 'unitTest8'})-[:PREFERS]->(:UserAppConf{tag: 'unitTest8-rich', owner: 'principal-rich-multiple', language: 'fr', timeline: 'timeline-principal-multiple'})", params);
             txl.add("create (u2:User{id: 'userToRemove8', source: 'MANUAL', ine: {ine}, tag: 'unitTest8'}) " +
-                    "create (u2)-[:PREFERS]->(:UserAppConf{tag: 'unitTest8-old-a', owner: 'old-quiet-hours-a', quietHours: 'quiet-hours-old-a'}) " +
-                    "create (u2)-[:PREFERS]->(:UserAppConf{tag: 'unitTest8-old-b', owner: 'old-quiet-hours-b', quietHours: 'quiet-hours-old-b'}) " +
-                    "create (u2)-[:PREFERS]->(:UserAppConf{tag: 'unitTest8-old-c', owner: 'old-quiet-hours-c', quietHours: 'quiet-hours-old-c'})", params);
+                    "create (u2)-[:PREFERS]->(:UserAppConf{tag: 'unitTest8-old-a', owner: 'old-quiet-hours-a', quietHours: 'quiet-hours-old-a', timezone: 'Europe/Paris'}) " +
+                    "create (u2)-[:PREFERS]->(:UserAppConf{tag: 'unitTest8-old-b', owner: 'old-quiet-hours-b', quietHours: 'quiet-hours-old-b', timezone: 'Europe/Madrid'}) " +
+                    "create (u2)-[:PREFERS]->(:UserAppConf{tag: 'unitTest8-old-c', owner: 'old-quiet-hours-c', quietHours: 'quiet-hours-old-c', timezone: 'Europe/Rome'})", params);
             txl.commit(event -> {
                 if ("ok".equals(event.body().getString("status"))) {
                     promise.complete();
@@ -651,9 +656,9 @@ public class MergeUsersINETest {
             txl = TransactionManager.getTransaction();
             txl.add("match (u) detach delete u", new JsonObject());
             txl.add("create (u1:User{id: 'userToKeep9', source: 'AAF', activationCode: 'toto', ine: {ine}, tag: 'unitTest9'}) " +
-                    "create (u1)-[:PREFERS]->(:UserAppConf{tag: 'unitTest9-principal-a', owner: 'principal-quiet-hours-a', quietHours: 'quiet-hours-principal-a'}) " +
-                    "create (u1)-[:PREFERS]->(:UserAppConf{tag: 'unitTest9-principal-b', owner: 'principal-quiet-hours-b', quietHours: 'quiet-hours-principal-b'}) " +
-                    "create (u1)-[:PREFERS]->(:UserAppConf{tag: 'unitTest9-principal-c', owner: 'principal-quiet-hours-c', quietHours: 'quiet-hours-principal-c'})", params);
+                    "create (u1)-[:PREFERS]->(:UserAppConf{tag: 'unitTest9-principal-a', owner: 'principal-quiet-hours-a', quietHours: 'quiet-hours-principal-a', timezone: 'Europe/Paris'}) " +
+                    "create (u1)-[:PREFERS]->(:UserAppConf{tag: 'unitTest9-principal-b', owner: 'principal-quiet-hours-b', quietHours: 'quiet-hours-principal-b', timezone: 'Europe/Madrid'}) " +
+                    "create (u1)-[:PREFERS]->(:UserAppConf{tag: 'unitTest9-principal-c', owner: 'principal-quiet-hours-c', quietHours: 'quiet-hours-principal-c', timezone: 'Europe/Rome'})", params);
             txl.add("create (u2:User{id: 'userToRemove9', source: 'MANUAL', ine: {ine}, tag: 'unitTest9'})-[:PREFERS]->(:UserAppConf{tag: 'unitTest9-rich', owner: 'old-rich-multiple', language: 'fr', timeline: 'timeline-old-multiple'})", params);
             txl.commit(event -> {
                 if ("ok".equals(event.body().getString("status"))) {

--- a/feeder/src/test/java/org/entcore/feeder/dictionary/structures/MergeUsersINETest.java
+++ b/feeder/src/test/java/org/entcore/feeder/dictionary/structures/MergeUsersINETest.java
@@ -191,6 +191,215 @@ public class MergeUsersINETest {
             }));
         }));
     }
+ 
+    /**
+     * <h2>Goal</h2>
+    * <p>Test that when the principal user already has duplicate UserAppConf nodes, the merge keeps the node carrying
+    * language/timeline and recovers one quietHours value from the discarded duplicates.</p>
+     */
+    @Test
+    public void testMergeSameINEMergesAlreadyDuplicatedPreferences(final TestContext testContext) {
+        final String ine = "my-duplicated-ine-5";
+        final Async async = testContext.async(2);
+        prepareSameINEUsersWithAlreadyDuplicatedPreferences(ine).onComplete(testContext.asyncAssertSuccess(h -> {
+            duplicateUsers.mergeSameINE(true, testContext.asyncAssertSuccess(e -> {
+                neo4j.execute(
+                    "MATCH (u:User{ine:{ine}, tag: 'unitTest5'})-[r:PREFERS]->(uac:UserAppConf) return u.id as id, uac.owner as owner, uac.language as language, uac.timeline as timeline, uac.quietHours as quietHours",
+                    new JsonObject().put("ine", ine),
+                    result -> {
+                        if ("ok".equals(result.body().getString("status"))) {
+                            final JsonArray users = result.body().getJsonArray("result");
+                            testContext.assertEquals(1, users.size(), "There should be only one user left, linked to exactly one merged UserAppConf");
+                            final JsonObject principalUser = users.getJsonObject(0);
+                            testContext.assertEquals("userToKeep5A", principalUser.getString("owner"), "The principal's own oldest UserAppConf should be kept as canonical");
+                            testContext.assertEquals("fr", principalUser.getString("language"), "The canonical's own property should be preserved");
+                            testContext.assertEquals("timeline-config", principalUser.getString("timeline"), "The canonical's own timeline should be preserved");
+                            testContext.assertEquals("quiet-hours-principal-duplicate", principalUser.getString("quietHours"), "One quietHours value from the duplicates should be recovered");
+                            async.countDown();
+                        } else {
+                            testContext.fail("Could not fetch users with the same ine");
+                        }
+                    });
+                neo4j.execute(
+                        "MATCH (uac:UserAppConf) WHERE uac.tag STARTS WITH 'unitTest5' return uac",
+                        new JsonObject(),
+                        result -> {
+                            if ("ok".equals(result.body().getString("status"))) {
+                                final JsonArray userAppConfs = result.body().getJsonArray("result");
+                                testContext.assertEquals(1, userAppConfs.size(), "All duplicate UserAppConf nodes must be merged, with no orphan left");
+                                async.complete();
+                            } else {
+                                testContext.fail("Could not fetch UserAppConf nodes");
+                            }
+                        });
+            }));
+        }));
+    }
+
+    /**
+     * <h2>Goal</h2>
+     * <p>Test that when only the principal user has one UserAppConf, it is preserved whatever its language, timeline
+     * and quietHours fields are.</p>
+     */
+    @Test
+    public void testMergeSameINEKeepsSinglePrincipalUserAppConf(final TestContext testContext) {
+        final String inePrefix = "my-duplicated-ine-6";
+        final Async async = testContext.async();
+        prepareOldWithoutUserAppConfAndPrincipalWithOneUserAppConf(inePrefix).onComplete(testContext.asyncAssertSuccess(h -> {
+            duplicateUsers.mergeSameINE(true, testContext.asyncAssertSuccess(e -> {
+                neo4j.execute(
+                        "MATCH (u:User)-[:PREFERS]->(uac:UserAppConf) WHERE u.tag IN ['unitTest6-rich', 'unitTest6-quiet-hours', 'unitTest6-minimal'] " +
+                                "RETURN u.tag as tag, uac.owner as owner, uac.language as language, uac.timeline as timeline, uac.quietHours as quietHours ORDER BY tag",
+                        new JsonObject(),
+                        result -> {
+                            if ("ok".equals(result.body().getString("status"))) {
+                                final JsonArray users = result.body().getJsonArray("result");
+                                testContext.assertEquals(3, users.size(), "Each merged user should keep exactly one UserAppConf");
+                                testContext.assertEquals("unitTest6-minimal", users.getJsonObject(0).getString("tag"));
+                                testContext.assertEquals("principal-minimal", users.getJsonObject(0).getString("owner"));
+                                testContext.assertNull(users.getJsonObject(0).getString("language"));
+                                testContext.assertNull(users.getJsonObject(0).getString("timeline"));
+                                testContext.assertNull(users.getJsonObject(0).getString("quietHours"));
+                                testContext.assertEquals("unitTest6-quiet-hours", users.getJsonObject(1).getString("tag"));
+                                testContext.assertEquals("quiet-hours-principal", users.getJsonObject(1).getString("quietHours"));
+                                testContext.assertEquals("unitTest6-rich", users.getJsonObject(2).getString("tag"));
+                                testContext.assertEquals("fr", users.getJsonObject(2).getString("language"));
+                                testContext.assertEquals("timeline-principal", users.getJsonObject(2).getString("timeline"));
+                                async.complete();
+                            } else {
+                                testContext.fail("Could not fetch users with principal UserAppConf");
+                            }
+                        });
+            }));
+        }));
+    }
+
+    /**
+     * <h2>Goal</h2>
+     * <p>Test the nominal merge: old user's quietHours is copied into the principal user's language/timeline node.</p>
+     */
+    @Test
+    public void testMergeSameINEMergesOldQuietHoursIntoPrincipalRichUserAppConf(final TestContext testContext) {
+        final String ine = "my-duplicated-ine-7";
+        final Async async = testContext.async(2);
+        prepareOldQuietHoursAndPrincipalRichUserAppConf(ine).onComplete(testContext.asyncAssertSuccess(h -> {
+            duplicateUsers.mergeSameINE(true, testContext.asyncAssertSuccess(e -> {
+                neo4j.execute(
+                        "MATCH (u:User{ine:{ine}, tag: 'unitTest7'})-[r:PREFERS]->(uac:UserAppConf) RETURN uac.owner as owner, uac.language as language, uac.timeline as timeline, uac.quietHours as quietHours",
+                        new JsonObject().put("ine", ine),
+                        result -> {
+                            if ("ok".equals(result.body().getString("status"))) {
+                                final JsonArray users = result.body().getJsonArray("result");
+                                testContext.assertEquals(1, users.size(), "There should be one merged UserAppConf");
+                                final JsonObject userAppConf = users.getJsonObject(0);
+                                testContext.assertEquals("principal-rich", userAppConf.getString("owner"));
+                                testContext.assertEquals("fr", userAppConf.getString("language"));
+                                testContext.assertEquals("timeline-principal", userAppConf.getString("timeline"));
+                                testContext.assertEquals("quiet-hours-old", userAppConf.getString("quietHours"));
+                                async.countDown();
+                            } else {
+                                testContext.fail("Could not fetch merged UserAppConf");
+                            }
+                        });
+                neo4j.execute(
+                        "MATCH (uac:UserAppConf) WHERE uac.tag STARTS WITH 'unitTest7' RETURN uac",
+                        new JsonObject(),
+                        result -> {
+                            if ("ok".equals(result.body().getString("status"))) {
+                                testContext.assertEquals(1, result.body().getJsonArray("result").size(), "The old UserAppConf should be deleted after merge");
+                                async.complete();
+                            } else {
+                                testContext.fail("Could not fetch UserAppConf nodes");
+                            }
+                        });
+            }));
+        }));
+    }
+
+    /**
+     * <h2>Goal</h2>
+     * <p>Test the nominal cleanup when the old user already has several quietHours-only UserAppConf nodes.</p>
+     */
+    @Test
+    public void testMergeSameINEMergesOneQuietHoursFromSeveralOldUserAppConfs(final TestContext testContext) {
+        final String ine = "my-duplicated-ine-8";
+        final Async async = testContext.async(2);
+        prepareOldSeveralQuietHoursAndPrincipalRichUserAppConf(ine).onComplete(testContext.asyncAssertSuccess(h -> {
+            duplicateUsers.mergeSameINE(true, testContext.asyncAssertSuccess(e -> {
+                neo4j.execute(
+                        "MATCH (u:User{ine:{ine}, tag: 'unitTest8'})-[r:PREFERS]->(uac:UserAppConf) RETURN uac.owner as owner, uac.language as language, uac.timeline as timeline, uac.quietHours as quietHours",
+                        new JsonObject().put("ine", ine),
+                        result -> {
+                            if ("ok".equals(result.body().getString("status"))) {
+                                final JsonArray users = result.body().getJsonArray("result");
+                                testContext.assertEquals(1, users.size(), "There should be one merged UserAppConf");
+                                final JsonObject userAppConf = users.getJsonObject(0);
+                                testContext.assertEquals("principal-rich-multiple", userAppConf.getString("owner"));
+                                testContext.assertEquals("fr", userAppConf.getString("language"));
+                                testContext.assertEquals("timeline-principal-multiple", userAppConf.getString("timeline"));
+                                testContext.assertTrue(userAppConf.getString("quietHours").startsWith("quiet-hours-old-"), "One old quietHours value should be recovered");
+                                async.countDown();
+                            } else {
+                                testContext.fail("Could not fetch merged UserAppConf");
+                            }
+                        });
+                neo4j.execute(
+                        "MATCH (uac:UserAppConf) WHERE uac.tag STARTS WITH 'unitTest8' RETURN uac",
+                        new JsonObject(),
+                        result -> {
+                            if ("ok".equals(result.body().getString("status"))) {
+                                testContext.assertEquals(1, result.body().getJsonArray("result").size(), "All old duplicate UserAppConf nodes should be deleted after merge");
+                                async.complete();
+                            } else {
+                                testContext.fail("Could not fetch UserAppConf nodes");
+                            }
+                        });
+            }));
+        }));
+    }
+
+    /**
+     * <h2>Goal</h2>
+     * <p>Test the nominal cleanup when the old user has language/timeline and the principal user already has several
+     * quietHours-only UserAppConf nodes.</p>
+     */
+    @Test
+    public void testMergeSameINEMergesOnePrincipalQuietHoursIntoOldRichUserAppConf(final TestContext testContext) {
+        final String ine = "my-duplicated-ine-9";
+        final Async async = testContext.async(2);
+        prepareOldRichAndPrincipalSeveralQuietHoursUserAppConfs(ine).onComplete(testContext.asyncAssertSuccess(h -> {
+            duplicateUsers.mergeSameINE(true, testContext.asyncAssertSuccess(e -> {
+                neo4j.execute(
+                        "MATCH (u:User{ine:{ine}, tag: 'unitTest9'})-[r:PREFERS]->(uac:UserAppConf) RETURN uac.owner as owner, uac.language as language, uac.timeline as timeline, uac.quietHours as quietHours",
+                        new JsonObject().put("ine", ine),
+                        result -> {
+                            if ("ok".equals(result.body().getString("status"))) {
+                                final JsonArray users = result.body().getJsonArray("result");
+                                testContext.assertEquals(1, users.size(), "There should be one merged UserAppConf");
+                                final JsonObject userAppConf = users.getJsonObject(0);
+                                testContext.assertEquals("old-rich-multiple", userAppConf.getString("owner"));
+                                testContext.assertEquals("fr", userAppConf.getString("language"));
+                                testContext.assertEquals("timeline-old-multiple", userAppConf.getString("timeline"));
+                                testContext.assertTrue(userAppConf.getString("quietHours").startsWith("quiet-hours-principal-"), "One principal quietHours value should be recovered");
+                                async.countDown();
+                            } else {
+                                testContext.fail("Could not fetch merged UserAppConf");
+                            }
+                        });
+                neo4j.execute(
+                        "MATCH (uac:UserAppConf) WHERE uac.tag STARTS WITH 'unitTest9' RETURN uac",
+                        new JsonObject(),
+                        result -> {
+                            if ("ok".equals(result.body().getString("status"))) {
+                                testContext.assertEquals(1, result.body().getJsonArray("result").size(), "All principal duplicate UserAppConf nodes should be deleted after merge");
+                                async.complete();
+                            } else {
+                                testContext.fail("Could not fetch UserAppConf nodes");
+                            }
+                        });
+            }));
+        }));
+    }
 
     /**
      * Creates 2 users as follows :
@@ -299,6 +508,153 @@ public class MergeUsersINETest {
             txl.add("match (u) detach delete u", new JsonObject());
             txl.add("create (u1:User{id: 'userToKeep4', source: 'AAF', activationCode: 'toto', ine: {ine}, tag: 'unitTest4'})", params);
             txl.add("create (u2:User{id: 'userToRemove4', source: 'MANUAL', ine: {ine}, tag: 'unitTest4'})-[:PREFERS]->(:UserAppConf{tag: 'unitTest4', owner: 'userToRemove4'})", params);
+            txl.commit(event -> {
+                if ("ok".equals(event.body().getString("status"))) {
+                    promise.complete();
+                } else {
+                    promise.fail(event.body().encodePrettily());
+                }
+            });
+        } catch (TransactionException e) {
+            promise.fail(e);
+        }
+        return promise.future();
+    }
+
+    /**
+     * Creates 2 users as follows :
+     * <ol>
+     *     <li>(:User{id: 'userToKeep5', source: 'AAF', ine: ine, activationCode: 'toto'}) with two UserAppConf nodes.</li>
+     *     <li>(:User{id: 'userToRemove5', source: 'MANUAL', ine: ine}) with one UserAppConf node.</li>
+     * </ol>
+     * @param ine The ine to use for both users
+     */
+    public static Future<Void> prepareSameINEUsersWithAlreadyDuplicatedPreferences(final String ine) {
+        final JsonObject params = new JsonObject().put("ine", ine);
+        final Promise<Void> promise = Promise.promise();
+        TransactionHelper txl = null;
+        try {
+            txl = TransactionManager.getTransaction();
+            txl.add("match (u) detach delete u", new JsonObject());
+                txl.add("create (u1:User{id: 'userToKeep5', source: 'AAF', activationCode: 'toto', ine: {ine}, tag: 'unitTest5'}) " +
+                    "create (u1)-[:PREFERS]->(:UserAppConf{tag: 'unitTest5-a', owner: 'userToKeep5A', language: 'fr', timeline: 'timeline-config'}) " +
+                    "create (u1)-[:PREFERS]->(:UserAppConf{tag: 'unitTest5-b', owner: 'userToKeep5B', quietHours: 'quiet-hours-principal-duplicate'})", params);
+                txl.add("create (u2:User{id: 'userToRemove5', source: 'MANUAL', ine: {ine}, tag: 'unitTest5'})-[:PREFERS]->(:UserAppConf{tag: 'unitTest5-old', owner: 'userToRemove5', quietHours: 'quiet-hours-old-user'})", params);
+            txl.commit(event -> {
+                if ("ok".equals(event.body().getString("status"))) {
+                    promise.complete();
+                } else {
+                    promise.fail(event.body().encodePrettily());
+                }
+            });
+        } catch (TransactionException e) {
+            promise.fail(e);
+        }
+        return promise.future();
+    }
+
+    /**
+     * Creates three merge pairs where only the principal user has one UserAppConf, with different combinations of
+     * language, timeline and quietHours fields.
+     * @param inePrefix The ine prefix to use for the three pairs
+     */
+    public static Future<Void> prepareOldWithoutUserAppConfAndPrincipalWithOneUserAppConf(final String inePrefix) {
+        final JsonObject params = new JsonObject().put("inePrefix", inePrefix);
+        final Promise<Void> promise = Promise.promise();
+        TransactionHelper txl = null;
+        try {
+            txl = TransactionManager.getTransaction();
+            txl.add("match (u) detach delete u", new JsonObject());
+            txl.add("create (u1:User{id: 'userToKeep6A', source: 'AAF', activationCode: 'toto', ine: {inePrefix} + '-a', tag: 'unitTest6-rich'})-[:PREFERS]->(:UserAppConf{tag: 'unitTest6-rich', owner: 'principal-rich', language: 'fr', timeline: 'timeline-principal'})", params);
+            txl.add("create (u2:User{id: 'userToRemove6A', source: 'MANUAL', ine: {inePrefix} + '-a', tag: 'unitTest6-rich'})", params);
+            txl.add("create (u1:User{id: 'userToKeep6B', source: 'AAF', activationCode: 'toto', ine: {inePrefix} + '-b', tag: 'unitTest6-quiet-hours'})-[:PREFERS]->(:UserAppConf{tag: 'unitTest6-quiet-hours', owner: 'principal-quiet-hours', quietHours: 'quiet-hours-principal'})", params);
+            txl.add("create (u2:User{id: 'userToRemove6B', source: 'MANUAL', ine: {inePrefix} + '-b', tag: 'unitTest6-quiet-hours'})", params);
+            txl.add("create (u1:User{id: 'userToKeep6C', source: 'AAF', activationCode: 'toto', ine: {inePrefix} + '-c', tag: 'unitTest6-minimal'})-[:PREFERS]->(:UserAppConf{tag: 'unitTest6-minimal', owner: 'principal-minimal'})", params);
+            txl.add("create (u2:User{id: 'userToRemove6C', source: 'MANUAL', ine: {inePrefix} + '-c', tag: 'unitTest6-minimal'})", params);
+            txl.commit(event -> {
+                if ("ok".equals(event.body().getString("status"))) {
+                    promise.complete();
+                } else {
+                    promise.fail(event.body().encodePrettily());
+                }
+            });
+        } catch (TransactionException e) {
+            promise.fail(e);
+        }
+        return promise.future();
+    }
+
+    /**
+     * Creates one old user with quietHours and one principal user with language/timeline.
+     * @param ine The ine to use for both users
+     */
+    public static Future<Void> prepareOldQuietHoursAndPrincipalRichUserAppConf(final String ine) {
+        final JsonObject params = new JsonObject().put("ine", ine);
+        final Promise<Void> promise = Promise.promise();
+        TransactionHelper txl = null;
+        try {
+            txl = TransactionManager.getTransaction();
+            txl.add("match (u) detach delete u", new JsonObject());
+            txl.add("create (u1:User{id: 'userToKeep7', source: 'AAF', activationCode: 'toto', ine: {ine}, tag: 'unitTest7'})-[:PREFERS]->(:UserAppConf{tag: 'unitTest7-rich', owner: 'principal-rich', language: 'fr', timeline: 'timeline-principal'})", params);
+            txl.add("create (u2:User{id: 'userToRemove7', source: 'MANUAL', ine: {ine}, tag: 'unitTest7'})-[:PREFERS]->(:UserAppConf{tag: 'unitTest7-old', owner: 'old-quiet-hours', quietHours: 'quiet-hours-old'})", params);
+            txl.commit(event -> {
+                if ("ok".equals(event.body().getString("status"))) {
+                    promise.complete();
+                } else {
+                    promise.fail(event.body().encodePrettily());
+                }
+            });
+        } catch (TransactionException e) {
+            promise.fail(e);
+        }
+        return promise.future();
+    }
+
+    /**
+     * Creates one old user with three quietHours UserAppConf nodes and one principal user with language/timeline.
+     * @param ine The ine to use for both users
+     */
+    public static Future<Void> prepareOldSeveralQuietHoursAndPrincipalRichUserAppConf(final String ine) {
+        final JsonObject params = new JsonObject().put("ine", ine);
+        final Promise<Void> promise = Promise.promise();
+        TransactionHelper txl = null;
+        try {
+            txl = TransactionManager.getTransaction();
+            txl.add("match (u) detach delete u", new JsonObject());
+            txl.add("create (u1:User{id: 'userToKeep8', source: 'AAF', activationCode: 'toto', ine: {ine}, tag: 'unitTest8'})-[:PREFERS]->(:UserAppConf{tag: 'unitTest8-rich', owner: 'principal-rich-multiple', language: 'fr', timeline: 'timeline-principal-multiple'})", params);
+            txl.add("create (u2:User{id: 'userToRemove8', source: 'MANUAL', ine: {ine}, tag: 'unitTest8'}) " +
+                    "create (u2)-[:PREFERS]->(:UserAppConf{tag: 'unitTest8-old-a', owner: 'old-quiet-hours-a', quietHours: 'quiet-hours-old-a'}) " +
+                    "create (u2)-[:PREFERS]->(:UserAppConf{tag: 'unitTest8-old-b', owner: 'old-quiet-hours-b', quietHours: 'quiet-hours-old-b'}) " +
+                    "create (u2)-[:PREFERS]->(:UserAppConf{tag: 'unitTest8-old-c', owner: 'old-quiet-hours-c', quietHours: 'quiet-hours-old-c'})", params);
+            txl.commit(event -> {
+                if ("ok".equals(event.body().getString("status"))) {
+                    promise.complete();
+                } else {
+                    promise.fail(event.body().encodePrettily());
+                }
+            });
+        } catch (TransactionException e) {
+            promise.fail(e);
+        }
+        return promise.future();
+    }
+
+    /**
+     * Creates one old user with language/timeline and one principal user with three quietHours UserAppConf nodes.
+     * @param ine The ine to use for both users
+     */
+    public static Future<Void> prepareOldRichAndPrincipalSeveralQuietHoursUserAppConfs(final String ine) {
+        final JsonObject params = new JsonObject().put("ine", ine);
+        final Promise<Void> promise = Promise.promise();
+        TransactionHelper txl = null;
+        try {
+            txl = TransactionManager.getTransaction();
+            txl.add("match (u) detach delete u", new JsonObject());
+            txl.add("create (u1:User{id: 'userToKeep9', source: 'AAF', activationCode: 'toto', ine: {ine}, tag: 'unitTest9'}) " +
+                    "create (u1)-[:PREFERS]->(:UserAppConf{tag: 'unitTest9-principal-a', owner: 'principal-quiet-hours-a', quietHours: 'quiet-hours-principal-a'}) " +
+                    "create (u1)-[:PREFERS]->(:UserAppConf{tag: 'unitTest9-principal-b', owner: 'principal-quiet-hours-b', quietHours: 'quiet-hours-principal-b'}) " +
+                    "create (u1)-[:PREFERS]->(:UserAppConf{tag: 'unitTest9-principal-c', owner: 'principal-quiet-hours-c', quietHours: 'quiet-hours-principal-c'})", params);
+            txl.add("create (u2:User{id: 'userToRemove9', source: 'MANUAL', ine: {ine}, tag: 'unitTest9'})-[:PREFERS]->(:UserAppConf{tag: 'unitTest9-rich', owner: 'old-rich-multiple', language: 'fr', timeline: 'timeline-old-multiple'})", params);
             txl.commit(event -> {
                 if ("ok".equals(event.body().getString("status"))) {
                     promise.complete();

--- a/feeder/src/test/java/org/entcore/feeder/dictionary/structures/MergeUsersINETest.java
+++ b/feeder/src/test/java/org/entcore/feeder/dictionary/structures/MergeUsersINETest.java
@@ -91,7 +91,9 @@ public class MergeUsersINETest {
     /**
      * <h2>Goal</h2>
      * <p>Test that when we merge 2 users with the same INE and only one user book linked to the user to be removed,
-     * we don't end up with a user linked to a userbook whose userid is not his/her.</p>
+     * we don't end up with a user linked to a userbook whose userid is not his/her own (post-merge) id. Since
+     * COCO-4598, the surviving user keeps the old (removed) user's id, and the transferred userbook's userid is set
+     * to that same old id, so the two must match.</p>
      */
     @Test
     public void testMergeSameINEWithOnlyOneUserBook(final TestContext testContext) {
@@ -107,7 +109,8 @@ public class MergeUsersINETest {
                                 final JsonArray users = result.body().getJsonArray("result");
                                 testContext.assertEquals(1, users.size(), "There should be only one user left");
                                 final JsonObject principalUser = users.getJsonObject(0);
-                                testContext.assertEquals("userToKeep1Userbook", principalUser.getString("ub_user_id"), "The connected userbook's userid is not the one that we should have. Has anything changed regarding the userbook policy ?");
+                                testContext.assertEquals("userToRemove1Userbook", principalUser.getString("id"), "The remaining user is not the expected one. Have source priorities changed ?");
+                                testContext.assertEquals(principalUser.getString("id"), principalUser.getString("ub_user_id"), "The connected userbook's userid is not the one that we should have. Has anything changed regarding the userbook policy ?");
                                 async.complete();
                             } else {
                                 testContext.fail("Could not fetch users with the same ine");

--- a/feeder/src/test/java/org/entcore/feeder/dictionary/structures/MergeUsersINETest.java
+++ b/feeder/src/test/java/org/entcore/feeder/dictionary/structures/MergeUsersINETest.java
@@ -228,7 +228,7 @@ public class MergeUsersINETest {
                             if ("ok".equals(result.body().getString("status"))) {
                                 final JsonArray userAppConfs = result.body().getJsonArray("result");
                                 testContext.assertEquals(1, userAppConfs.size(), "All duplicate UserAppConf nodes must be merged, with no orphan left");
-                                async.complete();
+                                async.countDown();
                             } else {
                                 testContext.fail("Could not fetch UserAppConf nodes");
                             }
@@ -310,7 +310,7 @@ public class MergeUsersINETest {
                         result -> {
                             if ("ok".equals(result.body().getString("status"))) {
                                 testContext.assertEquals(1, result.body().getJsonArray("result").size(), "The old UserAppConf should be deleted after merge");
-                                async.complete();
+                                async.countDown();
                             } else {
                                 testContext.fail("Could not fetch UserAppConf nodes");
                             }
@@ -353,7 +353,7 @@ public class MergeUsersINETest {
                         result -> {
                             if ("ok".equals(result.body().getString("status"))) {
                                 testContext.assertEquals(1, result.body().getJsonArray("result").size(), "All old duplicate UserAppConf nodes should be deleted after merge");
-                                async.complete();
+                                async.countDown();
                             } else {
                                 testContext.fail("Could not fetch UserAppConf nodes");
                             }
@@ -397,7 +397,7 @@ public class MergeUsersINETest {
                         result -> {
                             if ("ok".equals(result.body().getString("status"))) {
                                 testContext.assertEquals(1, result.body().getJsonArray("result").size(), "All principal duplicate UserAppConf nodes should be deleted after merge");
-                                async.complete();
+                                async.countDown();
                             } else {
                                 testContext.fail("Could not fetch UserAppConf nodes");
                             }


### PR DESCRIPTION
# Description

On trouve des relations `[:PREFERS]->(:UserAppConf)` en double dans la base.

Après analyse des requêtes Cypher créant ces relations, toutes utilisent MERGE `(u)-[:PREFERS]->(uacX:UserAppConf)` — ce qui garantit qu'aucune nouvelle relation/nœud n'est créé si `u` en a déjà un.

La seule exception est dans `DuplicateUsers.java:1078-1082`, méthode `mergeDuplicateIneUser` (fusion de comptes doublons par INE) :
```
final String query2 =
    "MATCH (old:User {id: {oldId}})-[r:PREFERS]->(ub:UserAppConf), (u:User {id: {id}}) " +
        "SET ub.theme = null " +
        "CREATE UNIQUE u-[:PREFERS]->ub " +
        "DELETE r";
```
Ici, `CREATE UNIQUE` ne garantit l'unicité que du couple exact `(u, ub)` — pas l'unicité de la relation `PREFERS` sortante de `u` en général. Si l'utilisateur principal `u` possède déjà son propre `UserAppConf` (via son propre PREFERS), cette requête crée une seconde relation `PREFERS` vers le `UserAppConf` de l'ancien compte `old`, sans jamais vérifier ni fusionner avec l'existant.

Or, l'application des Plages Silencieuses crée des relations `PREFERS` sur tous les utlisateurs rattachés à un établissement => aujourd'hui, les `old` ont donc possiblement leur propre relation `PREFERS`.

Les données trouvées en base semblent confirmer que les utilisateurs concernés par le problème ont été traités par la fonction `mergeDuplicateIneUser`.

### Correctif proposé

Le correctif proposé ici consiste à éviter la création de relation PREFERS en doublon.


Note complémentaire sur l'algorithme appliqué par ce fix :  logique retenue (2 requêtes mutuellement exclusives, mêmes params) :

* les statements s'exécutent séquentiellement dans la même transaction, et chaque statement voit les écritures des précédents.
* `query2a` ne s'exécute (crée le lien + supprime `r`) que si `u` n'a pas encore de UserAppConf — et dans ce cas précis, elle supprime aussi `r`, c'est-à-dire la relation `(old)-[:PREFERS]->(ub)`.

Ensuite, `query2b` a pour pattern `MATCH (old:User)-[:PREFERS]->(ub:UserAppConf)`. Or :

* Si `query2a` a créé le lien pour `u`, elle a déjà supprimé `r` → ce pattern ne matche plus rien pour `query2b` → 0 ligne → aucune action, peu importe le WHERE.
* Si `query2a` ne s'est pas déclenchée (car `u` avait déjà son UserAppConf), `r` est intact → `query2b` matche bien et fait le nettoyage.

Le nettoyage du vieux nœud old par `query4` (le catch-all `OPTIONAL MATCH (old)-[r]-()`) continue de fonctionner normalement puisqu'il ne reste plus aucune relation `PREFERS` pendante à ce stade.


## Fixes

* https://edifice-community.atlassian.net/browse/IMPULS-6274
* Ainsi que le test testMergeSameINEWithOnlyOneUserBook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [X] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

* Ajout d'un test (TestContainer) dédié 
  * _testMergeSameINEWithEachAUserAppConfNoDuplicatePreferences_
     Test that when we merge 2 users with the same INE and each with a UserAppConf (PREFERS), we don't end up with a user linked to 2 UserAppConf, nor with the old one left as an orphan node.

  * _testMergeSameINEWithOnlyOneUserAppConf_
     Test that when we merge 2 users with the same INE and only one has a UserAppConf linked, the preference is correctly transferred to the surviving user.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: